### PR TITLE
Modified server-side streaming behavior 

### DIFF
--- a/src/nvrpc/Interfaces.h
+++ b/src/nvrpc/Interfaces.h
@@ -74,6 +74,12 @@ class IContextLifeCycle : public IContext {
   virtual void OnLifeCycleStart() = 0;
   virtual void OnLifeCycleReset() = 0;
 
+  // Function to get the context which the current RPC is related to
+  virtual uintptr_t GetExecutionContext() = 0;
+
+  // Callback function to be called at the end of RPC execution
+  virtual void CompleteExecution(uintptr_t execution_context) = 0;
+
   virtual void FinishResponse() = 0;
   virtual void CancelResponse() = 0;
 };

--- a/src/nvrpc/LifeCycleUnary.h
+++ b/src/nvrpc/LifeCycleUnary.h
@@ -51,6 +51,12 @@ class LifeCycleUnary : public IContextLifeCycle {
 
   virtual void ExecuteRPC(RequestType& request, ResponseType& response) = 0;
 
+  uintptr_t GetExecutionContext() final override { return 0; }
+  void CompleteExecution(uintptr_t execution_context) final override
+  {
+    FinishResponse();
+  }
+
   void FinishResponse() final override;
   void CancelResponse() final override;
 


### PR DESCRIPTION
With this commit, the TRTIS streaming API will:
1. handle (enqueue) the requests in the stream as they arrive (always run `ExecuteRPC()` on successful `Read()`)
2. queue up the responses in write-back queue as soon as they are ready (so they may be out of "order"), the lifecycle is no longer responsible for sending back responses in the same order as their requests arrived

In short, it will behave the same as what is in the non-streaming case, except that the requests and responses are transferred in the same connection, instead of one connection for one request/response pair.