### PR TITLE
Ensured ServerStatus to update stored model config on model modification

### DIFF
--- a/src/core/server.cc
+++ b/src/core/server.cc
@@ -1030,6 +1030,12 @@ InferenceServer::Wait()
                         << "': " << status.error_message();
               goto next;
             }
+            status = status_manager_->UpdateConfigForModel(name);
+            if (!status.ok()) {
+              LOG_ERROR << "Failed to reload model config for '" << name
+                        << "': " << status.error_message();
+              goto next;
+            }
           }
 
           status = core_->ReloadConfig(msc);

--- a/src/core/server_status.h
+++ b/src/core/server_status.h
@@ -169,6 +169,9 @@ class ServerStatusManager {
   // Initialize status for a model.
   tensorflow::Status InitForModel(const std::string& model_name);
 
+  // Update model config for an existing model.
+  tensorflow::Status UpdateConfigForModel(const std::string& model_name);
+
   // Get the entire server status, including status for all models.
   tensorflow::Status Get(
       ServerStatus* server_status, const std::string& server_id,


### PR DESCRIPTION
Addressed issue #36 , now the model config shown in status API is always up to date.

The error mentioned in the issue seems to be spurious (in my experiment, always show version 1 of the model). And the error message only happens on modified model. It may due to the fact that on modified model, the inference server first triggers its unload and then reload the model, which makes the model "unavailable" for a short period of time.