### PR TITLE
Use absolute path in case of changing work dir

### DIFF
--- a/nvidia_entrypoint.sh
+++ b/nvidia_entrypoint.sh
@@ -49,9 +49,9 @@ if [[ "$(find /usr -name libcuda.so.1 | grep -v "compat") " == " " || "$(ls /dev
   echo "WARNING: The NVIDIA Driver was not detected.  GPU functionality will not be available."
   echo "   Use 'nvidia-docker run' to start this container; see"
   echo "   https://github.com/NVIDIA/nvidia-docker/wiki/nvidia-docker ."
-  ln -s `find / -name libcuda.so.1 -print -quit` lib/libcuda.so.1
-  ln -s `find / -name libnvidia-ml.so -print -quit` lib/libnvidia-ml.so.1
-  ln -s `find / -name libnvidia-fatbinaryloader.so.${CUDA_DRIVER_VERSION} -print -quit` lib/libnvidia-fatbinaryloader.so.${CUDA_DRIVER_VERSION}
+  ln -s `find / -name libcuda.so.1 -print -quit` /opt/tensorrtserver/lib/libcuda.so.1
+  ln -s `find / -name libnvidia-ml.so -print -quit` /opt/tensorrtserver/lib/libnvidia-ml.so.1
+  ln -s `find / -name libnvidia-fatbinaryloader.so.${CUDA_DRIVER_VERSION} -print -quit` /opt/tensorrtserver/lib/libnvidia-fatbinaryloader.so.${CUDA_DRIVER_VERSION}
   export TENSORRT_SERVER_CPU_ONLY=1
 else
   ( /usr/local/bin/checkSMVER.sh )


### PR DESCRIPTION
If the docker is run with option to change working directory, the entrypoint script will fail on CPU-only device.

**Don't delete this branch on merge, still using the branch for tuning CI tests**