### PR TITLE
Fixed resize in client examples

### DIFF
--- a/src/clients/python/grpc_image_client.py
+++ b/src/clients/python/grpc_image_client.py
@@ -152,7 +152,7 @@ def preprocess(img, format, dtype, c, h, w, scaling):
     else:
         sample_img = img.convert('RGB')
 
-    resized_img = sample_img.resize((h, w), Image.BILINEAR)
+    resized_img = sample_img.resize((w, h), Image.BILINEAR)
     resized = np.array(resized_img)
     if resized.ndim == 2:
         resized = resized[:,:,np.newaxis]

--- a/src/clients/python/image_client.py
+++ b/src/clients/python/image_client.py
@@ -156,7 +156,7 @@ def preprocess(img, format, dtype, c, h, w, scaling):
     else:
         sample_img = img.convert('RGB')
 
-    resized_img = sample_img.resize((h, w), Image.BILINEAR)
+    resized_img = sample_img.resize((w, h), Image.BILINEAR)
     resized = np.array(resized_img)
     if resized.ndim == 2:
         resized = resized[:,:,np.newaxis]


### PR DESCRIPTION
Currently image client examples works correcly only with square inputs. Width and height must be swapped in resize functions, see https://pillow.readthedocs.io/en/3.1.x/reference/Image.html#PIL.Image.Image.resize