### PR TITLE
Improved "model fail" test in L0_lifecycle

### DIFF
--- a/qa/L0_lifecycle/test.sh
+++ b/qa/L0_lifecycle/test.sh
@@ -100,7 +100,7 @@ if [ "$SERVER_PID" == "0" ]; then
 fi
 
 # give plenty of time for model to load (and fail to load)
-sleep 10
+wait_for_model_stable 30
 
 set +e
 python $LC_TEST LifeCycleTest.test_parse_error_modelfail >>$CLIENT_LOG 2>&1


### PR DESCRIPTION
After server is live, wait until all models load/fail to load or until timeout (30 seconds)