### PR TITLE
Use stub library if running on CPU-only device

### DIFF
--- a/nvidia_entrypoint.sh
+++ b/nvidia_entrypoint.sh
@@ -49,6 +49,10 @@ if [[ "$(find /usr -name libcuda.so.1 | grep -v "compat") " == " " || "$(ls /dev
   echo "WARNING: The NVIDIA Driver was not detected.  GPU functionality will not be available."
   echo "   Use 'nvidia-docker run' to start this container; see"
   echo "   https://github.com/NVIDIA/nvidia-docker/wiki/nvidia-docker ."
+  ln -s `find / -name libcuda.so.1 -print -quit` lib/libcuda.so.1
+  ln -s `find / -name libnvidia-ml.so -print -quit` lib/libnvidia-ml.so.1
+  ln -s `find / -name libnvidia-fatbinaryloader.so.${CUDA_DRIVER_VERSION} -print -quit` lib/libnvidia-fatbinaryloader.so.${CUDA_DRIVER_VERSION}
+  export TENSORRT_SERVER_CPU_ONLY=
 else
   ( /usr/local/bin/checkSMVER.sh )
   DRIVER_VERSION=$(sed -n 's/^NVRM.*Kernel Module *\([0-9.]*\).*$/\1/p' /proc/driver/nvidia/version 2>/dev/null || true)

--- a/nvidia_entrypoint.sh
+++ b/nvidia_entrypoint.sh
@@ -52,7 +52,7 @@ if [[ "$(find /usr -name libcuda.so.1 | grep -v "compat") " == " " || "$(ls /dev
   ln -s `find / -name libcuda.so.1 -print -quit` lib/libcuda.so.1
   ln -s `find / -name libnvidia-ml.so -print -quit` lib/libnvidia-ml.so.1
   ln -s `find / -name libnvidia-fatbinaryloader.so.${CUDA_DRIVER_VERSION} -print -quit` lib/libnvidia-fatbinaryloader.so.${CUDA_DRIVER_VERSION}
-  export TENSORRT_SERVER_CPU_ONLY=
+  export TENSORRT_SERVER_CPU_ONLY=1
 else
   ( /usr/local/bin/checkSMVER.sh )
   DRIVER_VERSION=$(sed -n 's/^NVRM.*Kernel Module *\([0-9.]*\).*$/\1/p' /proc/driver/nvidia/version 2>/dev/null || true)

--- a/qa/L0_infer/test.sh
+++ b/qa/L0_infer/test.sh
@@ -40,6 +40,16 @@ rm -f $SERVER_LOG_BASE* $CLIENT_LOG_BASE*
 RET=0
 
 for TARGET in cpu gpu; do
+    if [ "$TENSORRT_SERVER_CPU_ONLY" == "1" ]; then
+        if [ "$TARGET" == "gpu" ]; then
+            echo -e "Skip GPU testing on CPU-only device"
+            continue
+        fi
+        # set strict readiness=false on CPU-only device to allow
+        # unsuccessful load of TensorRT plans, which require GPU.
+        SERVER_ARGS="--model-store=$DATADIR --strict-readiness=false"
+    fi
+
     SERVER_LOG=$SERVER_LOG_BASE.${TARGET}.log
     CLIENT_LOG=$CLIENT_LOG_BASE.${TARGET}.log
 

--- a/src/core/metrics.cc
+++ b/src/core/metrics.cc
@@ -120,7 +120,8 @@ Metrics::Initialize(uint32_t port)
     return;
   }
 
-  singleton->InitializeNvmlMetrics();
+  if (std::getenv("TENSORRT_SERVER_CPU_ONLY") == nullptr)
+    singleton->InitializeNvmlMetrics();
 
   std::ostringstream stream;
   stream << "0.0.0.0:" << port;


### PR DESCRIPTION
Note that the libcuda used is from `/usr/local/cuda-10.0/compat/lib.real/`, which is not a stub library. Because `cudaGetDeviceCount()` is called multiple times to initialize servables on proper devices (CPU if return cudaErrorNoDevice), avoid adding new condition if a usable library is already in the image.