### PR TITLE
Fix sequence scheduler to efficiently handle backlogs

### DIFF
--- a/Dockerfile.QA
+++ b/Dockerfile.QA
@@ -65,7 +65,9 @@ RUN mkdir -p qa/clients && mkdir -p qa/pkgs && \
     mkdir -p qa/custom_models/custom_float32_float32_float32/1 && \
     cp /opt/tensorrtserver/custom/libaddsub.so qa/custom_models/custom_float32_float32_float32/1/. && \
     mkdir -p qa/custom_models/custom_nobatch_float32_float32_float32/1 && \
-    cp /opt/tensorrtserver/custom/libaddsub.so qa/custom_models/custom_nobatch_float32_float32_float32/1/.
+    cp /opt/tensorrtserver/custom/libaddsub.so qa/custom_models/custom_nobatch_float32_float32_float32/1/. && \
+    mkdir -p qa/custom_models/custom_sequence_int32/1 && \
+    cp /opt/tensorrtserver/custom/libsequence.so qa/custom_models/custom_sequence_int32/1/.
 
 ############################################################################
 ## Create CI enabled image

--- a/qa/L0_infer/test.sh
+++ b/qa/L0_infer/test.sh
@@ -65,7 +65,9 @@ for TARGET in cpu gpu; do
 
     rm -fr models && \
         cp -r /data/inferenceserver/qa_model_repository models && \
-        cp -r ../custom_models/* models/.
+        cp -r ../custom_models/custom_float32_* models/. && \
+        cp -r ../custom_models/custom_int32_* models/. && \
+        cp -r ../custom_models/custom_nobatch_* models/.
 
     KIND="KIND_GPU" && [[ "$TARGET" == "cpu" ]] && KIND="KIND_CPU"
     for FW in graphdef savedmodel netdef custom; do

--- a/qa/L0_infer_variable/test.sh
+++ b/qa/L0_infer_variable/test.sh
@@ -45,7 +45,9 @@ for TARGET in cpu gpu; do
 
     rm -fr models && \
         cp -r /data/inferenceserver/qa_variable_model_repository models && \
-        cp -r ../custom_models/* models/.
+        cp -r ../custom_models/custom_float32_* models/. && \
+        cp -r ../custom_models/custom_int32_* models/. && \
+        cp -r ../custom_models/custom_nobatch_* models/.
 
     for MC in `ls models/custom*_int32_int32_int32/config.pbtxt`; do
         sed -i "s/16/-1,-1/g" $MC

--- a/qa/L0_sequence_batcher/sequence_batcher_test.py
+++ b/qa/L0_sequence_batcher/sequence_batcher_test.py
@@ -1,0 +1,1189 @@
+# Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import sys
+sys.path.append("../common")
+
+from builtins import range
+from future.utils import iteritems
+import os
+import time
+import threading
+import traceback
+import unittest
+import numpy as np
+import infer_util as iu
+import test_util as tu
+from tensorrtserver.api import *
+import tensorrtserver.api.server_status_pb2 as server_status
+
+if os.environ['BATCHER_TYPE'] == "VARIABLE":
+    _trials = []
+else:
+    _trials = ("custom",)
+#    _trials = ("savedmodel", "graphdef", "plan", "netdef", "custom")
+
+_model_instances = int(os.environ['MODEL_INSTANCES'])
+
+_protocols = ("http", "grpc")
+_max_queue_delay_ms = 10000
+_check_exception = None
+
+class SequenceBatcherTest(unittest.TestCase):
+    def setUp(self):
+        global _check_exception
+        _check_exception = None
+
+    def check_deferred_exception(self):
+        if _check_exception is not None:
+            raise _check_exception
+
+    def check_sequence(self, trial, model_name, input_dtype, correlation_id,
+                       sequence_thresholds, values, expected_result,
+                       protocol, batch_size=1, sequence_name="<unknown>"):
+        """Perform sequence of inferences. The 'values' holds a list of
+        tuples, one for each inference with format:
+
+        (flag_str, value, (ls_ms, gt_ms), (pre_delay_ms, post_delay_ms)
+
+        """
+        global _check_exception
+
+        if (trial == "savedmodel" or trial == "graphdef" or
+            trial == "netdef" or trial == "custom"):
+            tensor_shape = (1,)
+        elif trial == "plan":
+            tensor_shape = (1,1,1)
+        else:
+            self.assertFalse(True, "unknown trial type: " + trial)
+
+        # Can only send the request exactly once since it is a
+        # sequence model with state
+        configs = []
+        if protocol == "http":
+            configs.append(("localhost:8000", ProtocolType.HTTP, False))
+        if protocol == "grpc":
+            configs.append(("localhost:8001", ProtocolType.GRPC, False))
+        if protocol == "streaming":
+            configs.append(("localhost:8001", ProtocolType.GRPC, True))
+
+        self.assertEqual(len(configs), 1)
+
+        for config in configs:
+            ctx = InferContext(config[0], config[1], model_name,
+                               correlation_id=correlation_id, streaming=config[2],
+                               verbose=True)
+            # Execute the sequence of inference...
+            try:
+                seq_start_ms = int(round(time.time() * 1000))
+
+                for flag_str, value, thresholds, delay_ms in values:
+                    if delay_ms is not None:
+                        time.sleep(delay_ms[0] / 1000.0)
+
+                    flags = InferRequestHeader.FLAG_NONE
+                    if flag_str is not None:
+                        if "start" in flag_str:
+                            flags = flags | InferRequestHeader.FLAG_SEQUENCE_START
+                        if "end" in flag_str:
+                            flags = flags | InferRequestHeader.FLAG_SEQUENCE_END
+
+                    input_list = list()
+                    for b in range(batch_size):
+                        input_list.append(np.full(tensor_shape, value, dtype=input_dtype))
+
+                    start_ms = int(round(time.time() * 1000))
+                    results = ctx.run(
+                        { "INPUT" : input_list }, { "OUTPUT" : InferContext.ResultFormat.RAW},
+                        batch_size=batch_size, flags=flags)
+                    end_ms = int(round(time.time() * 1000))
+
+                    self.assertEqual(len(results), 1)
+                    self.assertTrue("OUTPUT" in results)
+                    result = results["OUTPUT"][0][0]
+                    print("{}: {}".format(sequence_name, result))
+
+                    if thresholds is not None:
+                        lt_ms = thresholds[0]
+                        gt_ms = thresholds[1]
+                        if lt_ms is not None:
+                            self.assertTrue((end_ms - start_ms) < lt_ms,
+                                            "expected less than " + str(lt_ms) +
+                                            "ms response time, got " + str(end_ms - start_ms) + " ms")
+                        if gt_ms is not None:
+                            self.assertTrue((end_ms - start_ms) > gt_ms,
+                                            "expected greater than " + str(gt_ms) +
+                                            "ms response time, got " + str(end_ms - start_ms) + " ms")
+                    if delay_ms is not None:
+                        time.sleep(delay_ms[1] / 1000.0)
+
+                seq_end_ms = int(round(time.time() * 1000))
+                self.assertEqual(result, expected_result)
+
+                if sequence_thresholds is not None:
+                    lt_ms = sequence_thresholds[0]
+                    gt_ms = sequence_thresholds[1]
+                    if lt_ms is not None:
+                        self.assertTrue((seq_end_ms - seq_start_ms) < lt_ms,
+                                        "sequence expected less than " + str(lt_ms) +
+                                        "ms response time, got " + str(seq_end_ms - seq_start_ms) + " ms")
+                    if gt_ms is not None:
+                        self.assertTrue((seq_end_ms - seq_start_ms) > gt_ms,
+                                        "sequence expected greater than " + str(gt_ms) +
+                                        "ms response time, got " + str(seq_end_ms - seq_start_ms) + " ms")
+            except Exception as ex:
+                _check_exception = ex
+
+    def check_sequence_async(self, trial, model_name, input_dtype, correlation_id,
+                             sequence_thresholds, values, expected_result,
+                             protocol, batch_size=1, sequence_name="<unknown>"):
+        """Perform sequence of inferences using async run. The 'values' holds
+        a list of tuples, one for each inference with format:
+
+        (flag_str, value, pre_delay_ms)
+
+        """
+        global _check_exception
+
+        if (trial == "savedmodel" or trial == "graphdef" or
+            trial == "netdef" or trial == "custom"):
+            tensor_shape = (1,)
+        elif trial == "plan":
+            tensor_shape = (1,1,1)
+        else:
+            self.assertFalse(True, "unknown trial type: " + trial)
+
+        # Can only send the request exactly once since it is a
+        # sequence model with state
+        configs = []
+        if protocol == "http":
+            configs.append(("localhost:8000", ProtocolType.HTTP, False))
+        if protocol == "grpc":
+            configs.append(("localhost:8001", ProtocolType.GRPC, False))
+        if protocol == "streaming":
+            configs.append(("localhost:8001", ProtocolType.GRPC, True))
+
+        self.assertEqual(len(configs), 1)
+
+        for config in configs:
+            ctx = InferContext(config[0], config[1], model_name,
+                               correlation_id=correlation_id, streaming=config[2],
+                               verbose=True)
+            # Execute the sequence of inference...
+            try:
+                seq_start_ms = int(round(time.time() * 1000))
+                result_ids = list()
+
+                for flag_str, value, pre_delay_ms in values:
+                    flags = InferRequestHeader.FLAG_NONE
+                    if flag_str is not None:
+                        if "start" in flag_str:
+                            flags = flags | InferRequestHeader.FLAG_SEQUENCE_START
+                        if "end" in flag_str:
+                            flags = flags | InferRequestHeader.FLAG_SEQUENCE_END
+
+                    input_list = list()
+                    for b in range(batch_size):
+                        input_list.append(np.full(tensor_shape, value, dtype=input_dtype))
+
+                    if pre_delay_ms is not None:
+                        time.sleep(pre_delay_ms / 1000.0)
+
+                    result_ids.append(ctx.async_run(
+                        { "INPUT" : input_list }, { "OUTPUT" : InferContext.ResultFormat.RAW},
+                        batch_size=batch_size, flags=flags))
+
+                seq_end_ms = int(round(time.time() * 1000))
+
+                # Wait for the results in the order sent
+                result = None
+                for id in result_ids:
+                    results = ctx.get_async_run_results(id, True)
+                    self.assertEqual(len(results), 1)
+                    self.assertTrue("OUTPUT" in results)
+                    result = results["OUTPUT"][0][0]
+                    print("{}: {}".format(sequence_name, result))
+
+                self.assertEqual(result, expected_result)
+
+                if sequence_thresholds is not None:
+                    lt_ms = sequence_thresholds[0]
+                    gt_ms = sequence_thresholds[1]
+                    if lt_ms is not None:
+                        self.assertTrue((seq_end_ms - seq_start_ms) < lt_ms,
+                                        "sequence expected less than " + str(lt_ms) +
+                                        "ms response time, got " + str(seq_end_ms - seq_start_ms) + " ms")
+                    if gt_ms is not None:
+                        self.assertTrue((seq_end_ms - seq_start_ms) > gt_ms,
+                                        "sequence expected greater than " + str(gt_ms) +
+                                        "ms response time, got " + str(seq_end_ms - seq_start_ms) + " ms")
+            except Exception as ex:
+                _check_exception = ex
+
+    def check_setup(self, model_name):
+        # Make sure test.sh set up the correct batcher settings
+        ctx = ServerStatusContext("localhost:8000", ProtocolType.HTTP, model_name, True)
+        ss = ctx.get_server_status()
+        self.assertEqual(len(ss.model_status), 1)
+        self.assertTrue(model_name in ss.model_status,
+                        "expected status for model " + model_name)
+        bconfig = ss.model_status[model_name].config.sequence_batching
+        self.assertEqual(bconfig.max_queue_delay_microseconds, _max_queue_delay_ms * 1000) # 10 secs
+
+    def check_status(self, model_name, static_bs, exec_cnt, infer_cnt):
+        ctx = ServerStatusContext("localhost:8000", ProtocolType.HTTP, model_name, True)
+        ss = ctx.get_server_status()
+        self.assertEqual(len(ss.model_status), 1)
+        self.assertTrue(model_name in ss.model_status,
+                        "expected status for model " + model_name)
+        vs = ss.model_status[model_name].version_status
+        self.assertEqual(len(vs), 1)
+        self.assertTrue(1 in vs, "expected status for version 1")
+        infer = vs[1].infer_stats
+        self.assertEqual(len(infer), len(static_bs),
+                         "expected batch-sizes (" + ",".join(str(b) for b in static_bs) +
+                         "), got " + str(vs[1]))
+        for b in static_bs:
+            self.assertTrue(b in infer,
+                            "expected batch-size " + str(b) + ", got " + str(vs[1]))
+        self.assertEqual(vs[1].model_execution_count, exec_cnt,
+                        "expected model-execution-count " + str(exec_cnt) + ", got " +
+                        str(vs[1].model_execution_count))
+        self.assertEqual(vs[1].model_inference_count, infer_cnt,
+                        "expected model-inference-count " + str(infer_cnt) + ", got " +
+                        str(vs[1].model_inference_count))
+
+    def test_simple_sequence(self):
+        # Send one sequence and check for correct accumulator
+        # result. The result should be returned immediately.
+        for trial in _trials:
+            # Run on different protocols.
+            for idx, protocol in enumerate(_protocols):
+                try:
+                    model_name = tu.get_sequence_model_name(trial, np.int32)
+
+                    self.check_setup(model_name)
+                    self.assertFalse("TRTSERVER_DELAY_SCHEDULER" in os.environ)
+                    self.assertFalse("TRTSERVER_BACKLOG_DELAY_SCHEDULER" in os.environ)
+
+                    self.check_sequence(trial, model_name, np.int32, 5,
+                                        (3000, None),
+                                        # (flag_str, value, (ls_ms, gt_ms), (pre_delay, post_delay))
+                                        (("start", 1, None, None),
+                                         (None, 2, None, None),
+                                         (None, 3, None, None),
+                                         (None, 4, None, None),
+                                         (None, 5, None, None),
+                                         (None, 6, None, None),
+                                         (None, 7, None, None),
+                                         (None, 8, None, None),
+                                         ("end", 9, None, None)),
+                                        45,
+                                        protocol, sequence_name="{}_{}".format(self._testMethodName, protocol))
+
+                    self.check_deferred_exception()
+                    self.check_status(model_name, (1,), 9 * (idx + 1), 9 * (idx + 1))
+                except InferenceServerException as ex:
+                    self.assertTrue(False, "unexpected error {}".format(ex))
+
+    def test_length1_sequence(self):
+        # Send a length-1 sequence and check for correct accumulator
+        # result. The result should be returned immediately.
+        for trial in _trials:
+            # Run on different protocols.
+            for idx, protocol in enumerate(_protocols):
+                try:
+                    model_name = tu.get_sequence_model_name(trial, np.int32)
+
+                    self.check_setup(model_name)
+                    self.assertFalse("TRTSERVER_DELAY_SCHEDULER" in os.environ)
+                    self.assertFalse("TRTSERVER_BACKLOG_DELAY_SCHEDULER" in os.environ)
+
+                    self.check_sequence(trial, model_name, np.int32, 99,
+                                        (3000, None),
+                                        # (flag_str, value, (ls_ms, gt_ms), (pre_delay, post_delay))
+                                        (("start,end", 42, None, None),),
+                                        42,
+                                        protocol, sequence_name="{}_{}".format(self._testMethodName, protocol))
+
+                    self.check_deferred_exception()
+                    self.check_status(model_name, (1,), (idx + 1), (idx + 1))
+                except InferenceServerException as ex:
+                    self.assertTrue(False, "unexpected error {}".format(ex))
+
+    def test_batch_size(self):
+        # Send sequence with a batch-size > 1 and check for error.
+
+        # When 4 model instances the max-batch-size is 1 so can't test
+        # since that gives a different error: "batch-size 2 exceeds
+        # maximum batch size"
+        if _model_instances == 4:
+            return
+
+        for trial in _trials:
+            # Run on different protocols.
+            for idx, protocol in enumerate(_protocols):
+                try:
+                    model_name = tu.get_sequence_model_name(trial, np.int32)
+
+                    self.check_setup(model_name)
+                    self.assertFalse("TRTSERVER_DELAY_SCHEDULER" in os.environ)
+                    self.assertFalse("TRTSERVER_BACKLOG_DELAY_SCHEDULER" in os.environ)
+
+                    self.check_sequence(trial, model_name, np.int32, 27,
+                                        (3000, None),
+                                        # (flag_str, value, (ls_ms, gt_ms), (pre_delay, post_delay))
+                                        (("start", 1, None, None),
+                                         ("end", 9, None, None)),
+                                        10,
+                                        protocol, batch_size=2,
+                                        sequence_name="{}_{}".format(self._testMethodName, protocol))
+
+                    self.check_deferred_exception()
+                    self.assertTrue(False, "expected error")
+                except InferenceServerException as ex:
+                    self.assertEqual("inference:0", ex.server_id())
+                    self.assertTrue(
+                        ex.message().startswith(
+                            "inference request to model 'custom_sequence_int32' must specify batch-size 1 due to requirements of sequence batcher"))
+
+    def test_no_correlation_id(self):
+        # Send sequence without correlation ID and check for error.
+        for trial in _trials:
+            # Run on different protocols.
+            for idx, protocol in enumerate(_protocols):
+                try:
+                    model_name = tu.get_sequence_model_name(trial, np.int32)
+
+                    self.check_setup(model_name)
+                    self.assertFalse("TRTSERVER_DELAY_SCHEDULER" in os.environ)
+                    self.assertFalse("TRTSERVER_BACKLOG_DELAY_SCHEDULER" in os.environ)
+
+                    self.check_sequence(trial, model_name, np.int32, 0, # correlation_id = 0
+                                        (3000, None),
+                                        # (flag_str, value, (ls_ms, gt_ms), (pre_delay, post_delay))
+                                        (("start", 1, None, None),
+                                         ("end", 9, None, None)),
+                                        10,
+                                        protocol, sequence_name="{}_{}".format(self._testMethodName, protocol))
+
+                    self.check_deferred_exception()
+                    self.assertTrue(False, "expected error")
+                except InferenceServerException as ex:
+                    self.assertEqual("inference:0", ex.server_id())
+                    self.assertTrue(
+                        ex.message().startswith(
+                            "inference request to model 'custom_sequence_int32' must specify a non-zero correlation ID"))
+
+    def test_no_sequence_start(self):
+        # Send sequence without start flag for never before seen
+        # correlation ID. Expect failure.
+        for trial in _trials:
+            # Run on different protocols.
+            for idx, protocol in enumerate(_protocols):
+                try:
+                    model_name = tu.get_sequence_model_name(trial, np.int32)
+
+                    self.check_setup(model_name)
+                    self.assertFalse("TRTSERVER_DELAY_SCHEDULER" in os.environ)
+                    self.assertFalse("TRTSERVER_BACKLOG_DELAY_SCHEDULER" in os.environ)
+
+                    self.check_sequence(trial, model_name, np.int32, 37469245,
+                                        (3000, None),
+                                        # (flag_str, value, (ls_ms, gt_ms), (pre_delay, post_delay))
+                                        ((None, 1, None, None),
+                                         (None, 2, None, None),
+                                         ("end", 3, None, None)),
+                                        6,
+                                        protocol, sequence_name="{}_{}".format(self._testMethodName, protocol))
+
+                    self.check_deferred_exception()
+                    self.assertTrue(False, "expected error")
+                except InferenceServerException as ex:
+                    self.assertEqual("inference:0", ex.server_id())
+                    self.assertTrue(
+                        ex.message().startswith(
+                            "inference request for sequence 37469245 to model 'custom_sequence_int32' must specify the START flag on the first request of the sequence"))
+
+    def test_no_sequence_start2(self):
+        # Send sequence without start flag after sending a valid
+        # sequence with the same correlation ID. Expect failure for
+        # the second sequence.
+        for trial in _trials:
+            # Run on different protocols.
+            for idx, protocol in enumerate(_protocols):
+                try:
+                    model_name = tu.get_sequence_model_name(trial, np.int32)
+
+                    self.check_setup(model_name)
+                    self.assertFalse("TRTSERVER_DELAY_SCHEDULER" in os.environ)
+                    self.assertFalse("TRTSERVER_BACKLOG_DELAY_SCHEDULER" in os.environ)
+
+                    self.check_sequence(trial, model_name, np.int32, 3,
+                                        (3000, None),
+                                        # (flag_str, value, (ls_ms, gt_ms), (pre_delay, post_delay))
+                                        (("start", 1, None, None),
+                                         (None, 2, None, None),
+                                         ("end", 3, None, None),
+                                         (None, 55, None, None)),
+                                        6,
+                                        protocol, sequence_name="{}_{}".format(self._testMethodName, protocol))
+
+                    self.check_status(model_name, (1,), 3 * (idx + 1), 3 * (idx + 1))
+                    self.check_deferred_exception()
+                    self.assertTrue(False, "expected error")
+                except InferenceServerException as ex:
+                    self.assertEqual("inference:0", ex.server_id())
+                    self.assertTrue(
+                        ex.message().startswith(
+                            "inference request for sequence 3 to model 'custom_sequence_int32' must specify the START flag on the first request of the sequence"))
+
+    def test_no_sequence_end(self):
+        # Send sequence without end flag. Use same correlation ID to
+        # send another sequence. The first sequence will be ended
+        # automatically but the second should complete successfully.
+        for trial in _trials:
+            # Run on different protocols.
+            for idx, protocol in enumerate(_protocols):
+                try:
+                    model_name = tu.get_sequence_model_name(trial, np.int32)
+
+                    self.check_setup(model_name)
+                    self.assertFalse("TRTSERVER_DELAY_SCHEDULER" in os.environ)
+                    self.assertFalse("TRTSERVER_BACKLOG_DELAY_SCHEDULER" in os.environ)
+
+                    self.check_sequence(trial, model_name, np.int32, 4566,
+                                        (3000, None),
+                                        # (flag_str, value, (ls_ms, gt_ms), (pre_delay, post_delay))
+                                        (("start", 1, None, None),
+                                         (None, 2, None, None),
+                                         ("start", 42, None, None),
+                                         ("end", 9, None, None)),
+                                        51,
+                                        protocol, sequence_name="{}_{}".format(self._testMethodName, protocol))
+
+                    self.check_deferred_exception()
+                    self.check_status(model_name, (1,), 4 * (idx + 1), 4 * (idx + 1))
+                except InferenceServerException as ex:
+                    self.assertTrue(False, "unexpected error {}".format(ex))
+
+    def test_half_batch(self):
+        # Test model instances together are configured with
+        # total-batch-size 4.  Send two equal-length sequences in
+        # parallel and make sure they get completely batched into
+        # batch-size 2 inferences.
+        for trial in _trials:
+            try:
+                model_name = tu.get_sequence_model_name(trial, np.int32)
+                protocol = "streaming"
+
+                self.check_setup(model_name)
+
+                # Need scheduler to wait for queue to contain all
+                # inferences for both sequences.
+                self.assertTrue("TRTSERVER_DELAY_SCHEDULER" in os.environ)
+                self.assertEqual(int(os.environ["TRTSERVER_DELAY_SCHEDULER"]), 8)
+                self.assertTrue("TRTSERVER_BACKLOG_DELAY_SCHEDULER" in os.environ)
+                self.assertEqual(int(os.environ["TRTSERVER_BACKLOG_DELAY_SCHEDULER"]), 0)
+
+                threads = []
+                threads.append(threading.Thread(
+                    target=self.check_sequence_async,
+                    args=(trial, model_name, np.int32, 987,
+                          (3000, None),
+                          # (flag_str, value, pre_delay_ms)
+                          (("start", 1, None),
+                           (None, 2, None),
+                           (None, 3, None),
+                           ("end", 4, None)),
+                          10,
+                          protocol),
+                    kwargs={'sequence_name' : "{}_{}".format(self._testMethodName, protocol)}))
+                threads.append(threading.Thread(
+                    target=self.check_sequence_async,
+                    args=(trial, model_name, np.int32, 988,
+                          (3000, None),
+                          # (flag_str, value, pre_delay_ms)
+                          (("start", 0, None),
+                           (None, 9, None),
+                           (None, 5, None),
+                           ("end", 13, None)),
+                          27,
+                          protocol),
+                    kwargs={'sequence_name' : "{}_{}".format(self._testMethodName, protocol)}))
+
+                for t in threads:
+                    t.start()
+                for t in threads:
+                    t.join()
+                self.check_deferred_exception()
+                self.check_status(model_name, (1,), 4 * min(2, _model_instances), 8)
+            except InferenceServerException as ex:
+                self.assertTrue(False, "unexpected error {}".format(ex))
+
+    def test_skip_batch(self):
+        # Test model instances together are configured with
+        # total-batch-size 4. Send four sequences in parallel where
+        # two sequences have shorter length so that padding must be
+        # applied correctly for the longer sequences.
+        for trial in _trials:
+            try:
+                model_name = tu.get_sequence_model_name(trial, np.int32)
+                protocol = "streaming"
+
+                self.check_setup(model_name)
+
+                # Need scheduler to wait for queue to contain all
+                # inferences for both sequences.
+                self.assertTrue("TRTSERVER_DELAY_SCHEDULER" in os.environ)
+                self.assertEqual(int(os.environ["TRTSERVER_DELAY_SCHEDULER"]), 12)
+                self.assertTrue("TRTSERVER_BACKLOG_DELAY_SCHEDULER" in os.environ)
+                self.assertEqual(int(os.environ["TRTSERVER_BACKLOG_DELAY_SCHEDULER"]), 0)
+
+                threads = []
+                threads.append(threading.Thread(
+                    target=self.check_sequence_async,
+                    args=(trial, model_name, np.int32, 1001,
+                          (3000, None),
+                          # (flag_str, value, pre_delay_ms)
+                          (("start", 1, None),
+                           ("end", 3, None)),
+                          4,
+                          protocol),
+                    kwargs={'sequence_name' : "{}_{}".format(self._testMethodName, protocol)}))
+                threads.append(threading.Thread(
+                    target=self.check_sequence_async,
+                    args=(trial, model_name, np.int32, 1002,
+                          (3000, None),
+                          # (flag_str, value, pre_delay_ms)
+                          (("start", 11, None),
+                           (None, 12, None),
+                           (None, 13, None),
+                           ("end", 14, None)),
+                          50,
+                          protocol),
+                    kwargs={'sequence_name' : "{}_{}".format(self._testMethodName, protocol)}))
+                threads.append(threading.Thread(
+                    target=self.check_sequence_async,
+                    args=(trial, model_name, np.int32, 1003,
+                          (3000, None),
+                          # (flag_str, value, pre_delay_ms)
+                          (("start", 111, None),
+                           ("end", 113, None)),
+                          224,
+                          protocol),
+                    kwargs={'sequence_name' : "{}_{}".format(self._testMethodName, protocol)}))
+                threads.append(threading.Thread(
+                    target=self.check_sequence_async,
+                    args=(trial, model_name, np.int32, 1004,
+                          (3000, None),
+                          # (flag_str, value, pre_delay_ms)
+                          (("start", 1111, None),
+                           (None, 1112, None),
+                           (None, 1113, None),
+                           ("end", 1114, None)),
+                          4450,
+                          protocol),
+                    kwargs={'sequence_name' : "{}_{}".format(self._testMethodName, protocol)}))
+
+                threads[1].start()
+                threads[3].start()
+                time.sleep(1)
+                threads[0].start()
+                threads[2].start()
+                for t in threads:
+                    t.join()
+                self.check_deferred_exception()
+                if _model_instances == 1:
+                    self.check_status(model_name, (1,), 4, 12)
+                elif _model_instances == 2:
+                    self.check_status(model_name, (1,), 8, 12)
+                elif _model_instances == 4:
+                    self.check_status(model_name, (1,), 12, 12)
+            except InferenceServerException as ex:
+                self.assertTrue(False, "unexpected error {}".format(ex))
+
+    def test_full_batch(self):
+        # Test model instances together are configured with
+        # total-batch-size 4. Send four equal-length sequences in
+        # parallel and make sure they get completely batched into
+        # batch-size 4 inferences.
+        for trial in _trials:
+            try:
+                model_name = tu.get_sequence_model_name(trial, np.int32)
+                protocol = "streaming"
+
+                self.check_setup(model_name)
+
+                # Need scheduler to wait for queue to contain all
+                # inferences for both sequences.
+                self.assertTrue("TRTSERVER_DELAY_SCHEDULER" in os.environ)
+                self.assertEqual(int(os.environ["TRTSERVER_DELAY_SCHEDULER"]), 12)
+                self.assertTrue("TRTSERVER_BACKLOG_DELAY_SCHEDULER" in os.environ)
+                self.assertEqual(int(os.environ["TRTSERVER_BACKLOG_DELAY_SCHEDULER"]), 0)
+
+                threads = []
+                threads.append(threading.Thread(
+                    target=self.check_sequence_async,
+                    args=(trial, model_name, np.int32, 1001,
+                          (3000, None),
+                          # (flag_str, value, pre_delay_ms)
+                          (("start", 1, None),
+                           (None, 2, None),
+                           ("end", 3, None)),
+                          6,
+                          protocol),
+                    kwargs={'sequence_name' : "{}_{}".format(self._testMethodName, protocol)}))
+                threads.append(threading.Thread(
+                    target=self.check_sequence_async,
+                    args=(trial, model_name, np.int32, 1002,
+                          (3000, None),
+                          # (flag_str, value, pre_delay_ms)
+                          (("start", 11, None),
+                           (None, 12, None),
+                           ("end", 13, None)),
+                          36,
+                          protocol),
+                    kwargs={'sequence_name' : "{}_{}".format(self._testMethodName, protocol)}))
+                threads.append(threading.Thread(
+                    target=self.check_sequence_async,
+                    args=(trial, model_name, np.int32, 1003,
+                          (3000, None),
+                          # (flag_str, value, pre_delay_ms)
+                          (("start", 111, None),
+                           (None, 112, None),
+                           ("end", 113, None)),
+                          336,
+                          protocol),
+                    kwargs={'sequence_name' : "{}_{}".format(self._testMethodName, protocol)}))
+                threads.append(threading.Thread(
+                    target=self.check_sequence_async,
+                    args=(trial, model_name, np.int32, 1004,
+                          (3000, None),
+                          # (flag_str, value, pre_delay_ms)
+                          (("start", 1111, None),
+                           (None, 1112, None),
+                           ("end", 1113, None)),
+                          3336,
+                          protocol),
+                    kwargs={'sequence_name' : "{}_{}".format(self._testMethodName, protocol)}))
+
+                for t in threads:
+                    t.start()
+                for t in threads:
+                    t.join()
+                self.check_deferred_exception()
+                self.check_status(model_name, (1,), 3 * _model_instances, 12)
+            except InferenceServerException as ex:
+                self.assertTrue(False, "unexpected error {}".format(ex))
+
+    def test_backlog(self):
+        # Test model instances together are configured with
+        # total-max-batch-size 4. Send 5 equal-length sequences in
+        # parallel and make sure they get completely batched into
+        # batch-size 4 inferences plus the 5th should go in the
+        # backlog and then get handled once there is a free slot.
+        for trial in _trials:
+            try:
+                protocol = "streaming"
+                model_name = tu.get_sequence_model_name(trial, np.int32)
+
+                self.check_setup(model_name)
+
+                # Need scheduler to wait for queue to contain all
+                # inferences for both sequences.
+                self.assertTrue("TRTSERVER_DELAY_SCHEDULER" in os.environ)
+                self.assertEqual(int(os.environ["TRTSERVER_DELAY_SCHEDULER"]), 12)
+                self.assertTrue("TRTSERVER_BACKLOG_DELAY_SCHEDULER" in os.environ)
+                self.assertEqual(int(os.environ["TRTSERVER_BACKLOG_DELAY_SCHEDULER"]), 0)
+
+                threads = []
+                threads.append(threading.Thread(
+                    target=self.check_sequence_async,
+                    args=(trial, model_name, np.int32, 1001,
+                          (3000, None),
+                          # (flag_str, value, pre_delay_ms)
+                          (("start", 1, None),
+                           (None, 2, None),
+                           ("end", 3, None)),
+                          6,
+                          protocol),
+                    kwargs={'sequence_name' : "{}_{}".format(self._testMethodName, protocol)}))
+                threads.append(threading.Thread(
+                    target=self.check_sequence_async,
+                    args=(trial, model_name, np.int32, 1002,
+                          (3000, None),
+                          # (flag_str, value, pre_delay_ms)
+                          (("start", 11, None),
+                           (None, 12, None),
+                           ("end", 13, None)),
+                          36,
+                          protocol),
+                    kwargs={'sequence_name' : "{}_{}".format(self._testMethodName, protocol)}))
+                threads.append(threading.Thread(
+                    target=self.check_sequence_async,
+                    args=(trial, model_name, np.int32, 1003,
+                          (3000, None),
+                          # (flag_str, value, pre_delay_ms)
+                          (("start", 111, None),
+                           (None, 112, None),
+                           ("end", 113, None)),
+                          336,
+                          protocol),
+                    kwargs={'sequence_name' : "{}_{}".format(self._testMethodName, protocol)}))
+                threads.append(threading.Thread(
+                    target=self.check_sequence_async,
+                    args=(trial, model_name, np.int32, 1004,
+                          (3000, None),
+                          # (flag_str, value, pre_delay_ms)
+                          (("start", 1111, None),
+                           (None, 1112, None),
+                           ("end", 1113, None)),
+                          3336,
+                          protocol),
+                    kwargs={'sequence_name' : "{}_{}".format(self._testMethodName, protocol)}))
+                threads.append(threading.Thread(
+                    target=self.check_sequence_async,
+                    args=(trial, model_name, np.int32, 1005,
+                          (3000, None),
+                          # (flag_str, value, pre_delay_ms)
+                          (("start", 11111, None),
+                           (None, 11112, None),
+                           ("end", 11113, None)),
+                          33336,
+                          protocol),
+                    kwargs={'sequence_name' : "{}_{}".format(self._testMethodName, protocol)}))
+
+                for t in threads:
+                    t.start()
+                for t in threads:
+                    t.join()
+                self.check_deferred_exception()
+                self.check_status(model_name, (1,), (3 * _model_instances) + 3, 15)
+            except InferenceServerException as ex:
+                self.assertTrue(False, "unexpected error {}".format(ex))
+
+    def test_backlog_fill(self):
+        # Test model instances together are configured with
+        # total-max-batch-size 4. Send 4 sequences in parallel, two of
+        # which are shorter. Send 2 additional sequences that should
+        # go into backlog but should immediately fill into the short
+        # sequences.
+
+        # Only works with 1 model instance since otherwise an instance
+        # can run ahead and handle more work than expected (leads to
+        # intermittent failures)
+        if _model_instances != 1:
+            return
+
+        for trial in _trials:
+            try:
+                protocol = "streaming"
+                model_name = tu.get_sequence_model_name(trial, np.int32)
+
+                self.check_setup(model_name)
+
+                # Need scheduler to wait for queue to contain all
+                # inferences for both sequences.
+                self.assertTrue("TRTSERVER_DELAY_SCHEDULER" in os.environ)
+                self.assertEqual(int(os.environ["TRTSERVER_DELAY_SCHEDULER"]), 10)
+                self.assertTrue("TRTSERVER_BACKLOG_DELAY_SCHEDULER" in os.environ)
+                self.assertEqual(int(os.environ["TRTSERVER_BACKLOG_DELAY_SCHEDULER"]), 2)
+
+                threads = []
+                threads.append(threading.Thread(
+                    target=self.check_sequence_async,
+                    args=(trial, model_name, np.int32, 1001,
+                          (3000, None),
+                          # (flag_str, value, pre_delay_ms)
+                          (("start", 1, None),
+                           (None, 2, None),
+                           ("end", 3, None)),
+                          6,
+                          protocol),
+                    kwargs={'sequence_name' : "{}_{}".format(self._testMethodName, protocol)}))
+                threads.append(threading.Thread(
+                    target=self.check_sequence_async,
+                    args=(trial, model_name, np.int32, 1002,
+                          (3000, None),
+                          # (flag_str, value, pre_delay_ms)
+                          (("start", 11, None),
+                           ("end", 13, None)),
+                          24,
+                          protocol),
+                    kwargs={'sequence_name' : "{}_{}".format(self._testMethodName, protocol)}))
+                threads.append(threading.Thread(
+                    target=self.check_sequence_async,
+                    args=(trial, model_name, np.int32, 1003,
+                          (3000, None),
+                          # (flag_str, value, pre_delay_ms)
+                          (("start", 111, None),
+                           ("end", 113, None)),
+                          224,
+                          protocol),
+                    kwargs={'sequence_name' : "{}_{}".format(self._testMethodName, protocol)}))
+                threads.append(threading.Thread(
+                    target=self.check_sequence_async,
+                    args=(trial, model_name, np.int32, 1004,
+                          (3000, None),
+                          # (flag_str, value, pre_delay_ms)
+                          (("start", 1111, None),
+                           (None, 1112, None),
+                           ("end", 1113, None)),
+                          3336,
+                          protocol),
+                    kwargs={'sequence_name' : "{}_{}".format(self._testMethodName, protocol)}))
+                threads.append(threading.Thread(
+                    target=self.check_sequence_async,
+                    args=(trial, model_name, np.int32, 1005,
+                          (3000, None),
+                          # (flag_str, value, pre_delay_ms)
+                          (("start,end", 11111, None),),
+                          11111,
+                          protocol),
+                    kwargs={'sequence_name' : "{}_{}".format(self._testMethodName, protocol)}))
+                threads.append(threading.Thread(
+                    target=self.check_sequence_async,
+                    args=(trial, model_name, np.int32, 1006,
+                          (3000, None),
+                          # (flag_str, value, pre_delay_ms)
+                          (("start,end", 22222, None),),
+                          22222,
+                          protocol),
+                    kwargs={'sequence_name' : "{}_{}".format(self._testMethodName, protocol)}))
+
+                threads[0].start()
+                threads[1].start()
+                threads[2].start()
+                threads[3].start()
+                time.sleep(2)
+                threads[4].start()
+                threads[5].start()
+                for t in threads:
+                    t.join()
+                self.check_deferred_exception()
+                self.check_status(model_name, (1,), (3 * _model_instances), 12)
+            except InferenceServerException as ex:
+                self.assertTrue(False, "unexpected error {}".format(ex))
+
+    def test_backlog_fill_no_end(self):
+        # Test model instances together are configured with
+        # total-max-batch-size 4. Send 4 sequences in parallel, two of
+        # which are shorter. Send 2 additional sequences that should
+        # go into backlog but should immediately fill into the short
+        # sequences. One of those sequences is filled before it gets
+        # its end request.
+
+        # Only works with 1 model instance since otherwise an instance
+        # can run ahead and handle more work than expected (leads to
+        # intermittent failures)
+        if _model_instances != 1:
+            return
+
+        for trial in _trials:
+            try:
+                protocol = "streaming"
+                model_name = tu.get_sequence_model_name(trial, np.int32)
+
+                self.check_setup(model_name)
+
+                # Need scheduler to wait for queue to contain all
+                # inferences for both sequences.
+                self.assertTrue("TRTSERVER_DELAY_SCHEDULER" in os.environ)
+                self.assertEqual(int(os.environ["TRTSERVER_DELAY_SCHEDULER"]), 10)
+                self.assertTrue("TRTSERVER_BACKLOG_DELAY_SCHEDULER" in os.environ)
+                self.assertEqual(int(os.environ["TRTSERVER_BACKLOG_DELAY_SCHEDULER"]), 3)
+
+                threads = []
+                threads.append(threading.Thread(
+                    target=self.check_sequence_async,
+                    args=(trial, model_name, np.int32, 1001,
+                          (3000, None),
+                          # (flag_str, value, pre_delay_ms)
+                          (("start", 1, None),
+                           (None, 2, None),
+                           ("end", 3, None)),
+                          6,
+                          protocol),
+                    kwargs={'sequence_name' : "{}_{}".format(self._testMethodName, protocol)}))
+                threads.append(threading.Thread(
+                    target=self.check_sequence_async,
+                    args=(trial, model_name, np.int32, 1002,
+                          (3000, None),
+                          # (flag_str, value, pre_delay_ms)
+                          (("start", 11, None),
+                           ("end", 13, None)),
+                          24,
+                          protocol),
+                    kwargs={'sequence_name' : "{}_{}".format(self._testMethodName, protocol)}))
+                threads.append(threading.Thread(
+                    target=self.check_sequence_async,
+                    args=(trial, model_name, np.int32, 1003,
+                          (3000, None),
+                          # (flag_str, value, pre_delay_ms)
+                          (("start", 111, None),
+                           ("end", 113, None)),
+                          224,
+                          protocol),
+                    kwargs={'sequence_name' : "{}_{}".format(self._testMethodName, protocol)}))
+                threads.append(threading.Thread(
+                    target=self.check_sequence_async,
+                    args=(trial, model_name, np.int32, 1004,
+                          (3000, None),
+                          # (flag_str, value, pre_delay_ms)
+                          (("start", 1111, None),
+                           (None, 1112, None),
+                           ("end", 1113, None)),
+                          3336,
+                          protocol),
+                    kwargs={'sequence_name' : "{}_{}".format(self._testMethodName, protocol)}))
+                threads.append(threading.Thread(
+                    target=self.check_sequence_async,
+                    args=(trial, model_name, np.int32, 1005,
+                          (3000, None),
+                          # (flag_str, value, pre_delay_ms)
+                          (("start,end", 11111, None),),
+                          11111,
+                          protocol),
+                    kwargs={'sequence_name' : "{}_{}".format(self._testMethodName, protocol)}))
+                threads.append(threading.Thread(
+                    target=self.check_sequence_async,
+                    args=(trial, model_name, np.int32, 1006,
+                          (3000, None),
+                          # (flag_str, value, pre_delay_ms)
+                          (("start", 22222, None),
+                           (None, 22223, None),
+                           ("end", 22224, 2000),),
+                          66669,
+                          protocol),
+                    kwargs={'sequence_name' : "{}_{}".format(self._testMethodName, protocol)}))
+
+                threads[0].start()
+                threads[1].start()
+                threads[2].start()
+                threads[3].start()
+                time.sleep(2)
+                threads[4].start()
+                threads[5].start()
+                for t in threads:
+                    t.join()
+                self.check_deferred_exception()
+                self.check_status(model_name, (1,), (3 * _model_instances) + 2, 14)
+            except InferenceServerException as ex:
+                self.assertTrue(False, "unexpected error {}".format(ex))
+
+    def test_backlog_same_correlation_id(self):
+        # Test model instances together are configured with
+        # total-max-batch-size 4. Send 4 equal-length sequences in
+        # parallel and make sure they get completely batched into
+        # batch-size 4 inferences. Send a 5th with the same
+        # correlation ID as one of the first four.
+        for trial in _trials:
+            try:
+                protocol = "streaming"
+                model_name = tu.get_sequence_model_name(trial, np.int32)
+
+                self.check_setup(model_name)
+
+                # Need scheduler to wait for queue to contain all
+                # inferences for both sequences.
+                self.assertTrue("TRTSERVER_DELAY_SCHEDULER" in os.environ)
+                self.assertEqual(int(os.environ["TRTSERVER_DELAY_SCHEDULER"]), 12)
+                self.assertTrue("TRTSERVER_BACKLOG_DELAY_SCHEDULER" in os.environ)
+                self.assertEqual(int(os.environ["TRTSERVER_BACKLOG_DELAY_SCHEDULER"]), 2)
+
+                threads = []
+                threads.append(threading.Thread(
+                    target=self.check_sequence_async,
+                    args=(trial, model_name, np.int32, 1001,
+                          (3000, None),
+                          # (flag_str, value, pre_delay_ms)
+                          (("start", 1, None),
+                           (None, 2, None),
+                           ("end", 3, None)),
+                          6,
+                          protocol),
+                    kwargs={'sequence_name' : "{}_{}".format(self._testMethodName, protocol)}))
+                threads.append(threading.Thread(
+                    target=self.check_sequence_async,
+                    args=(trial, model_name, np.int32, 1002,
+                          (3000, None),
+                          # (flag_str, value, pre_delay_ms)
+                          (("start", 11, None),
+                           (None, 12, None),
+                           ("end", 13, None)),
+                          36,
+                          protocol),
+                    kwargs={'sequence_name' : "{}_{}".format(self._testMethodName, protocol)}))
+                threads.append(threading.Thread(
+                    target=self.check_sequence_async,
+                    args=(trial, model_name, np.int32, 1003,
+                          (3000, None),
+                          # (flag_str, value, pre_delay_ms)
+                          (("start", 111, None),
+                           (None, 112, None),
+                           ("end", 113, None)),
+                          336,
+                          protocol),
+                    kwargs={'sequence_name' : "{}_{}".format(self._testMethodName, protocol)}))
+                threads.append(threading.Thread(
+                    target=self.check_sequence_async,
+                    args=(trial, model_name, np.int32, 1004,
+                          (3000, None),
+                          # (flag_str, value, pre_delay_ms)
+                          (("start", 1111, None),
+                           (None, 1112, None),
+                           ("end", 1113, None)),
+                          3336,
+                          protocol),
+                    kwargs={'sequence_name' : "{}_{}".format(self._testMethodName, protocol)}))
+                threads.append(threading.Thread(
+                    target=self.check_sequence_async,
+                    args=(trial, model_name, np.int32, 1002,
+                          (3000, None),
+                          # (flag_str, value, pre_delay_ms)
+                          (("start", 11111, None),
+                           ("end", 11113, None)),
+                          22224,
+                          protocol),
+                    kwargs={'sequence_name' : "{}_{}".format(self._testMethodName, protocol)}))
+
+                threads[0].start()
+                threads[1].start()
+                threads[2].start()
+                threads[3].start()
+                time.sleep(2)
+                threads[4].start()
+                for t in threads:
+                    t.join()
+                self.check_deferred_exception()
+                self.check_status(model_name, (1,), (3 * _model_instances) + 2, 14)
+            except InferenceServerException as ex:
+                self.assertTrue(False, "unexpected error {}".format(ex))
+
+    def test_backlog_same_correlation_id_no_end(self):
+        # Test model instances together are configured with
+        # total-max-batch-size 4. Send 4 sequences in parallel and
+        # make sure they get completely batched into batch-size 4
+        # inferences. One of the sequences is shorter and does not
+        # have an end marker but has same correlation ID as the 5th
+        # sequence. We expect that short sequence to get ended early
+        # (because of the same correlation ID) and make room for the
+        # 5th sequence.
+
+        # Only works with 1 model instance since otherwise an instance
+        # can run ahead and handle more work than expected (leads to
+        # intermittent failures)
+        if _model_instances != 1:
+            return
+
+        for trial in _trials:
+            try:
+                protocol = "streaming"
+                model_name = tu.get_sequence_model_name(trial, np.int32)
+
+                self.check_setup(model_name)
+
+                # Need scheduler to wait for queue to contain all
+                # inferences for both sequences.
+                self.assertTrue("TRTSERVER_DELAY_SCHEDULER" in os.environ)
+                self.assertEqual(int(os.environ["TRTSERVER_DELAY_SCHEDULER"]), 16)
+                self.assertTrue("TRTSERVER_BACKLOG_DELAY_SCHEDULER" in os.environ)
+                self.assertEqual(int(os.environ["TRTSERVER_BACKLOG_DELAY_SCHEDULER"]), 0)
+
+                threads = []
+                threads.append(threading.Thread(
+                    target=self.check_sequence_async,
+                    args=(trial, model_name, np.int32, 1001,
+                          (3000, None),
+                          # (flag_str, value, pre_delay_ms)
+                          (("start", 1, None),
+                           (None, 3, None)),
+                          4,
+                          protocol),
+                    kwargs={'sequence_name' : "{}_{}".format(self._testMethodName, protocol)}))
+                threads.append(threading.Thread(
+                    target=self.check_sequence_async,
+                    args=(trial, model_name, np.int32, 1002,
+                          (3000, None),
+                          # (flag_str, value, pre_delay_ms)
+                          (("start", 11, None),
+                           (None, 12, None),
+                           (None, 12, None),
+                           ("end", 13, None)),
+                          48,
+                          protocol),
+                    kwargs={'sequence_name' : "{}_{}".format(self._testMethodName, protocol)}))
+                threads.append(threading.Thread(
+                    target=self.check_sequence_async,
+                    args=(trial, model_name, np.int32, 1003,
+                          (3000, None),
+                          # (flag_str, value, pre_delay_ms)
+                          (("start", 111, None),
+                           (None, 112, None),
+                           (None, 112, None),
+                           ("end", 113, None)),
+                          448,
+                          protocol),
+                    kwargs={'sequence_name' : "{}_{}".format(self._testMethodName, protocol)}))
+                threads.append(threading.Thread(
+                    target=self.check_sequence_async,
+                    args=(trial, model_name, np.int32, 1004,
+                          (3000, None),
+                          # (flag_str, value, pre_delay_ms)
+                          (("start", 1111, None),
+                           (None, 1112, None),
+                           (None, 1112, None),
+                           ("end", 1113, None)),
+                          4448,
+                          protocol),
+                    kwargs={'sequence_name' : "{}_{}".format(self._testMethodName, protocol)}))
+                threads.append(threading.Thread(
+                    target=self.check_sequence_async,
+                    args=(trial, model_name, np.int32, 1001,
+                          (3000, None),
+                          # (flag_str, value, pre_delay_ms)
+                          (("start", 11111, None),
+                           ("end", 11113, None)),
+                          22224,
+                          protocol),
+                    kwargs={'sequence_name' : "{}_{}".format(self._testMethodName, protocol)}))
+
+                threads[0].start()
+                threads[1].start()
+                threads[2].start()
+                threads[3].start()
+                time.sleep(2)
+                threads[4].start()
+                for t in threads:
+                    t.join()
+                self.check_deferred_exception()
+                self.check_status(model_name, (1,), 4 * _model_instances, 16)
+            except InferenceServerException as ex:
+                self.assertTrue(False, "unexpected error {}".format(ex))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/qa/L0_sequence_batcher/test.sh
+++ b/qa/L0_sequence_batcher/test.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+# Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+CLIENT_LOG="./client.log"
+BATCHER_TEST=sequence_batcher_test.py
+
+DATADIR=/data/inferenceserver
+
+SERVER=/opt/tensorrtserver/bin/trtserver
+source ../common/util.sh
+
+RET=0
+
+# Setup non-variable-size model stores. The same models are in each
+# store but they are configured as:
+#   models1 - one instance with batch-size 4
+#   models2 - two instances with batch-size 2
+#   models4 - four instances with batch-size 1
+rm -fr *.log *.serverlog models{1,2,4} && mkdir models{1,2,4}
+for m in \
+        ../custom_models/custom_sequence_int32 ; do
+    cp -r $m models1/. && \
+        (cd models1/$(basename $m) && \
+            sed -i "s/max_queue_delay_microseconds:.*/max_queue_delay_microseconds: 10000000/" config.pbtxt && \
+            sed -i "s/^max_batch_size:.*/max_batch_size: 4/" config.pbtxt && \
+            sed -i "s/kind: KIND_CPU/kind: KIND_CPU\\ncount: 1/" config.pbtxt)
+    cp -r $m models2/. && \
+        (cd models2/$(basename $m) && \
+            sed -i "s/max_queue_delay_microseconds:.*/max_queue_delay_microseconds: 10000000/" config.pbtxt && \
+            sed -i "s/^max_batch_size:.*/max_batch_size: 2/" config.pbtxt && \
+            sed -i "s/kind: KIND_CPU/kind: KIND_CPU\\ncount: 2/" config.pbtxt)
+    cp -r $m models4/. && \
+        (cd models4/$(basename $m) && \
+            sed -i "s/max_queue_delay_microseconds:.*/max_queue_delay_microseconds: 10000000/" config.pbtxt && \
+            sed -i "s/^max_batch_size:.*/max_batch_size: 1/" config.pbtxt && \
+            sed -i "s/kind: KIND_CPU/kind: KIND_CPU\\ncount: 4/" config.pbtxt)
+done
+
+# Same test work on all models since they all have same total number
+# of batch slots.
+for model_instances in 1 2 4; do
+    export MODEL_INSTANCES=$model_instances
+    MODEL_DIR=models${model_instances}
+
+    # Need to launch the server for each test so that the model status is
+    # reset (which is used to make sure the correctly batch size was used
+    # for execution). Test everything with fixed-tensor-size models and
+    # variable-tensor-size models.
+    for model_type in FIXED; do    # add VARIABLE
+        export BATCHER_TYPE=$model_type
+        MODEL_PATH=$MODEL_DIR && [[ "$model_type" == "VARIABLE" ]] && MODEL_PATH=var_models
+        for i in \
+                test_simple_sequence \
+                test_length1_sequence \
+                test_batch_size \
+                test_no_sequence_start \
+                test_no_sequence_start2 \
+                test_no_sequence_end \
+                test_no_correlation_id ; do
+            SERVER_ARGS="--model-store=`pwd`/$MODEL_PATH"
+            SERVER_LOG="./$i.$MODEL_DIR.$model_type.serverlog"
+            run_server
+            if [ "$SERVER_PID" == "0" ]; then
+                echo -e "\n***\n*** Failed to start $SERVER\n***"
+                cat $SERVER_LOG
+                exit 1
+            fi
+
+            echo "Test: $i" >>$CLIENT_LOG
+
+            set +e
+            python $BATCHER_TEST SequenceBatcherTest.$i >>$CLIENT_LOG 2>&1
+            if [ $? -ne 0 ]; then
+                echo -e "\n***\n*** Test Failed\n***"
+                RET=1
+            fi
+            set -e
+
+            kill $SERVER_PID
+            wait $SERVER_PID
+        done
+
+        # Tests that require TRTSERVER_DELAY_SCHEDULER so that the
+        # scheduler is delayed and requests can collect in the queue.
+        for i in \
+                test_backlog_fill \
+                test_backlog_fill_no_end \
+                test_backlog_same_correlation_id \
+                test_backlog_same_correlation_id_no_end \
+                test_half_batch \
+                test_skip_batch \
+                test_full_batch \
+                test_backlog ; do
+            export TRTSERVER_BACKLOG_DELAY_SCHEDULER=3 &&
+                [[ "$i" != "test_backlog_fill_no_end" ]] && export TRTSERVER_BACKLOG_DELAY_SCHEDULER=2 &&
+                [[ "$i" != "test_backlog_fill" ]] &&
+                [[ "$i" != "test_backlog_same_correlation_id" ]] && export TRTSERVER_BACKLOG_DELAY_SCHEDULER=0
+            export TRTSERVER_DELAY_SCHEDULER=10 &&
+                [[ "$i" != "test_backlog_fill_no_end" ]] &&
+                [[ "$i" != "test_backlog_fill" ]] && export TRTSERVER_DELAY_SCHEDULER=16 &&
+                [[ "$i" != "test_backlog_same_correlation_id_no_end" ]] && export TRTSERVER_DELAY_SCHEDULER=8 &&
+                [[ "$i" != "test_half_batch" ]] && export TRTSERVER_DELAY_SCHEDULER=12
+            SERVER_ARGS="--model-store=`pwd`/$MODEL_PATH"
+            SERVER_LOG="./$i.$MODEL_DIR.$model_type.serverlog"
+            run_server
+            if [ "$SERVER_PID" == "0" ]; then
+                echo -e "\n***\n*** Failed to start $SERVER\n***"
+                cat $SERVER_LOG
+                exit 1
+            fi
+
+            echo "Test: $i" >>$CLIENT_LOG
+
+            set +e
+            python $BATCHER_TEST SequenceBatcherTest.$i >>$CLIENT_LOG 2>&1
+            if [ $? -ne 0 ]; then
+                echo -e "\n***\n*** Test Failed\n***"
+                RET=1
+            fi
+            set -e
+
+            unset TRTSERVER_DELAY_SCHEDULER
+            unset TRTSERVER_BACKLOG_DELAY_SCHEDULER
+            kill $SERVER_PID
+            wait $SERVER_PID
+        done
+    done
+done
+
+# python unittest seems to swallow ImportError and still return 0 exit
+# code. So need to explicitly check CLIENT_LOG to make sure we see
+# some running tests
+grep -c "HTTP/1.1 200 OK" $CLIENT_LOG
+if [ $? -ne 0 ]; then
+    echo -e "\n***\n*** Test Failed To Run\n***"
+    RET=1
+fi
+
+if [ $RET -eq 0 ]; then
+    echo -e "\n***\n*** Test Passed\n***"
+else
+    cat $CLIENT_LOG
+    echo -e "\n***\n*** Test FAILED\n***"
+fi
+
+exit $RET

--- a/qa/common/infer_util.py
+++ b/qa/common/infer_util.py
@@ -41,13 +41,15 @@ def _range_repr_dtype(dtype):
         return np.int32
     return dtype
 
+# Perform inference using an "addsum" type verification backend.
 def infer_exact(tester, pf, tensor_shape, batch_size,
                 input_dtype, output0_dtype, output1_dtype,
                 output0_raw=True, output1_raw=True,
                 model_version=None, swap=False,
                 outputs=("OUTPUT0", "OUTPUT1"), use_http=True, use_grpc=True,
-                skip_request_id_check=False, use_streaming=True):
-    tester.assertTrue(use_http or use_grpc)
+                skip_request_id_check=False, use_streaming=True,
+                correlation_id=0):
+    tester.assertTrue(use_http or use_grpc or use_streaming)
     configs = []
     if use_http:
         configs.append(("localhost:8000", ProtocolType.HTTP, False))
@@ -136,7 +138,9 @@ def infer_exact(tester, pf, tensor_shape, batch_size,
             else:
                 output_req["OUTPUT1"] = (InferContext.ResultFormat.CLASS, num_classes)
 
-        ctx = InferContext(config[0], config[1], model_name, model_version, True, streaming=config[2])
+        ctx = InferContext(config[0], config[1], model_name, model_version,
+                           correlation_id=correlation_id, streaming=config[2],
+                           verbose=True)
         results = ctx.run(
             { "INPUT0" : input0_list, "INPUT1" : input1_list },
             output_req, batch_size)

--- a/qa/common/test_util.py
+++ b/qa/common/test_util.py
@@ -134,3 +134,6 @@ def get_model_name(pf, input_dtype, output0_dtype, output1_dtype):
     return "{}_{}_{}_{}".format(
         pf, np.dtype(input_dtype).name, np.dtype(output0_dtype).name,
         np.dtype(output1_dtype).name)
+
+def get_sequence_model_name(pf, dtype):
+    return "{}_sequence_{}".format(pf, np.dtype(dtype).name)

--- a/qa/custom_models/custom_sequence_int32/config.pbtxt
+++ b/qa/custom_models/custom_sequence_int32/config.pbtxt
@@ -1,0 +1,72 @@
+# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+name: "custom_sequence_int32"
+platform: "custom"
+max_batch_size: 8
+default_model_filename: "libsequence.so"
+sequence_batching {
+  max_queue_delay_microseconds: 0
+  control_input [
+    {
+      name: "START"
+      control [
+        {
+          kind: CONTROL_SEQUENCE_START
+          int32_false_true: [ 0, 1 ]
+        }
+      ]
+    },
+    {
+      name: "READY"
+      control [
+        {
+          kind: CONTROL_SEQUENCE_READY
+          int32_false_true: [ 0, 1 ]
+        }
+      ]
+    }
+  ]
+}
+input [
+  {
+    name: "INPUT"
+    data_type: TYPE_INT32
+    dims: [ 1 ]
+  }
+]
+output [
+  {
+    name: "OUTPUT"
+    data_type: TYPE_INT32
+    dims: [ 1 ]
+  }
+]
+instance_group [
+  {
+    kind: KIND_CPU
+  }
+]

--- a/src/core/api.proto
+++ b/src/core/api.proto
@@ -52,11 +52,17 @@ message InferRequestHeader
     //@@
     FLAG_NONE = 0;
 
-    //@@    .. cpp:enumerator:: Flag::FLAG_SEQUENCE_END = 1
+    //@@    .. cpp:enumerator:: Flag::FLAG_SEQUENCE_START = 1 << 0
+    //@@
+    //@@       This request is the start of a related sequence of requests.
+    //@@
+    FLAG_SEQUENCE_START = 1;
+
+    //@@    .. cpp:enumerator:: Flag::FLAG_SEQUENCE_END = 1 << 1
     //@@
     //@@       This request is the end of a related sequence of requests.
     //@@
-    FLAG_SEQUENCE_END = 1;
+    FLAG_SEQUENCE_END = 2;
   }
 
   //@@  .. cpp:var:: message Input

--- a/src/core/server.cc
+++ b/src/core/server.cc
@@ -635,7 +635,7 @@ InferenceServer::InferenceServer()
   http_port_ = 8000;
   grpc_port_ = 8001;
   metrics_port_ = 8002;
-  http_thread_cnt_ = 8;
+  http_thread_cnt_ = 16;
   strict_model_config_ = true;
   strict_readiness_ = true;
   profiling_enabled_ = false;


### PR DESCRIPTION
When all available slots are busy, sequences are kept in backlog
queues and then swapped into batch slots as they come available.

Add end-to-end testing for sequence batcher