### PR TITLE
Cleaned up timers on server side

### DIFF
--- a/src/clients/c++/perf_client.cc
+++ b/src/clients/c++/perf_client.cc
@@ -1037,6 +1037,10 @@ Report(
   const uint64_t compute_time_us = summary.server_compute_time_ns / 1000;
   const uint64_t compute_avg_us = compute_time_us / cnt;
 
+  const uint64_t overhead = (cumm_avg_us > queue_avg_us + compute_avg_us)
+                                ? (cumm_avg_us - queue_avg_us - compute_avg_us)
+                                : 0;
+
   const uint64_t avg_latency_us = summary.client_avg_latency_ns / 1000;
   const uint64_t std_us = summary.std_us;
 
@@ -1095,8 +1099,7 @@ Report(
             << "  Server: " << std::endl
             << "    Request count: " << cnt << std::endl
             << "    Avg request latency: " << cumm_avg_us << " usec"
-            << " (overhead " << (cumm_avg_us - queue_avg_us - compute_avg_us)
-            << " usec + "
+            << " (overhead " << overhead << " usec + "
             << "queue " << queue_avg_us << " usec + "
             << "compute " << compute_avg_us << " usec)" << std::endl
             << std::endl;

--- a/src/core/infer.cc
+++ b/src/core/infer.cc
@@ -916,14 +916,10 @@ InferenceServable::AsyncRun(
     std::shared_ptr<InferResponseProvider> response_provider,
     std::function<void(tensorflow::Status)> OnCompleteHandleInfer)
 {
-  auto run_timer = std::make_shared<ModelInferStats::ScopedTimer>();
-  stats->StartRunTimer(run_timer.get());
-
   scheduler_->Enqueue(
       stats, request_provider, response_provider,
-      [OnCompleteHandleInfer, run_timer](tensorflow::Status status) mutable {
+      [OnCompleteHandleInfer](tensorflow::Status status) mutable {
         OnCompleteHandleInfer(status);
-        run_timer.reset();
       });
 }
 
@@ -938,11 +934,6 @@ InferenceServable::Run(
     std::shared_ptr<InferResponseProvider> response_provider,
     std::function<void(tensorflow::Status)> OnCompleteHandleInfer)
 {
-  // Since this call is synchronous we can just use a scoped timer to
-  // measure the entire run time.
-  ModelInferStats::ScopedTimer run_timer;
-  stats->StartRunTimer(&run_timer);
-
   std::mutex lmu;
   std::condition_variable lcv;
   tensorflow::Status run_status;

--- a/src/core/infer.cc
+++ b/src/core/infer.cc
@@ -922,8 +922,8 @@ InferenceServable::AsyncRun(
   scheduler_->Enqueue(
       stats, request_provider, response_provider,
       [OnCompleteHandleInfer, run_timer](tensorflow::Status status) mutable {
-        run_timer.reset();
         OnCompleteHandleInfer(status);
+        run_timer.reset();
       });
 }
 

--- a/src/core/infer.cc
+++ b/src/core/infer.cc
@@ -917,10 +917,7 @@ InferenceServable::AsyncRun(
     std::function<void(tensorflow::Status)> OnCompleteHandleInfer)
 {
   scheduler_->Enqueue(
-      stats, request_provider, response_provider,
-      [OnCompleteHandleInfer](tensorflow::Status status) mutable {
-        OnCompleteHandleInfer(status);
-      });
+      stats, request_provider, response_provider, OnCompleteHandleInfer);
 }
 
 // Since callers are expecting synchronous behavior, this function

--- a/src/core/scheduler.h
+++ b/src/core/scheduler.h
@@ -25,6 +25,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
+#include "src/core/server_status.h"
 #include "tensorflow/core/lib/core/errors.h"
 
 namespace nvidia { namespace inferenceserver {
@@ -43,12 +44,12 @@ class Scheduler {
     Payload() = default;
     Payload(const Payload& payload) = default;
     Payload(
-        const struct timespec queued_timestamp,
+        const std::shared_ptr<ModelInferStats::ScopedTimer> queue_timer,
         const std::shared_ptr<ModelInferStats>& stats,
         const std::shared_ptr<InferRequestProvider>& request_provider,
         const std::shared_ptr<InferResponseProvider>& response_provider,
         const std::function<void(tensorflow::Status)> complete_function)
-        : queued_timestamp_(queued_timestamp), stats_(stats),
+        : queue_timer_(queue_timer), stats_(stats),
           request_provider_(request_provider),
           response_provider_(response_provider),
           complete_function_(complete_function),
@@ -57,7 +58,7 @@ class Scheduler {
     {
     }
 
-    const struct timespec queued_timestamp_;
+    std::shared_ptr<ModelInferStats::ScopedTimer> queue_timer_;
     std::shared_ptr<ModelInferStats> stats_;
     std::shared_ptr<InferRequestProvider> request_provider_;
     std::shared_ptr<InferResponseProvider> response_provider_;

--- a/src/core/scheduler.h
+++ b/src/core/scheduler.h
@@ -42,14 +42,23 @@ class Scheduler {
   // The data associated with each request being scheduled.
   struct Payload {
     Payload() = default;
-    Payload(const Payload& payload) = default;
+    Payload(const Payload& payload) = delete;
+    Payload(Payload&& payload)
+        : queue_timer_(std::move(payload.queue_timer_)),
+          stats_(std::move(payload.stats_)),
+          request_provider_(std::move(payload.request_provider_)),
+          response_provider_(std::move(payload.response_provider_)),
+          complete_function_(std::move(payload.complete_function_)),
+          status_(payload.status_), compute_status_(payload.compute_status_)
+    {
+    }
     Payload(
-        const std::shared_ptr<ModelInferStats::ScopedTimer> queue_timer,
+        std::unique_ptr<ModelInferStats::ScopedTimer>& queue_timer,
         const std::shared_ptr<ModelInferStats>& stats,
         const std::shared_ptr<InferRequestProvider>& request_provider,
         const std::shared_ptr<InferResponseProvider>& response_provider,
         const std::function<void(tensorflow::Status)> complete_function)
-        : queue_timer_(queue_timer), stats_(stats),
+        : queue_timer_(std::move(queue_timer)), stats_(stats),
           request_provider_(request_provider),
           response_provider_(response_provider),
           complete_function_(complete_function),
@@ -58,7 +67,7 @@ class Scheduler {
     {
     }
 
-    std::shared_ptr<ModelInferStats::ScopedTimer> queue_timer_;
+    std::unique_ptr<ModelInferStats::ScopedTimer> queue_timer_;
     std::shared_ptr<ModelInferStats> stats_;
     std::shared_ptr<InferRequestProvider> request_provider_;
     std::shared_ptr<InferResponseProvider> response_provider_;

--- a/src/core/sequence_batch_scheduler.cc
+++ b/src/core/sequence_batch_scheduler.cc
@@ -62,8 +62,9 @@ SequenceBatchScheduler::Enqueue(
     const std::shared_ptr<InferResponseProvider>& response_provider,
     std::function<void(tensorflow::Status)> OnComplete)
 {
-  struct timespec now;
-  clock_gettime(CLOCK_MONOTONIC, &now);
+  // Queue timer starts at the beginning of the queueing and scheduling process
+  auto queue_timer = std::make_shared<ModelInferStats::ScopedTimer>();
+  stats->StartQueueTimer(queue_timer.get());
 
   const auto& request_header = request_provider->RequestHeader();
   const CorrelationID correlation_id = request_header.correlation_id();
@@ -120,7 +121,7 @@ SequenceBatchScheduler::Enqueue(
 
   if (target->IsBacklog()) {
     target->backlog_.emplace_back(
-        now, stats, request_provider, response_provider, OnComplete);
+        queue_timer, stats, request_provider, response_provider, OnComplete);
     return;
   }
 
@@ -130,8 +131,8 @@ SequenceBatchScheduler::Enqueue(
   lock.unlock();
 
   sb->Enqueue(
-      slot, correlation_id, now, stats, request_provider, response_provider,
-      OnComplete);
+      slot, correlation_id, queue_timer, stats, request_provider,
+      response_provider, OnComplete);
 }
 
 SequenceBatchScheduler::SequenceBatch::SequenceBatch(
@@ -180,7 +181,7 @@ SequenceBatchScheduler::SequenceBatch::GetFreeSlot(uint32_t* slot)
 void
 SequenceBatchScheduler::SequenceBatch::Enqueue(
     const uint32_t slot, const CorrelationID correlation_id,
-    const struct timespec queue_timestamp,
+    const std::shared_ptr<ModelInferStats::ScopedTimer> queue_timer,
     const std::shared_ptr<ModelInferStats>& stats,
     const std::shared_ptr<InferRequestProvider>& request_provider,
     const std::shared_ptr<InferResponseProvider>& response_provider,
@@ -193,8 +194,7 @@ SequenceBatchScheduler::SequenceBatch::Enqueue(
 
     correlation_ids_[slot] = correlation_id;
     queues_[slot].emplace_back(
-        queue_timestamp, stats, request_provider, response_provider,
-        OnComplete);
+        queue_timer, stats, request_provider, response_provider, OnComplete);
     max_active_slot_ = std::max(max_active_slot_, static_cast<int32_t>(slot));
 
     // If runner is idle then wake it to service this request. We do
@@ -285,7 +285,7 @@ SequenceBatchScheduler::SequenceBatch::SchedulerThread(
             const SequencePayload& slot_payload = queue.front();
 
             payloads->emplace_back(
-                slot_payload.queued_timestamp_, slot_payload.stats_,
+                slot_payload.queue_timer_, slot_payload.stats_,
                 slot_payload.request_provider_, slot_payload.response_provider_,
                 slot_payload.complete_function_);
 

--- a/src/core/sequence_batch_scheduler.h
+++ b/src/core/sequence_batch_scheduler.h
@@ -62,13 +62,13 @@ class SequenceBatchScheduler : public Scheduler {
     SequencePayload() = default;
     SequencePayload(const SequencePayload& payload) = default;
     SequencePayload(
-        const struct timespec queued_timestamp,
+        const std::shared_ptr<ModelInferStats::ScopedTimer> queue_timer,
         const std::shared_ptr<ModelInferStats>& stats,
         const std::shared_ptr<InferRequestProvider>& request_provider,
         const std::shared_ptr<InferResponseProvider>& response_provider,
         const std::function<void(tensorflow::Status)> complete_function)
         : Payload(
-              queued_timestamp, stats, request_provider, response_provider,
+              queue_timer, stats, request_provider, response_provider,
               complete_function)
     {
     }
@@ -92,7 +92,7 @@ class SequenceBatchScheduler : public Scheduler {
     // slot.
     void Enqueue(
         const uint32_t slot, const CorrelationID correlation_id,
-        const struct timespec queue_timestamp,
+        const std::shared_ptr<ModelInferStats::ScopedTimer> queue_timer,
         const std::shared_ptr<ModelInferStats>& stats,
         const std::shared_ptr<InferRequestProvider>& request_provider,
         const std::shared_ptr<InferResponseProvider>& response_provider,

--- a/src/core/sequence_batch_scheduler.h
+++ b/src/core/sequence_batch_scheduler.h
@@ -60,9 +60,10 @@ class SequenceBatchScheduler : public Scheduler {
   // Scheduler payload for each request.
   struct SequencePayload : public Scheduler::Payload {
     SequencePayload() = default;
-    SequencePayload(const SequencePayload& payload) = default;
+    SequencePayload(const SequencePayload& payload) = delete;
+    SequencePayload(SequencePayload&& payload) : Payload(std::move(payload)) {}
     SequencePayload(
-        const std::shared_ptr<ModelInferStats::ScopedTimer> queue_timer,
+        std::unique_ptr<ModelInferStats::ScopedTimer>& queue_timer,
         const std::shared_ptr<ModelInferStats>& stats,
         const std::shared_ptr<InferRequestProvider>& request_provider,
         const std::shared_ptr<InferResponseProvider>& response_provider,
@@ -92,7 +93,7 @@ class SequenceBatchScheduler : public Scheduler {
     // slot.
     void Enqueue(
         const uint32_t slot, const CorrelationID correlation_id,
-        const std::shared_ptr<ModelInferStats::ScopedTimer> queue_timer,
+        std::unique_ptr<ModelInferStats::ScopedTimer>& queue_timer,
         const std::shared_ptr<ModelInferStats>& stats,
         const std::shared_ptr<InferRequestProvider>& request_provider,
         const std::shared_ptr<InferResponseProvider>& response_provider,

--- a/src/core/server.cc
+++ b/src/core/server.cc
@@ -193,8 +193,8 @@ class InferContext final
                   response.mutable_raw_output()->Clear();
                 }
 
-                timer.reset();
                 this->FinishResponse();
+                timer.reset();
               },
               true  // async_frontend
           );

--- a/src/core/server_status.h
+++ b/src/core/server_status.h
@@ -89,6 +89,8 @@ class ModelInferStats {
     struct timespec Start();
     void Stop();
 
+    const struct timespec& StartTimeStamp() const { return start_; };
+
    private:
     friend class ModelInferStats;
     struct timespec start_;
@@ -133,10 +135,10 @@ class ModelInferStats {
   // lifetime of 'this' object.
   struct timespec StartRequestTimer(ScopedTimer* timer) const;
 
-  // Get a ScopedTimer that measures time spent in servable Run(),
-  // including queuing, scheduling and compute time. The lifetime of
+  // Get a ScopedTimer that measures wait time spent in servable Run(),
+  // including queuing, scheduling. The lifetime of
   // 'timer' must not exceed the lifetime of 'this' object.
-  struct timespec StartRunTimer(ScopedTimer* timer) const;
+  struct timespec StartQueueTimer(ScopedTimer* timer) const;
 
   // Get a ScopedTimer that measures model compute duration including
   // H2D, compute and D2H. The lifetime of 'timer' must not exceed the
@@ -154,7 +156,7 @@ class ModelInferStats {
   uint32_t execution_count_;
 
   mutable uint64_t request_duration_ns_;
-  mutable uint64_t run_duration_ns_;
+  mutable uint64_t queue_duration_ns_;
   mutable uint64_t compute_duration_ns_;
 };
 
@@ -192,7 +194,7 @@ class ServerStatusManager {
   void UpdateSuccessInferStats(
       const std::string& model_name, const int64_t model_version,
       size_t batch_size, uint32_t execution_cnt, uint64_t request_duration_ns,
-      uint64_t run_duration_ns, uint64_t compute_duration_ns);
+      uint64_t queue_duration_ns, uint64_t compute_duration_ns);
 
  private:
   mutable std::mutex mu_;

--- a/src/servables/caffe2/netdef_bundle.cc
+++ b/src/servables/caffe2/netdef_bundle.cc
@@ -304,6 +304,9 @@ NetDefBundle::Run(
 
   std::vector<ModelInferStats::ScopedTimer> compute_timers;
   for (auto& payload : *payloads) {
+    // Stop queue timer when the payload is scheduled to run
+    payload.queue_timer_.reset();
+
     compute_timers.emplace_back();
     payload.stats_->StartComputeTimer(&compute_timers.back());
     payload.stats_->SetGPUDevice(contexts_[runner_idx].gpu_device_);

--- a/src/servables/custom/custom_bundle.cc
+++ b/src/servables/custom/custom_bundle.cc
@@ -230,6 +230,9 @@ CustomBundle::Run(
 
   std::vector<ModelInferStats::ScopedTimer> compute_timers;
   for (auto& payload : *payloads) {
+    // Stop queue timer when the payload is scheduled to run
+    payload.queue_timer_.reset();
+
     compute_timers.emplace_back();
     payload.stats_->StartComputeTimer(&compute_timers.back());
     payload.stats_->SetGPUDevice(contexts_[runner_idx].gpu_device_);

--- a/src/servables/tensorflow/base_bundle.cc
+++ b/src/servables/tensorflow/base_bundle.cc
@@ -261,6 +261,9 @@ BaseBundle::Run(
 
   std::vector<ModelInferStats::ScopedTimer> compute_timers;
   for (auto& payload : *payloads) {
+    // Stop queue timer when the payload is scheduled to run
+    payload.queue_timer_.reset();
+
     compute_timers.emplace_back();
     payload.stats_->StartComputeTimer(&compute_timers.back());
     payload.stats_->SetGPUDevice(contexts_[runner_idx].gpu_device_);

--- a/src/servables/tensorrt/plan_bundle.cc
+++ b/src/servables/tensorrt/plan_bundle.cc
@@ -409,6 +409,9 @@ PlanBundle::Run(
 
   std::vector<ModelInferStats::ScopedTimer> compute_timers;
   for (auto& payload : *payloads) {
+    // Stop queue timer when the payload is scheduled to run
+    payload.queue_timer_.reset();
+
     compute_timers.emplace_back();
     payload.stats_->StartComputeTimer(&compute_timers.back());
     payload.stats_->SetGPUDevice(contexts_[runner_idx].gpu_device_);


### PR DESCRIPTION
After this change, the scope of run timer is more aligned with the one in Run(), which is stopping the timer after `OnCompleteHandleInfer()`.