### PR TITLE
Decouple from tensorflow::Status to avoid unnecessary TF dependency

### DIFF
--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -113,7 +113,7 @@ cc_library(
     hdrs = ["autofill.h"],
     deps = [
         ":model_config",
-        "@org_tensorflow//tensorflow/core:lib",
+        ":status",
         "@tf_serving//tensorflow_serving/config:platform_config_proto",
     ],
 )
@@ -130,7 +130,6 @@ cc_library(
         "//src/servables/caffe2:autofill",
         "//src/servables/tensorflow:autofill",
         "//src/servables/tensorrt:autofill",
-        "@org_tensorflow//tensorflow/core:lib",
     ],
 )
 
@@ -150,11 +149,10 @@ cc_library(
         ":logging",
         ":metrics",
         ":model_config_proto",
+        ":model_config_utils",
         ":scheduler",
         ":sequence_batch_scheduler",
-        ":model_config_utils",
-        "@com_github_libevent_libevent//:libevent",
-        "@org_tensorflow//tensorflow/core:lib",
+        ":status",
     ],
 )
 
@@ -164,8 +162,8 @@ cc_library(
     deps = [
         ":api_proto",
         ":grpc_service_proto",
+        ":status",
         "@com_github_libevent_libevent//:libevent",
-        "@org_tensorflow//tensorflow/core:lib",
     ],
 )
 
@@ -180,7 +178,6 @@ cc_library(
         ":model_config",
         ":model_config_utils",
         "@com_github_libevent_libevent//:libevent",
-        "@org_tensorflow//tensorflow/core:lib",
     ],
 )
 
@@ -189,6 +186,8 @@ cc_library(
     srcs = ["label_provider.cc"],
     hdrs = ["label_provider.h"],
     deps = [
+        ":constants",
+        ":status",
         "@org_tensorflow//tensorflow/core:lib",
     ],
 )
@@ -210,8 +209,7 @@ cc_library(
         ":logging",
         "@prometheus//core:core",
         "@prometheus//pull:pull",
-        "@org_tensorflow//tensorflow/c:c_api",
-        "@org_tensorflow//tensorflow/core:lib",
+        "@local_config_cuda//cuda:cuda_headers",
     ],
 )
 
@@ -245,7 +243,7 @@ cc_library(
         ":model_config",
         ":model_config_proto",
         ":model_config_utils",
-        "@org_tensorflow//tensorflow/core:lib",
+        ":status",
         "@tf_serving//tensorflow_serving/config:model_server_config_proto",
         "@tf_serving//tensorflow_serving/config:platform_config_proto",
     ],
@@ -256,8 +254,8 @@ cc_library(
     srcs = ["profile.cc"],
     hdrs = ["profile.h"],
     deps = [
-        "@org_tensorflow//tensorflow/c:c_api",
-        "@org_tensorflow//tensorflow/core:lib",
+        ":status",
+        "@local_config_cuda//cuda:cuda_headers",
     ],
 )
 
@@ -265,8 +263,8 @@ cc_library(
     name = "scheduler",
     hdrs = ["scheduler.h"],
     deps = [
-        "@org_tensorflow//tensorflow/c:c_api",
-        "@org_tensorflow//tensorflow/core:lib",
+        ":server_status_header",
+        ":status",
     ],
 )
 
@@ -283,8 +281,7 @@ cc_library(
         ":model_config_proto",
         ":scheduler",
         ":server_status_header",
-        "@org_tensorflow//tensorflow/c:c_api",
-        "@org_tensorflow//tensorflow/core:lib",
+        ":status",
     ],
 )
 
@@ -298,11 +295,25 @@ cc_library(
         ":logging",
         ":model_config",
         ":model_config_proto",
+        ":model_config_utils",
         ":scheduler",
         ":server_status_header",
-        ":model_config_utils",
-        "@org_tensorflow//tensorflow/c:c_api",
-        "@org_tensorflow//tensorflow/core:lib",
+        ":status",
+    ],
+)
+
+cc_library(
+    name = "server_header",
+    hdrs = ["server.h"],
+    deps = [
+        ":api_proto",
+        ":provider",
+        ":model_config_proto",
+        ":request_status_proto",
+        ":server_status_header",
+        ":server_status_proto",
+        ":status",
+        "@tf_serving//tensorflow_serving/model_servers:server_core",
     ],
 )
 
@@ -317,6 +328,7 @@ cc_library(
         ":logging",
         ":model_config",
         ":model_config_proto",
+        ":model_config_utils",
         ":model_repository_manager",
         ":profile",
         ":provider",
@@ -325,7 +337,6 @@ cc_library(
         ":server_header",
         ":server_status_header",
         ":server_status_proto",
-        ":model_config_utils",
         "//src/servables/caffe2:netdef_bundle_source_adapter",
         "//src/servables/tensorflow:graphdef_bundle_source_adapter",
         "//src/servables/tensorflow:savedmodel_bundle_source_adapter",
@@ -333,25 +344,9 @@ cc_library(
         "//src/servables/custom:custom_bundle_source_adapter",
         "//src/servables/ensemble:ensemble_bundle_source_adapter",
         "@com_github_libevent_libevent//:libevent",
-        "@org_tensorflow//tensorflow/core:lib",
         "@tf_serving//tensorflow_serving/config:model_server_config_proto",
         "@tf_serving//tensorflow_serving/core:servable_state_monitor",
         "@tf_serving//tensorflow_serving/core:availability_preserving_policy",
-        "@tf_serving//tensorflow_serving/model_servers:server_core",
-    ],
-)
-
-cc_library(
-    name = "server_header",
-    hdrs = ["server.h"],
-    deps = [
-        ":api_proto",
-        ":provider",
-        ":model_config_proto",
-        ":request_status_proto",
-        ":server_status_header",
-        ":server_status_proto",
-        "@org_tensorflow//tensorflow/core:lib",
         "@tf_serving//tensorflow_serving/model_servers:server_core",
     ],
 )
@@ -367,11 +362,11 @@ cc_library(
         ":request_status",
         ":request_status_proto",
         ":server_header",
+        ":status",
         "@com_github_libevhtp//:libevhtp",
         "@com_github_libevent_libevent//:libevent",
         "@com_google_absl//absl/strings",
         "@com_googlesource_code_re2//:re2",
-        "@org_tensorflow//tensorflow/core:lib",
     ],
 )
 
@@ -387,9 +382,9 @@ cc_library(
         ":request_status",
         ":request_status_proto",
         ":server_header",
+        ":status",
         "//src/nvrpc:nvrpc",
         "@grpc//:grpc++_unsecure",
-        "@org_tensorflow//tensorflow/core:lib",
     ],
 )
 
@@ -400,7 +395,7 @@ cc_library(
         ":model_config_proto",
         ":model_repository_manager",
         ":server_status_proto",
-        "@org_tensorflow//tensorflow/core:lib",
+        ":status",
         "@tf_serving//tensorflow_serving/core:servable_state_monitor",
     ],
 )
@@ -415,8 +410,16 @@ cc_library(
         ":logging",
         ":metrics",
         ":server_status_header",
-        "@org_tensorflow//tensorflow/core:lib",
         "@tf_serving//tensorflow_serving/core:servable_state",
+    ],
+)
+
+cc_library(
+    name = "status",
+    srcs = ["status.cc"],
+    hdrs = ["status.h"],
+    deps = [
+        ":request_status_proto",
     ],
 )
 
@@ -426,7 +429,7 @@ cc_library(
     hdrs = ["request_status.h"],
     deps = [
         ":request_status_proto",
-        "@org_tensorflow//tensorflow/core:lib",
+        ":status",
     ],
 )
 
@@ -440,8 +443,7 @@ cc_library(
         ":logging",
         ":model_config",
         ":model_config_proto",
-        "@org_tensorflow//tensorflow/c:c_api",
-        "@org_tensorflow//tensorflow/core:lib",
+        ":status",
         "@tf_serving//tensorflow_serving/config:platform_config_proto",
     ],
 )
@@ -454,6 +456,6 @@ cc_library(
         ":logging",
         ":model_config_proto",
         ":model_config_utils",
-        "@org_tensorflow//tensorflow/core:lib",
+        ":status",
     ],
 )

--- a/src/core/autofill.h
+++ b/src/core/autofill.h
@@ -27,7 +27,7 @@
 
 #include <string>
 #include "src/core/model_config.pb.h"
-#include "tensorflow/core/lib/core/errors.h"
+#include "src/core/status.h"
 #include "tensorflow_serving/config/platform_config.pb.h"
 
 namespace tfs = tensorflow::serving;
@@ -37,22 +37,21 @@ namespace nvidia { namespace inferenceserver {
 class AutoFill {
  public:
   /// Create an AutoFill object for a specific model.
-  static tensorflow::Status Create(
+  static Status Create(
       const std::string& model_name,
       const tfs::PlatformConfigMap& platform_config_map,
       const std::string& model_path, const ModelConfig& config,
       std::unique_ptr<AutoFill>* autofill);
 
   /// Autofill settings in a configuration.
-  virtual tensorflow::Status Fix(ModelConfig* config) = 0;
+  virtual Status Fix(ModelConfig* config) = 0;
 
  protected:
   AutoFill(const std::string& model_name) : model_name_(model_name) {}
 
-  static tensorflow::Status GetSubdirs(
+  static Status GetSubdirs(
       const std::string& path, std::set<std::string>* subdirs);
-  static tensorflow::Status GetFiles(
-      const std::string& path, std::set<std::string>* files);
+  static Status GetFiles(const std::string& path, std::set<std::string>* files);
 
   const std::string model_name_;
 };

--- a/src/core/backend.h
+++ b/src/core/backend.h
@@ -29,7 +29,7 @@
 #include "src/core/metrics.h"
 #include "src/core/model_config.pb.h"
 #include "src/core/scheduler.h"
-#include "tensorflow/core/lib/core/errors.h"
+#include "src/core/status.h"
 
 namespace nvidia { namespace inferenceserver {
 
@@ -45,7 +45,7 @@ class InferenceBackend {
   virtual ~InferenceBackend() {}
 
   // Set reference to the inference server that is serving the servable.
-  virtual tensorflow::Status SetInferenceServer(void* inference_server);
+  virtual Status SetInferenceServer(void* inference_server);
 
   // Get the name of model being served.
   const std::string& Name() const { return config_.name(); }
@@ -57,12 +57,10 @@ class InferenceBackend {
   const ModelConfig& Config() const { return config_; }
 
   // Get the model configuration for a named input.
-  tensorflow::Status GetInput(
-      const std::string& name, const ModelInput** input) const;
+  Status GetInput(const std::string& name, const ModelInput** input) const;
 
   // Get the model configuration for a named output.
-  tensorflow::Status GetOutput(
-      const std::string& name, const ModelOutput** output) const;
+  Status GetOutput(const std::string& name, const ModelOutput** output) const;
 
   // Get a label provider for the model.
   const LabelProvider& GetLabelProvider() const { return label_provider_; }
@@ -77,7 +75,7 @@ class InferenceBackend {
       std::shared_ptr<ModelInferStats> stats,
       std::shared_ptr<InferRequestProvider> request_provider,
       std::shared_ptr<InferResponseProvider> response_provider,
-      std::function<void(tensorflow::Status)> OnCompleteHandleInfer);
+      std::function<void(Status)> OnCompleteHandleInfer);
 
   // Get a metric for the servable specialized for the given GPU index
   // (if -1 then return non-specialized version of the metric).
@@ -92,16 +90,15 @@ class InferenceBackend {
 
  protected:
   // Set the configuration of the model being served.
-  tensorflow::Status SetModelConfig(
-      const tensorflow::StringPiece& path, const ModelConfig& config);
+  Status SetModelConfig(const std::string& path, const ModelConfig& config);
 
   // Explicitly set the scheduler to use for inference requests to the
   // model. The scheduler can only be set once for a servable.
-  tensorflow::Status SetScheduler(std::unique_ptr<Scheduler> scheduler);
+  Status SetScheduler(std::unique_ptr<Scheduler> scheduler);
 
   // Set the scheduler based on the model configuration. The scheduler
   // can only be set once for a servable.
-  tensorflow::Status SetConfiguredScheduler(
+  Status SetConfiguredScheduler(
       const uint32_t runner_cnt, Scheduler::StandardInitFunc OnInit,
       Scheduler::StandardRunFunc OnRun);
 

--- a/src/core/constants.h
+++ b/src/core/constants.h
@@ -62,4 +62,12 @@ constexpr int MAX_GRPC_MESSAGE_SIZE = INT32_MAX;
 constexpr int SCHEDULER_DEFAULT_NICE = 5;
 constexpr uint64_t SEQUENCE_IDLE_DEFAULT_MICROSECONDS = 1000 * 1000;
 
+#define DISALLOW_COPY(TypeName) TypeName(const TypeName&) = delete;
+
+#define DISALLOW_ASSIGN(TypeName) void operator=(const TypeName&) = delete;
+
+#define DISALLOW_COPY_AND_ASSIGN(TypeName) \
+  DISALLOW_COPY(TypeName)                  \
+  DISALLOW_ASSIGN(TypeName)
+
 }}  // namespace nvidia::inferenceserver

--- a/src/core/dynamic_batch_scheduler.h
+++ b/src/core/dynamic_batch_scheduler.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -33,7 +33,7 @@
 #include "src/core/api.pb.h"
 #include "src/core/model_config.pb.h"
 #include "src/core/scheduler.h"
-#include "tensorflow/core/lib/core/errors.h"
+#include "src/core/status.h"
 
 namespace nvidia { namespace inferenceserver {
 
@@ -42,7 +42,7 @@ class DynamicBatchScheduler : public Scheduler {
  public:
   // Create a scheduler to support a given number of runners and a run
   // function to call when a request is scheduled.
-  static tensorflow::Status Create(
+  static Status Create(
       const ModelConfig& config, const uint32_t runner_cnt,
       StandardInitFunc OnInit, StandardRunFunc OnSchedule,
       std::unique_ptr<Scheduler>* scheduler);
@@ -54,7 +54,7 @@ class DynamicBatchScheduler : public Scheduler {
       const std::shared_ptr<ModelInferStats>& stats,
       const std::shared_ptr<InferRequestProvider>& request_provider,
       const std::shared_ptr<InferResponseProvider>& response_provider,
-      std::function<void(tensorflow::Status)> OnComplete) override;
+      std::function<void(Status)> OnComplete) override;
 
  private:
   DynamicBatchScheduler(

--- a/src/core/ensemble_utils.h
+++ b/src/core/ensemble_utils.h
@@ -29,7 +29,7 @@
 #include <unordered_map>
 #include "src/core/model_config.h"
 #include "src/core/model_config.pb.h"
-#include "tensorflow/core/lib/core/errors.h"
+#include "src/core/status.h"
 
 namespace nvidia { namespace inferenceserver {
 
@@ -62,7 +62,7 @@ std::string DimsListToString(const DimsList& list);
 /// if error status is non-OK.
 /// \return The error status. A non-OK status indicates the TensorNode objects
 /// are not consistent.
-tensorflow::Status ValidateTensorConsistency(
+Status ValidateTensorConsistency(
     const TensorNode& lhs, const TensorNode& rhs, const std::string& message);
 
 /// Validate that the ensembles are specified correctly. Assuming that the
@@ -72,7 +72,7 @@ tensorflow::Status ValidateTensorConsistency(
 /// in the ensembles.
 /// \return The error status. A non-OK status indicates the configuration
 /// is not valid.
-tensorflow::Status ValidateEnsembleConfig(
+Status ValidateEnsembleConfig(
     const std::unordered_map<std::string, ModelConfig>& config_map);
 
 /// Validate that the ensembles are specified correctly. Assuming that the
@@ -89,7 +89,7 @@ tensorflow::Status ValidateEnsembleConfig(
 /// 'ensemble' is in.
 /// \return The error status. A non-OK status indicates the configuration
 /// is not valid.
-tensorflow::Status ValidateEnsembleConfig(
+Status ValidateEnsembleConfig(
     const std::string& ensemble,
     const std::unordered_map<std::string, ModelConfig>& config_map,
     const std::unordered_map<std::string, std::string>& invalid_model_names,

--- a/src/core/grpc_server.h
+++ b/src/core/grpc_server.h
@@ -25,8 +25,8 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
+#include "src/core/status.h"
 #include "src/nvrpc/Server.h"
-#include "tensorflow/core/lib/core/status.h"
 
 namespace nvidia { namespace inferenceserver {
 
@@ -34,13 +34,14 @@ class InferenceServer;
 
 class GRPCServer : private nvrpc::Server {
  public:
-  static tensorflow::Status Create(
+  static Status Create(
       InferenceServer* server, uint16_t port,
       std::unique_ptr<GRPCServer>* grpc_server);
-  tensorflow::Status Start();
-  tensorflow::Status Stop();
+  Status Start();
+  Status Stop();
 
  private:
   GRPCServer(const std::string& addr);
 };
+
 }}  // namespace nvidia::inferenceserver

--- a/src/core/http_server.h
+++ b/src/core/http_server.h
@@ -25,7 +25,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
-#include "tensorflow/core/lib/core/status.h"
+#include "src/core/status.h"
 
 namespace nvidia { namespace inferenceserver {
 
@@ -33,10 +33,11 @@ class InferenceServer;
 
 class HTTPServer {
  public:
-  static tensorflow::Status Create(
+  static Status Create(
       InferenceServer* server, uint16_t port, int thread_cnt,
       std::unique_ptr<HTTPServer>* http_server);
-  virtual tensorflow::Status Start() = 0;
-  virtual tensorflow::Status Stop() = 0;
+  virtual Status Start() = 0;
+  virtual Status Stop() = 0;
 };
+
 }}  // namespace nvidia::inferenceserver

--- a/src/core/label_provider.cc
+++ b/src/core/label_provider.cc
@@ -28,7 +28,6 @@
 
 #include <iostream>
 #include <iterator>
-#include "tensorflow/core/lib/core/errors.h"
 #include "tensorflow/core/lib/io/inputbuffer.h"
 #include "tensorflow/core/platform/env.h"
 
@@ -51,17 +50,17 @@ LabelProvider::GetLabel(const std::string& name, size_t index) const
   return itr->second[index];
 }
 
-tensorflow::Status
+Status
 LabelProvider::AddLabels(const std::string& name, const std::string& filepath)
 {
   std::unique_ptr<tensorflow::RandomAccessFile> label_file;
-  TF_RETURN_IF_ERROR(
+  RETURN_IF_TF_ERROR(
       tensorflow::Env::Default()->NewRandomAccessFile(filepath, &label_file));
 
   auto p = label_map_.insert(std::make_pair(name, std::vector<std::string>()));
   if (!p.second) {
-    return tensorflow::errors::Internal(
-        "multiple label files for '", name, "'");
+    return Status(
+        RequestStatusCode::INTERNAL, "multiple label files for '" + name + "'");
   }
 
   auto itr = p.first;
@@ -76,10 +75,10 @@ LabelProvider::AddLabels(const std::string& name, const std::string& filepath)
   }
 
   if (!tensorflow::errors::IsOutOfRange(status)) {
-    return status;
+    return FROM_TF_STATUS(status);
   }
 
-  return tensorflow::Status::OK();
+  return Status::Success;
 }
 
 }}  // namespace nvidia::inferenceserver

--- a/src/core/label_provider.h
+++ b/src/core/label_provider.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -28,7 +28,8 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
-#include "tensorflow/core/lib/core/errors.h"
+#include "src/core/constants.h"
+#include "src/core/status.h"
 
 namespace nvidia { namespace inferenceserver {
 
@@ -42,11 +43,10 @@ class LabelProvider {
   const std::string& GetLabel(const std::string& name, size_t index) const;
 
   // Add a set of named labels initialized from a given 'filepath'.
-  tensorflow::Status AddLabels(
-      const std::string& name, const std::string& filepath);
+  Status AddLabels(const std::string& name, const std::string& filepath);
 
  private:
-  TF_DISALLOW_COPY_AND_ASSIGN(LabelProvider);
+  DISALLOW_COPY_AND_ASSIGN(LabelProvider);
 
   std::unordered_map<std::string, std::vector<std::string>> label_map_;
 };

--- a/src/core/metrics.cc
+++ b/src/core/metrics.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/core/metrics.h
+++ b/src/core/metrics.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/core/model_config_utils.h
+++ b/src/core/model_config_utils.h
@@ -26,7 +26,7 @@
 #pragma once
 
 #include "src/core/model_config.pb.h"
-#include "tensorflow/core/lib/core/errors.h"
+#include "src/core/status.h"
 #include "tensorflow_serving/config/platform_config.pb.h"
 
 namespace tfs = tensorflow::serving;
@@ -46,15 +46,14 @@ struct EnsembleTensor {
 /// \param path The path to the model definition file.
 /// \param version Returns the version.
 /// \return The error status.
-tensorflow::Status GetModelVersionFromPath(
-    const tensorflow::StringPiece& path, int64_t* version);
+Status GetModelVersionFromPath(const std::string& path, int64_t* version);
 
 /// Get the tensor name, false value, and true value for a sequence
 /// batcher control kind. If 'required' is true then must find a
 /// tensor for the control. If 'required' is false, return
 /// 'tensor_name' as empty-string if the control is not mapped to any
 /// tensor.
-tensorflow::Status GetSequenceControlProperties(
+Status GetSequenceControlProperties(
     const ModelSequenceBatching& batcher, const std::string& model_name,
     const ModelSequenceBatching::Control::Kind control_kind,
     const bool required, std::string* tensor_name, DataType* tensor_datatype,
@@ -68,10 +67,9 @@ tensorflow::Status GetSequenceControlProperties(
 /// configuration from the model definition.
 /// \param config Returns the normalized model configuration.
 /// \return The error status.
-tensorflow::Status GetNormalizedModelConfig(
-    const tensorflow::StringPiece& path,
-    const tfs::PlatformConfigMap& platform_config_map, const bool autofill,
-    ModelConfig* config);
+Status GetNormalizedModelConfig(
+    const std::string& path, const tfs::PlatformConfigMap& platform_config_map,
+    const bool autofill, ModelConfig* config);
 
 /// Validate that a model is specified correctly (excluding inputs and
 /// outputs which are validated via ValidateModelInput() and
@@ -81,7 +79,7 @@ tensorflow::Status GetNormalizedModelConfig(
 /// to make sure its platform matches this value.
 /// \return The error status. A non-OK status indicates the configuration
 /// is not valid.
-tensorflow::Status ValidateModelConfig(
+Status ValidateModelConfig(
     const ModelConfig& config, const std::string& expected_platform);
 
 /// Validate that the ensemble scheduling are specified correctly.
@@ -89,8 +87,7 @@ tensorflow::Status ValidateModelConfig(
 /// ensemble_scheduling field.
 /// \return The error status. A non-OK status indicates the configuration
 /// is not valid.
-tensorflow::Status ValidateEnsembleSchedulingConfig(
-    const ModelConfig& ensemble_config);
+Status ValidateEnsembleSchedulingConfig(const ModelConfig& ensemble_config);
 
 /// Build a graph that represents the data flow in the ensemble specifieed in
 /// given model config. the node (ensemble tensor) in the graph can be looked
@@ -100,7 +97,7 @@ tensorflow::Status ValidateEnsembleSchedulingConfig(
 /// \param keyed_ensemble_graph Returned the ensemble graph.
 /// \return The error status. A non-OK status indicates the build fails because
 /// the ensemble configuration is not valid.
-tensorflow::Status BuildEnsembleGraph(
+Status BuildEnsembleGraph(
     const ModelConfig& ensemble_config,
     std::unordered_map<std::string, EnsembleTensor>& keyed_ensemble_graph);
 
@@ -109,7 +106,7 @@ tensorflow::Status BuildEnsembleGraph(
 /// \param io The model input.
 /// \return The error status. A non-OK status indicates the input
 /// is not valid.
-tensorflow::Status ValidateModelInput(const ModelInput& io);
+Status ValidateModelInput(const ModelInput& io);
 
 /// Validate that an input is specified correctly in a model
 /// configuration and matches one of the allowed input names.
@@ -117,7 +114,7 @@ tensorflow::Status ValidateModelInput(const ModelInput& io);
 /// \param allowed The set of allowed input names.
 /// \return The error status. A non-OK status indicates the input
 /// is not valid.
-tensorflow::Status ValidateModelInput(
+Status ValidateModelInput(
     const ModelInput& io, const std::set<std::string>& allowed);
 
 /// Validate that an output is specified correctly in a model
@@ -125,7 +122,7 @@ tensorflow::Status ValidateModelInput(
 /// \param io The model output.
 /// \return The error status. A non-OK status indicates the output
 /// is not valid.
-tensorflow::Status ValidateModelOutput(const ModelOutput& io);
+Status ValidateModelOutput(const ModelOutput& io);
 
 /// Validate that an output is specified correctly in a model
 /// configuration and matches one of the allowed output names.
@@ -133,7 +130,7 @@ tensorflow::Status ValidateModelOutput(const ModelOutput& io);
 /// \param allowed The set of allowed output names.
 /// \return The error status. A non-OK status indicates the output
 /// is not valid.
-tensorflow::Status ValidateModelOutput(
+Status ValidateModelOutput(
     const ModelOutput& io, const std::set<std::string>& allowed);
 
 }}  // namespace nvidia::inferenceserver

--- a/src/core/model_repository_manager.h
+++ b/src/core/model_repository_manager.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -29,7 +29,7 @@
 #include <mutex>
 #include "src/core/model_config.h"
 #include "src/core/model_config.pb.h"
-#include "tensorflow/core/lib/core/status.h"
+#include "src/core/status.h"
 #include "tensorflow_serving/config/model_server_config.pb.h"
 #include "tensorflow_serving/config/platform_config.pb.h"
 
@@ -47,7 +47,7 @@ class ModelRepositoryManager {
   /// \param autofill If true attempt to autofill missing required
   /// information in each model configuration.
   /// \return The error status.
-  static tensorflow::Status Create(
+  static Status Create(
       const std::string& repository_path,
       const tfs::PlatformConfigMap& platform_config_map, const bool autofill);
 
@@ -61,7 +61,7 @@ class ModelRepositoryManager {
   /// \param unmodified The names of the models remaining in the
   /// repository that have not changed.
   /// \return The error status.
-  static tensorflow::Status Poll(
+  static Status Poll(
       std::set<std::string>* added, std::set<std::string>* deleted,
       std::set<std::string>* modified, std::set<std::string>* unmodified);
 
@@ -69,22 +69,21 @@ class ModelRepositoryManager {
   /// \param name The model name.
   /// \param model_config Returns the model configuration.
   /// \return OK if found, NOT_FOUND otherwise.
-  static tensorflow::Status GetModelConfig(
+  static Status GetModelConfig(
       const std::string& name, ModelConfig* model_config);
 
   /// Get TFS-style configuration for a named model.
   /// \param name The model name.
   /// \param tfs_model_config Returns the TFS-style model configuration.
   /// \return OK if found, NOT_FOUND otherwise.
-  static tensorflow::Status GetTFSModelConfig(
+  static Status GetTFSModelConfig(
       const std::string& name, tfs::ModelConfig* tfs_model_config);
 
   /// Get the platform for a named model.
   /// \param name The model name.
   /// \param platform Returns the Platform.
   /// \return OK if found, NOT_FOUND otherwise.
-  static tensorflow::Status GetModelPlatform(
-      const std::string& name, Platform* platform);
+  static Status GetModelPlatform(const std::string& name, Platform* platform);
 
  private:
   struct ModelInfo {

--- a/src/core/profile.cc
+++ b/src/core/profile.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -28,11 +28,10 @@
 
 #include "cuda/include/cuda_profiler_api.h"
 #include "cuda/include/cuda_runtime_api.h"
-#include "tensorflow/core/lib/core/errors.h"
 
 namespace nvidia { namespace inferenceserver {
 
-tensorflow::Status
+Status
 ProfileStartAll()
 {
   int dcnt;
@@ -40,29 +39,34 @@ ProfileStartAll()
   if (cuerr == cudaErrorNoDevice) {
     dcnt = 0;
   } else if (cuerr != cudaSuccess) {
-    return tensorflow::errors::Internal(
-        "failed to get device count for profiling: ",
-        cudaGetErrorString(cuerr));
+    return Status(
+        RequestStatusCode::INTERNAL,
+        "failed to get device count for profiling: " +
+            std::string(cudaGetErrorString(cuerr)));
   }
 
   for (int i = 0; i < dcnt; i++) {
     cuerr = cudaSetDevice(i);
     if (cuerr != cudaSuccess) {
-      return tensorflow::errors::Internal(
-          "failed to set device for profiling: ", cudaGetErrorString(cuerr));
+      return Status(
+          RequestStatusCode::INTERNAL,
+          "failed to set device for profiling: " +
+              std::string(cudaGetErrorString(cuerr)));
     }
 
     cuerr = cudaProfilerStart();
     if (cuerr != cudaSuccess) {
-      return tensorflow::errors::Internal(
-          "failed to start profiling: ", cudaGetErrorString(cuerr));
+      return Status(
+          RequestStatusCode::INTERNAL,
+          "failed to start profiling: " +
+              std::string(cudaGetErrorString(cuerr)));
     }
   }
 
-  return tensorflow::Status::OK();
+  return Status::Success;
 }
 
-tensorflow::Status
+Status
 ProfileStopAll()
 {
   int dcnt;
@@ -70,26 +74,31 @@ ProfileStopAll()
   if (cuerr == cudaErrorNoDevice) {
     dcnt = 0;
   } else if (cuerr != cudaSuccess) {
-    return tensorflow::errors::Internal(
-        "failed to get device count for profiling: ",
-        cudaGetErrorString(cuerr));
+    return Status(
+        RequestStatusCode::INTERNAL,
+        "failed to get device count for profiling: " +
+            std::string(cudaGetErrorString(cuerr)));
   }
 
   for (int i = 0; i < dcnt; i++) {
     cuerr = cudaSetDevice(i);
     if (cuerr != cudaSuccess) {
-      return tensorflow::errors::Internal(
-          "failed to set device for profiling: ", cudaGetErrorString(cuerr));
+      return Status(
+          RequestStatusCode::INTERNAL,
+          "failed to set device for profiling: " +
+              std::string(cudaGetErrorString(cuerr)));
     }
 
     cuerr = cudaProfilerStop();
     if (cuerr != cudaSuccess) {
-      return tensorflow::errors::Internal(
-          "failed to stop profiling: ", cudaGetErrorString(cuerr));
+      return Status(
+          RequestStatusCode::INTERNAL,
+          "failed to stop profiling: " +
+              std::string(cudaGetErrorString(cuerr)));
     }
   }
 
-  return tensorflow::Status::OK();
+  return Status::Success;
 }
 
 }}  // namespace nvidia::inferenceserver

--- a/src/core/profile.h
+++ b/src/core/profile.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -25,14 +25,14 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
-#include "tensorflow/core/lib/core/status.h"
+#include "src/core/status.h"
 
 namespace nvidia { namespace inferenceserver {
 
 // Start profiling on all GPU devices.
-tensorflow::Status ProfileStartAll();
+Status ProfileStartAll();
 
 // Stop profiling on all GPU devices.
-tensorflow::Status ProfileStopAll();
+Status ProfileStopAll();
 
 }}  // namespace nvidia::inferenceserver

--- a/src/core/request_status.cc
+++ b/src/core/request_status.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -28,33 +28,6 @@
 
 namespace nvidia { namespace inferenceserver {
 
-namespace {
-
-RequestStatusCode
-GetStatusCode(const tensorflow::Status& tf_status)
-{
-  if (tf_status.ok()) {
-    return RequestStatusCode::SUCCESS;
-  }
-
-  switch (tf_status.code()) {
-    case tensorflow::error::INVALID_ARGUMENT:
-      return RequestStatusCode::INVALID_ARG;
-    case tensorflow::error::NOT_FOUND:
-      return RequestStatusCode::NOT_FOUND;
-    case tensorflow::error::UNAVAILABLE:
-      return RequestStatusCode::UNAVAILABLE;
-    case tensorflow::error::INTERNAL:
-      return RequestStatusCode::INTERNAL;
-    default:
-      break;
-  }
-
-  return RequestStatusCode::UNKNOWN;
-}
-
-}  // namespace
-
 void
 RequestStatusFactory::Create(
     RequestStatus* status, uint64_t request_id, const std::string& server_id,
@@ -81,11 +54,10 @@ RequestStatusFactory::Create(
 void
 RequestStatusFactory::Create(
     RequestStatus* status, uint64_t request_id, const std::string& server_id,
-    const tensorflow::Status& tf_status)
+    const Status& isstatus)
 {
-  status->Clear();
-  status->set_code(GetStatusCode(tf_status));
-  status->set_msg(tf_status.error_message());
+  status->set_code(isstatus.Code());
+  status->set_msg(isstatus.Message());
   status->set_server_id(server_id);
   status->set_request_id(request_id);
 }

--- a/src/core/request_status.h
+++ b/src/core/request_status.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -26,13 +26,13 @@
 #pragma once
 
 #include "src/core/request_status.pb.h"
-#include "tensorflow/core/lib/core/status.h"
+#include "src/core/status.h"
 
 namespace nvidia { namespace inferenceserver {
 
 class RequestStatusFactory {
  public:
-  // Create a Status object from a code and optional message.
+  // Create a RequestStatus object from a code and optional message.
   static void Create(
       RequestStatus* status, uint64_t request_id, const std::string& server_id,
       RequestStatusCode code, const std::string& msg);
@@ -40,10 +40,10 @@ class RequestStatusFactory {
       RequestStatus* status, uint64_t request_id, const std::string& server_id,
       RequestStatusCode code);
 
-  // Create a Status object from a TensorFlow status.
+  // Create a RequestStatus object a Status.
   static void Create(
       RequestStatus* status, uint64_t request_id, const std::string& server_id,
-      const tensorflow::Status& tf_status);
+      const Status& isstatus);
 };
 
 }}  // namespace nvidia::inferenceserver

--- a/src/core/request_status.proto
+++ b/src/core/request_status.proto
@@ -87,6 +87,12 @@ enum RequestStatusCode {
   //@@     Error code indicating an unsupported request or operation.
   //@@
   UNSUPPORTED = 7;
+
+  //@@  .. cpp:enumerator:: RequestStatusCode::ALREADY_EXISTS = 8
+  //@@
+  //@@     Error code indicating an already existing resource.
+  //@@
+  ALREADY_EXISTS = 8;
 }
 
 //@@

--- a/src/core/scheduler.h
+++ b/src/core/scheduler.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 #pragma once
 
 #include "src/core/server_status.h"
-#include "tensorflow/core/lib/core/errors.h"
+#include "src/core/status.h"
 
 namespace nvidia { namespace inferenceserver {
 
@@ -57,12 +57,11 @@ class Scheduler {
         const std::shared_ptr<ModelInferStats>& stats,
         const std::shared_ptr<InferRequestProvider>& request_provider,
         const std::shared_ptr<InferResponseProvider>& response_provider,
-        const std::function<void(tensorflow::Status)> complete_function)
+        const std::function<void(Status)> complete_function)
         : queue_timer_(std::move(queue_timer)), stats_(stats),
           request_provider_(request_provider),
           response_provider_(response_provider),
-          complete_function_(complete_function),
-          status_(tensorflow::Status::OK())
+          complete_function_(complete_function), status_(Status::Success)
     {
     }
 
@@ -70,8 +69,8 @@ class Scheduler {
     std::shared_ptr<ModelInferStats> stats_;
     std::shared_ptr<InferRequestProvider> request_provider_;
     std::shared_ptr<InferResponseProvider> response_provider_;
-    std::function<void(tensorflow::Status)> complete_function_;
-    tensorflow::Status status_;
+    std::function<void(Status)> complete_function_;
+    Status status_;
   };
 
   // The prototype for the initialization function that will be called
@@ -80,8 +79,7 @@ class Scheduler {
   // the runner that will later execute payloads for 'runner_idx'. A
   // non-OK error status indicates an initialization error that
   // prevents scheduler from using the runner.
-  using StandardInitFunc =
-      std::function<tensorflow::Status(uint32_t runner_idx)>;
+  using StandardInitFunc = std::function<Status(uint32_t runner_idx)>;
 
   // The prototype for the run function that will be called by the
   // "standard" schedulers created based on a model's
@@ -94,14 +92,14 @@ class Scheduler {
   // single request in 'payloads' it will be reported in that payload.
   using StandardRunFunc = std::function<void(
       uint32_t runner_idx, std::vector<Payload>* payloads,
-      std::function<void(tensorflow::Status)> OnRunComplete)>;
+      std::function<void(Status)> OnRunComplete)>;
 
   // Enqueue a request with the scheduler.
   virtual void Enqueue(
       const std::shared_ptr<ModelInferStats>& stats,
       const std::shared_ptr<InferRequestProvider>& request_provider,
       const std::shared_ptr<InferResponseProvider>& response_provider,
-      std::function<void(tensorflow::Status)> OnComplete) = 0;
+      std::function<void(Status)> OnComplete) = 0;
 };
 
 }}  // namespace nvidia::inferenceserver

--- a/src/core/sequence_batch_scheduler.h
+++ b/src/core/sequence_batch_scheduler.h
@@ -37,7 +37,7 @@
 #include "src/core/model_config.pb.h"
 #include "src/core/provider.h"
 #include "src/core/scheduler.h"
-#include "tensorflow/core/lib/core/errors.h"
+#include "src/core/status.h"
 
 namespace nvidia { namespace inferenceserver {
 
@@ -50,7 +50,7 @@ class SequenceBatchScheduler : public Scheduler {
 
   // Create a scheduler to support a given number of runners and a run
   // function to call when a request is scheduled.
-  static tensorflow::Status Create(
+  static Status Create(
       const ModelConfig& config, const uint32_t runner_cnt,
       StandardInitFunc OnInit, StandardRunFunc OnSchedule,
       std::unique_ptr<Scheduler>* scheduler);
@@ -60,7 +60,7 @@ class SequenceBatchScheduler : public Scheduler {
       const std::shared_ptr<ModelInferStats>& stats,
       const std::shared_ptr<InferRequestProvider>& request_provider,
       const std::shared_ptr<InferResponseProvider>& response_provider,
-      std::function<void(tensorflow::Status)> OnComplete) override;
+      std::function<void(Status)> OnComplete) override;
 
   // A batch-slot combination. The batch is represented by the index
   // into 'batches_'.
@@ -84,7 +84,7 @@ class SequenceBatchScheduler : public Scheduler {
  private:
   void ReaperThread(const int nice);
 
-  tensorflow::Status CreateControlTensors(
+  Status CreateControlTensors(
       const ModelConfig& config,
       std::shared_ptr<InferRequestProvider::InputOverrideMap>*
           start_input_overrides,
@@ -117,7 +117,7 @@ class SequenceBatchScheduler : public Scheduler {
         const std::shared_ptr<ModelInferStats>& stats,
         const std::shared_ptr<InferRequestProvider>& request_provider,
         const std::shared_ptr<InferResponseProvider>& response_provider,
-        std::function<void(tensorflow::Status)> OnComplete);
+        std::function<void(Status)> OnComplete);
 
    private:
     void SchedulerThread(const int nice);

--- a/src/core/server.h
+++ b/src/core/server.h
@@ -38,7 +38,7 @@
 #include "src/core/request_status.pb.h"
 #include "src/core/server_status.h"
 #include "src/core/server_status.pb.h"
-#include "tensorflow/core/lib/core/status.h"
+#include "src/core/status.h"
 #include "tensorflow_serving/model_servers/server_core.h"
 
 namespace tfs = tensorflow::serving;
@@ -126,7 +126,7 @@ class InferenceServer {
   class InferBackendHandle {
    public:
     InferBackendHandle() : is_(nullptr) {}
-    tensorflow::Status Init(
+    Status Init(
         const std::string& model_name, const int64_t model_version,
         tfs::ServerCore* core);
     InferenceBackend* operator()() { return is_; }
@@ -141,7 +141,7 @@ class InferenceServer {
     tfs::ServableHandle<EnsembleBundle> ensemble_bundle_;
   };
 
-  tensorflow::Status CreateBackendHandle(
+  Status CreateBackendHandle(
       const std::string& model_name, const int64_t model_version,
       const std::shared_ptr<InferBackendHandle>& handle);
 
@@ -151,7 +151,7 @@ class InferenceServer {
 
   std::unique_ptr<GRPCServer> StartGrpcServer();
   std::unique_ptr<HTTPServer> StartHttpServer();
-  tensorflow::Status ParseProtoTextFile(
+  Status ParseProtoTextFile(
       const std::string& file, google::protobuf::Message* message);
   tfs::PlatformConfigMap BuildPlatformConfigMap(
       float tf_gpu_memory_fraction, bool tf_allow_soft_placement);

--- a/src/core/server_status.cc
+++ b/src/core/server_status.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -32,7 +32,6 @@
 #include "src/core/logging.h"
 #include "src/core/metrics.h"
 #include "src/core/provider.h"
-#include "tensorflow/core/lib/core/errors.h"
 #include "tensorflow_serving/core/servable_state.h"
 
 namespace nvidia { namespace inferenceserver {
@@ -92,11 +91,11 @@ ServerStatusManager::ServerStatusManager(const std::string& server_version)
   }
 }
 
-tensorflow::Status
+Status
 ServerStatusManager::InitForModel(const std::string& model_name)
 {
   ModelConfig model_config;
-  TF_RETURN_IF_ERROR(
+  RETURN_IF_ERROR(
       ModelRepositoryManager::GetModelConfig(model_name, &model_config));
 
   std::lock_guard<std::mutex> lock(mu_);
@@ -111,32 +110,33 @@ ServerStatusManager::InitForModel(const std::string& model_name)
 
   ms[model_name].mutable_config()->CopyFrom(model_config);
 
-  return tensorflow::Status::OK();
+  return Status::Success;
 }
 
-tensorflow::Status
+Status
 ServerStatusManager::UpdateConfigForModel(const std::string& model_name)
 {
   ModelConfig model_config;
-  TF_RETURN_IF_ERROR(
+  RETURN_IF_ERROR(
       ModelRepositoryManager::GetModelConfig(model_name, &model_config));
 
   std::lock_guard<std::mutex> lock(mu_);
 
   auto& ms = *server_status_.mutable_model_status();
   if (ms.find(model_name) == ms.end()) {
-    return tensorflow::errors::InvalidArgument(
-        "try to update config for non-existing model '", model_name, "'");
+    return Status(
+        RequestStatusCode::INVALID_ARG,
+        "try to update config for non-existing model '" + model_name + "'");
   } else {
     LOG_INFO << "Updating config for model '" << model_name << "'";
   }
 
   ms[model_name].mutable_config()->CopyFrom(model_config);
 
-  return tensorflow::Status::OK();
+  return Status::Success;
 }
 
-tensorflow::Status
+Status
 ServerStatusManager::Get(
     ServerStatus* server_status, const std::string& server_id,
     ServerReadyState server_ready_state, uint64_t server_uptime_ns,
@@ -154,10 +154,10 @@ ServerStatusManager::Get(
     }
   }
 
-  return tensorflow::Status::OK();
+  return Status::Success;
 }
 
-tensorflow::Status
+Status
 ServerStatusManager::Get(
     ServerStatus* server_status, const std::string& server_id,
     ServerReadyState server_ready_state, uint64_t server_uptime_ns,
@@ -174,8 +174,9 @@ ServerStatusManager::Get(
 
   const auto& itr = server_status_.model_status().find(model_name);
   if (itr == server_status_.model_status().end()) {
-    return tensorflow::errors::InvalidArgument(
-        "no status available for unknown model '", model_name, "'");
+    return Status(
+        RequestStatusCode::INVALID_ARG,
+        "no status available for unknown model '" + model_name + "'");
   }
 
   auto& ms = *server_status->mutable_model_status();
@@ -184,7 +185,7 @@ ServerStatusManager::Get(
     SetModelVersionReadyState(*monitor, ms[model_name]);
   }
 
-  return tensorflow::Status::OK();
+  return Status::Success;
 }
 
 void

--- a/src/core/server_status.h
+++ b/src/core/server_status.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -30,7 +30,7 @@
 #include "src/core/model_config.pb.h"
 #include "src/core/model_repository_manager.h"
 #include "src/core/server_status.pb.h"
-#include "tensorflow/core/lib/core/status.h"
+#include "src/core/status.h"
 #include "tensorflow_serving/core/servable_state_monitor.h"
 
 namespace nvidia { namespace inferenceserver {
@@ -167,19 +167,19 @@ class ServerStatusManager {
   explicit ServerStatusManager(const std::string& server_version);
 
   // Initialize status for a model.
-  tensorflow::Status InitForModel(const std::string& model_name);
+  Status InitForModel(const std::string& model_name);
 
   // Update model config for an existing model.
-  tensorflow::Status UpdateConfigForModel(const std::string& model_name);
+  Status UpdateConfigForModel(const std::string& model_name);
 
   // Get the entire server status, including status for all models.
-  tensorflow::Status Get(
+  Status Get(
       ServerStatus* server_status, const std::string& server_id,
       ServerReadyState server_ready_state, uint64_t server_uptime_ns,
       const tensorflow::serving::ServableStateMonitor* monitor) const;
 
   // Get the server status and the status for a single model.
-  tensorflow::Status Get(
+  Status Get(
       ServerStatus* server_status, const std::string& server_id,
       ServerReadyState server_ready_state, uint64_t server_uptime_ns,
       const std::string& model_name,

--- a/src/core/status.h
+++ b/src/core/status.h
@@ -1,0 +1,94 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include "src/core/request_status.pb.h"
+
+namespace nvidia { namespace inferenceserver {
+
+class Status {
+ public:
+  // Construct a status from a code with no message.
+  explicit Status(RequestStatusCode code = RequestStatusCode::SUCCESS)
+      : code_(code)
+  {
+  }
+
+  // Construct a status from a code and message.
+  explicit Status(RequestStatusCode code, const std::string& msg)
+      : code_(code), msg_(msg)
+  {
+  }
+
+  // Convenience "success" value. Can be used as Status::Success to
+  // indicate no error.
+  static const Status Success;
+
+  // Return the RequestStatusCode for this status.
+  RequestStatusCode Code() const { return code_; }
+
+  // Return the message for this status.
+  const std::string& Message() const { return msg_; }
+
+  // Return true if this status indicates "ok"/"success", false if
+  // status indicates some kind of failure.
+  bool IsOk() const { return code_ == RequestStatusCode::SUCCESS; }
+
+  // Return the status as a string.
+  std::string AsString() const;
+
+  // Convert a TensorFlow status code to inference server status code.
+  static RequestStatusCode FromTFError(const int tf_code);
+
+ private:
+  RequestStatusCode code_;
+  std::string msg_;
+};
+
+// If status is non-OK, return the Status.
+#define RETURN_IF_ERROR(S)                          \
+  do {                                              \
+    if ((S).Code() != RequestStatusCode::SUCCESS) { \
+      return (S);                                   \
+    }                                               \
+  } while (false)
+
+
+// Macro to convert from a TensorFlow Status -> Status. Implemented as
+// a macro to avoid including TF status and error headers and
+// everything they depend on.
+#define FROM_TF_STATUS(TFS) \
+  Status(Status::FromTFError((TFS).code()), (TFS).error_message())
+
+// If TensorFlow status is non-OK, return the equivalent Status.
+#define RETURN_IF_TF_ERROR(TFS)   \
+  do {                            \
+    if ((TFS).code() != 0) {      \
+      return FROM_TF_STATUS(TFS); \
+    }                             \
+  } while (false)
+
+}}  // namespace nvidia::inferenceserver

--- a/src/servables/caffe2/BUILD
+++ b/src/servables/caffe2/BUILD
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -33,10 +33,6 @@ load("@protobuf_archive//:protobuf.bzl", "cc_proto_library")
 cc_proto_library(
     name = "netdef_bundle_proto",
     srcs = ["netdef_bundle.proto"],
-    deps = [
-        "@org_tensorflow//tensorflow/core:protos_all_cc",
-        "@protobuf_archive//:cc_wkt_protos",
-    ],
 )
 
 cc_library(
@@ -46,6 +42,7 @@ cc_library(
     deps = [
         "//src/core:autofill_header",
         "//src/core:constants",
+        "//src/core:status",
         "@org_tensorflow//tensorflow/core:lib",
     ],
 )
@@ -71,6 +68,7 @@ cc_library(
         "//src/core:provider",
         "//src/core:server_status",
         "//src/core:model_config_utils",
+        "//src/core:status",
     ],
 )
 
@@ -85,7 +83,9 @@ cc_library(
         "//src/core:logging",
         "//src/core:model_config",
         "//src/core:model_config_proto",
-         "//src/core:model_config_utils",
+        "//src/core:model_config_utils",
+        "//src/core:status",
+        "@org_tensorflow//tensorflow/core:lib",
         "@tf_serving//tensorflow_serving/core:loader",
         "@tf_serving//tensorflow_serving/core:simple_loader",
         "@tf_serving//tensorflow_serving/core:source_adapter",

--- a/src/servables/caffe2/autofill.h
+++ b/src/servables/caffe2/autofill.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -28,16 +28,16 @@
 #include <string>
 #include "src/core/autofill.h"
 #include "src/core/model_config.pb.h"
-#include "tensorflow/core/lib/core/errors.h"
+#include "src/core/status.h"
 
 namespace nvidia { namespace inferenceserver {
 
 class AutoFillNetDef : public AutoFill {
  public:
-  static tensorflow::Status Create(
+  static Status Create(
       const std::string& model_name, const std::string& model_path,
       std::unique_ptr<AutoFillNetDef>* autofill);
-  tensorflow::Status Fix(ModelConfig* config) override;
+  Status Fix(ModelConfig* config) override;
 
  private:
   AutoFillNetDef(const std::string& model_name) : AutoFill(model_name) {}

--- a/src/servables/caffe2/netdef_bundle.h
+++ b/src/servables/caffe2/netdef_bundle.h
@@ -28,8 +28,8 @@
 #include "src/core/backend.h"
 #include "src/core/model_config.pb.h"
 #include "src/core/scheduler.h"
+#include "src/core/status.h"
 #include "src/servables/caffe2/netdef_bundle_c2.h"
-#include "tensorflow/core/lib/core/errors.h"
 
 namespace nvidia { namespace inferenceserver {
 
@@ -38,19 +38,18 @@ class NetDefBundle : public InferenceBackend {
   NetDefBundle() = default;
   NetDefBundle(NetDefBundle&&) = default;
 
-  tensorflow::Status Init(
-      const tensorflow::StringPiece& path, const ModelConfig& config);
+  Status Init(const std::string& path, const ModelConfig& config);
 
   // Create a context for execution for each instance for the
   // serialized netdefs specified in 'models'.
-  tensorflow::Status CreateExecutionContexts(
+  Status CreateExecutionContexts(
       const std::unordered_map<std::string, std::vector<char>>& models);
-  tensorflow::Status CreateExecutionContext(
+  Status CreateExecutionContext(
       const std::string& instance_name, const int gpu_device,
       const std::unordered_map<std::string, std::vector<char>>& models);
 
  private:
-  tensorflow::Status ValidateSequenceControl(
+  Status ValidateSequenceControl(
       const ModelSequenceBatching::Control::Kind control_kind,
       std::vector<std::string>* input_names);
 
@@ -58,7 +57,7 @@ class NetDefBundle : public InferenceBackend {
   // execute for one or more requests.
   void Run(
       uint32_t runner_idx, std::vector<Scheduler::Payload>* payloads,
-      std::function<void(tensorflow::Status)> OnCompleteQueuedPayloads);
+      std::function<void(Status)> OnCompleteQueuedPayloads);
 
  private:
   TF_DISALLOW_COPY_AND_ASSIGN(NetDefBundle);
@@ -81,13 +80,13 @@ class NetDefBundle : public InferenceBackend {
 
     TF_DISALLOW_COPY_AND_ASSIGN(Context);
 
-    tensorflow::Status ValidateInputs(
+    Status ValidateInputs(
         const ::google::protobuf::RepeatedPtrField<ModelInput>& ios);
-    tensorflow::Status ValidateOutputs(
+    Status ValidateOutputs(
         const ::google::protobuf::RepeatedPtrField<ModelOutput>& ios);
 
     // Set an input tensor data from payloads.
-    tensorflow::Status SetInput(
+    Status SetInput(
         const std::string& name, const DataType datatype, const DimsList& dims,
         const size_t total_batch_size,
         std::vector<Scheduler::Payload>* payloads,
@@ -99,18 +98,18 @@ class NetDefBundle : public InferenceBackend {
     // an internal error that prevents any of the of requests from
     // completing. If an error is isolate to a single request payload
     // it will be reported in that payload.
-    tensorflow::Status Run(
+    Status Run(
         const NetDefBundle* base, std::vector<Scheduler::Payload>* payloads);
 
     // Set an input tensor from one or more payloads.
-    tensorflow::Status SetFixedSizedInputTensor(
+    Status SetFixedSizedInputTensor(
         const std::string& input_name, const std::vector<int64_t>& shape,
         const Caffe2Workspace::DataType dtype, const size_t batch1_byte_size,
         const size_t total_byte_size, std::vector<Scheduler::Payload>* payloads,
         std::vector<std::unique_ptr<char[]>>* input_buffers);
 
     // Read an output tensor into one or more payloads.
-    tensorflow::Status ReadFixedSizedOutputTensor(
+    Status ReadFixedSizedOutputTensor(
         const std::string& name, const std::vector<int64_t>& shape,
         const Caffe2Workspace::DataType dtype, const size_t dtype_byte_size,
         const size_t total_batch_size,

--- a/src/servables/caffe2/netdef_bundle_source_adapter.h
+++ b/src/servables/caffe2/netdef_bundle_source_adapter.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -25,10 +25,10 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
+#include "src/core/status.h"
 #include "src/servables/caffe2/netdef_bundle.h"
 #include "src/servables/caffe2/netdef_bundle.pb.h"
-#include "tensorflow/core/lib/core/status.h"
-#include "tensorflow/core/platform/macros.h"
+#include "tensorflow/core/lib/core/errors.h"
 #include "tensorflow_serving/core/loader.h"
 #include "tensorflow_serving/core/simple_loader.h"
 #include "tensorflow_serving/core/source_adapter.h"

--- a/src/servables/caffe2/netdef_bundle_test.cc
+++ b/src/servables/caffe2/netdef_bundle_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -36,12 +36,11 @@ class NetDefBundleTest : public ModelConfigTestBase {
 
 TEST_F(NetDefBundleTest, ModelConfigSanity)
 {
-  BundleInitFunc init_func =
-      [](const std::string& path,
-         const ModelConfig& config) -> tensorflow::Status {
+  BundleInitFunc init_func = [](const std::string& path,
+                                const ModelConfig& config) -> Status {
     std::unique_ptr<NetDefBundle> bundle(new NetDefBundle());
-    tensorflow::Status status = bundle->Init(path, config);
-    if (status.ok()) {
+    Status status = bundle->Init(path, config);
+    if (status.IsOk()) {
       std::unordered_map<std::string, std::vector<char>> netdef_blobs;
 
       for (const auto& filename : std::vector<std::string>{

--- a/src/servables/custom/BUILD
+++ b/src/servables/custom/BUILD
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -33,10 +33,6 @@ load("@protobuf_archive//:protobuf.bzl", "cc_proto_library")
 cc_proto_library(
     name = "custom_bundle_proto",
     srcs = ["custom_bundle.proto"],
-    deps = [
-        "@org_tensorflow//tensorflow/core:protos_all_cc",
-        "@protobuf_archive//:cc_wkt_protos",
-    ],
 )
 
 cc_library(
@@ -57,10 +53,11 @@ cc_library(
         "//src/core:constants",
         "//src/core:logging",
         "//src/core:model_config_proto",
+        "//src/core:model_config_utils",
         "//src/core:model_config",
         "//src/core:provider",
         "//src/core:server_status",
-        "//src/core:model_config_utils",
+        "//src/core:status",
     ],
 )
 
@@ -76,6 +73,7 @@ cc_library(
         "//src/core:model_config",
         "//src/core:model_config_proto",
         "//src/core:model_config_utils",
+        "//src/core:status",
         "@tf_serving//tensorflow_serving/core:loader",
         "@tf_serving//tensorflow_serving/core:simple_loader",
         "@tf_serving//tensorflow_serving/core:source_adapter",
@@ -92,6 +90,7 @@ cc_library(
     deps = [
         ":custom",
         "//src/core:logging",
+        "//src/core:status",
         "@org_tensorflow//tensorflow/core:lib",
     ],
 )
@@ -108,6 +107,7 @@ cc_test(
     deps = [
         ":custom_bundle",
         "//src/core:constants",
+        "//src/core:status",
         "//src/test:model_config_test_base",
         "//src/test:testmain",
         "@local_config_cuda//cuda:cudart",

--- a/src/servables/custom/custom_bundle.h
+++ b/src/servables/custom/custom_bundle.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -28,8 +28,8 @@
 #include "src/core/backend.h"
 #include "src/core/model_config.pb.h"
 #include "src/core/scheduler.h"
+#include "src/core/status.h"
 #include "src/servables/custom/custom.h"
-#include "tensorflow/core/lib/core/errors.h"
 
 namespace nvidia { namespace inferenceserver {
 
@@ -38,27 +38,27 @@ class CustomBundle : public InferenceBackend {
   CustomBundle() = default;
   CustomBundle(CustomBundle&&) = default;
 
-  tensorflow::Status Init(
-      const tensorflow::StringPiece& path,
-      const std::vector<std::string>& server_params, const ModelConfig& config);
+  Status Init(
+      const std::string& path, const std::vector<std::string>& server_params,
+      const ModelConfig& config);
 
   // Create a context for execution for each instance for the custom
   // 'models'.
-  tensorflow::Status CreateExecutionContexts(
+  Status CreateExecutionContexts(
       const std::unordered_map<std::string, std::string>& libraries);
-  tensorflow::Status CreateExecutionContext(
+  Status CreateExecutionContext(
       const std::string& instance_name, const int gpu_device,
       const std::unordered_map<std::string, std::string>& libraries);
 
  private:
   // Init model on the context associated with 'runner_idx'.
-  tensorflow::Status InitBackend(uint32_t runner_idx);
+  Status InitBackend(uint32_t runner_idx);
 
   // Run model on the context associated with 'runner_idx' to
   // execute for one or more requests.
   void RunBackend(
       uint32_t runner_idx, std::vector<Scheduler::Payload>* payloads,
-      std::function<void(tensorflow::Status)> OnCompleteQueuedPayloads);
+      std::function<void(Status)> OnCompleteQueuedPayloads);
 
  private:
   TF_DISALLOW_COPY_AND_ASSIGN(CustomBundle);
@@ -95,8 +95,7 @@ class CustomBundle : public InferenceBackend {
     // an internal error that prevents any of the of requests from
     // completing. If an error is isolate to a single request payload
     // it will be reported in that payload.
-    tensorflow::Status Run(
-        CustomBundle* base, std::vector<Scheduler::Payload>* payloads);
+    Status Run(CustomBundle* base, std::vector<Scheduler::Payload>* payloads);
 
     struct GetInputOutputContext {
       GetInputOutputContext(

--- a/src/servables/custom/custom_bundle_source_adapter.h
+++ b/src/servables/custom/custom_bundle_source_adapter.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -28,7 +28,6 @@
 #include "src/servables/custom/custom_bundle.h"
 #include "src/servables/custom/custom_bundle.pb.h"
 #include "tensorflow/core/lib/core/status.h"
-#include "tensorflow/core/platform/macros.h"
 #include "tensorflow_serving/core/loader.h"
 #include "tensorflow_serving/core/simple_loader.h"
 #include "tensorflow_serving/core/source_adapter.h"

--- a/src/servables/custom/custom_bundle_test.cc
+++ b/src/servables/custom/custom_bundle_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -36,13 +36,12 @@ class CustomBundleTest : public ModelConfigTestBase {
 
 TEST_F(CustomBundleTest, ModelConfigSanity)
 {
-  BundleInitFunc init_func =
-      [](const std::string& path,
-         const ModelConfig& config) -> tensorflow::Status {
+  BundleInitFunc init_func = [](const std::string& path,
+                                const ModelConfig& config) -> Status {
     std::unique_ptr<CustomBundle> bundle(new CustomBundle());
     std::vector<std::string> server_params;
-    tensorflow::Status status = bundle->Init(path, server_params, config);
-    if (status.ok()) {
+    Status status = bundle->Init(path, server_params, config);
+    if (status.IsOk()) {
       std::unordered_map<std::string, std::string> custom_paths;
 
       for (const auto& filename : std::vector<std::string>{kCustomFilename}) {

--- a/src/servables/custom/loader.h
+++ b/src/servables/custom/loader.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -25,8 +25,8 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
+#include "src/core/status.h"
 #include "src/servables/custom/custom.h"
-#include "tensorflow/core/lib/core/errors.h"
 
 namespace nvidia { namespace inferenceserver {
 
@@ -43,7 +43,7 @@ namespace nvidia { namespace inferenceserver {
 /// \param ExecuteFn Returns the execute function from the custom
 /// library.
 /// \return Error status.
-tensorflow::Status LoadCustom(
+Status LoadCustom(
     const std::string& path, void** dlhandle,
     CustomInitializeFn_t* InitializeFn, CustomFinalizeFn_t* FinalizeFn,
     CustomErrorStringFn_t* ErrorStringFn, CustomExecuteFn_t* ExecuteFn);

--- a/src/servables/ensemble/BUILD
+++ b/src/servables/ensemble/BUILD
@@ -33,10 +33,6 @@ load("@protobuf_archive//:protobuf.bzl", "cc_proto_library")
 cc_proto_library(
     name = "ensemble_bundle_proto",
     srcs = ["ensemble_bundle.proto"],
-    deps = [
-        "@org_tensorflow//tensorflow/core:protos_all_cc",
-        "@protobuf_archive//:cc_wkt_protos",
-    ],
 )
 
 cc_library(
@@ -49,8 +45,7 @@ cc_library(
         "//src/core:model_config_proto",
         "//src/core:model_config_utils",
         "//src/core:server_status",
-        "@org_tensorflow//tensorflow/c:c_api",
-        "@org_tensorflow//tensorflow/core:lib",
+        "//src/core:status",
     ],
 )
 
@@ -66,12 +61,12 @@ cc_library(
         "//src/core:model_config",
         "//src/core:model_config_proto",
         "//src/core:model_config_utils",
+        "//src/core:status",
         "@tf_serving//tensorflow_serving/core:loader",
         "@tf_serving//tensorflow_serving/core:simple_loader",
         "@tf_serving//tensorflow_serving/core:source_adapter",
         "@tf_serving//tensorflow_serving/core:storage_path",
         "@tf_serving//tensorflow_serving/util:optional",
-        "@org_tensorflow//tensorflow/core:core_cpu",
         "@org_tensorflow//tensorflow/core:lib",
     ],
     alwayslink = 1,
@@ -100,6 +95,7 @@ cc_test(
         "//src/core:ensemble_utils",
         "//src/core:logging",
         "//src/core:model_config_utils",
+        "//src/core:status",
         "//src/test:model_config_test_base",
         "//src/test:testmain",
         "@local_config_cuda//cuda:cudart",

--- a/src/servables/ensemble/ensemble_bundle_source_adapter.h
+++ b/src/servables/ensemble/ensemble_bundle_source_adapter.h
@@ -28,7 +28,6 @@
 #include "src/servables/ensemble/ensemble_bundle.h"
 #include "src/servables/ensemble/ensemble_bundle.pb.h"
 #include "tensorflow/core/lib/core/status.h"
-#include "tensorflow/core/platform/macros.h"
 #include "tensorflow_serving/core/loader.h"
 #include "tensorflow_serving/core/simple_loader.h"
 #include "tensorflow_serving/core/source_adapter.h"

--- a/src/servables/ensemble/ensemble_bundle_test.cc
+++ b/src/servables/ensemble/ensemble_bundle_test.cc
@@ -64,16 +64,16 @@ EnsembleBundleTest::GetModelConfigsInRepository(
 
     ModelConfig config;
     tfs::PlatformConfigMap platform_map;
-    tensorflow::Status status =
+    Status status =
         GetNormalizedModelConfig(model_path, platform_map, false, &config);
-    if (!status.ok()) {
-      result->append(status.ToString());
+    if (!status.IsOk()) {
+      result->append(status.AsString());
       return false;
     }
 
     status = ValidateModelConfig(config, std::string());
-    if (!status.ok()) {
-      result->append(status.ToString());
+    if (!status.IsOk()) {
+      result->append(status.AsString());
       return false;
     }
 
@@ -84,10 +84,9 @@ EnsembleBundleTest::GetModelConfigsInRepository(
 
 TEST_F(EnsembleBundleTest, ModelConfigSanity)
 {
-  BundleInitFunc init_func =
-      [](const std::string& path,
-         const ModelConfig& config) -> tensorflow::Status {
-    return tensorflow::Status::OK();
+  BundleInitFunc init_func = [](const std::string& path,
+                                const ModelConfig& config) -> Status {
+    return Status::Success;
   };
 
   // Standard testing...
@@ -125,9 +124,9 @@ TEST_F(EnsembleBundleTest, EnsembleConfigSanity)
     }
 
     std::string actual;
-    tensorflow::Status status = ValidateEnsembleConfig(config_map);
-    if (!status.ok()) {
-      actual.append(status.ToString());
+    Status status = ValidateEnsembleConfig(config_map);
+    if (!status.IsOk()) {
+      actual.append(status.AsString());
     }
 
     std::string fail_expected;

--- a/src/servables/tensorflow/BUILD
+++ b/src/servables/tensorflow/BUILD
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -35,7 +35,6 @@ cc_proto_library(
     srcs = ["graphdef_bundle.proto"],
     deps = [
         "@org_tensorflow//tensorflow/core:protos_all_cc",
-        "@protobuf_archive//:cc_wkt_protos",
     ],
 )
 
@@ -44,7 +43,6 @@ cc_proto_library(
     srcs = ["savedmodel_bundle.proto"],
     deps = [
         "@org_tensorflow//tensorflow/core:protos_all_cc",
-        "@protobuf_archive//:cc_wkt_protos",
     ],
 )
 
@@ -58,8 +56,8 @@ cc_library(
         ":tf_utils",
         "//src/core:autofill_header",
         "//src/core:logging",
+        "//src/core:status",
         "@org_tensorflow//tensorflow/cc/saved_model:tag_constants",
-        "@org_tensorflow//tensorflow/c:c_api",
         "@org_tensorflow//tensorflow/core:lib",
     ],
 )
@@ -71,7 +69,7 @@ cc_library(
     deps = [
         "//src/core:model_config",
         "//src/core:model_config_proto",
-        "@org_tensorflow//tensorflow/core:lib",
+        "@org_tensorflow//tensorflow/core:protos_all_cc",
     ],
 )
 
@@ -81,8 +79,8 @@ cc_library(
     hdrs = ["loader.h"],
     deps = [
         "//src/core:logging",
+        "//src/core:status",
         "@org_tensorflow//tensorflow/c:c_api",
-        "@org_tensorflow//tensorflow/core:lib",
         "@org_tensorflow//tensorflow/cc/saved_model:tag_constants",
     ],
 )
@@ -96,9 +94,10 @@ cc_library(
         "//src/core:constants",
         "//src/core:logging",
         "//src/core:model_config_proto",
+        "//src/core:model_config_utils",
         "//src/core:provider",
         "//src/core:server_status",
-        "//src/core:model_config_utils",
+        "//src/core:status",
         "@org_tensorflow//tensorflow/c:c_api",
         "@org_tensorflow//tensorflow/core:lib",
     ],
@@ -112,6 +111,7 @@ cc_library(
         ":base_bundle",
         ":tf_utils",
         "//src/core:model_config",
+        "//src/core:status",
     ],
 )
 
@@ -127,12 +127,12 @@ cc_library(
         "//src/core:model_config",
         "//src/core:model_config_proto",
         "//src/core:model_config_utils",
+        "//src/core:status",
         "@tf_serving//tensorflow_serving/core:loader",
         "@tf_serving//tensorflow_serving/core:simple_loader",
         "@tf_serving//tensorflow_serving/core:source_adapter",
         "@tf_serving//tensorflow_serving/core:storage_path",
         "@tf_serving//tensorflow_serving/util:optional",
-        "@org_tensorflow//tensorflow/core:core_cpu",
         "@org_tensorflow//tensorflow/core:lib",
     ],
     alwayslink = 1,
@@ -147,6 +147,7 @@ cc_library(
         ":loader",
         ":tf_utils",
         "//src/core:model_config",
+        "//src/core:status",
     ],
 )
 
@@ -194,6 +195,7 @@ cc_test(
     deps = [
         ":graphdef_bundle",
         "//src/core:constants",
+        "//src/core:status",
         "//src/test:model_config_test_base",
         "//src/test:testmain",
         "@local_config_cuda//cuda:cudart",
@@ -216,6 +218,7 @@ cc_test(
     deps = [
         ":savedmodel_bundle",
         "//src/core:constants",
+        "//src/core:status",
         "//src/test:model_config_test_base",
         "//src/test:testmain",
         "@local_config_cuda//cuda:cudart",

--- a/src/servables/tensorflow/autofill.h
+++ b/src/servables/tensorflow/autofill.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -29,10 +29,8 @@
 #include "src/core/autofill.h"
 #include "src/core/model_config.pb.h"
 #include "src/servables/tensorflow/savedmodel_bundle.pb.h"
-#include "tensorflow/c/c_api.h"
 #include "tensorflow/cc/saved_model/loader.h"
 #include "tensorflow/cc/saved_model/tag_constants.h"
-#include "tensorflow/core/lib/core/errors.h"
 
 namespace nvidia { namespace inferenceserver {
 
@@ -41,12 +39,12 @@ namespace nvidia { namespace inferenceserver {
 //
 class AutoFillSavedModel : public AutoFill {
  public:
-  static tensorflow::Status Create(
+  static Status Create(
       const std::string& model_name,
       const ::google::protobuf::Any& platform_config,
       const std::string& model_path,
       std::unique_ptr<AutoFillSavedModel>* autofill);
-  tensorflow::Status Fix(ModelConfig* config) override;
+  Status Fix(ModelConfig* config) override;
 
  private:
   AutoFillSavedModel(
@@ -65,10 +63,10 @@ class AutoFillSavedModel : public AutoFill {
 //
 class AutoFillGraphDef : public AutoFill {
  public:
-  static tensorflow::Status Create(
+  static Status Create(
       const std::string& model_name, const std::string& model_path,
       std::unique_ptr<AutoFillGraphDef>* autofill);
-  tensorflow::Status Fix(ModelConfig* config) override;
+  Status Fix(ModelConfig* config) override;
 
  private:
   AutoFillGraphDef(const std::string& model_name) : AutoFill(model_name) {}

--- a/src/servables/tensorflow/base_bundle.h
+++ b/src/servables/tensorflow/base_bundle.h
@@ -28,7 +28,7 @@
 #include "src/core/backend.h"
 #include "src/core/model_config.pb.h"
 #include "src/core/scheduler.h"
-#include "tensorflow/core/lib/core/errors.h"
+#include "src/core/status.h"
 #include "tensorflow/core/public/session.h"
 
 namespace nvidia { namespace inferenceserver {
@@ -39,16 +39,15 @@ class BaseBundle : public InferenceBackend {
   BaseBundle() = default;
   BaseBundle(BaseBundle&&) = default;
 
-  tensorflow::Status Init(
-      const tensorflow::StringPiece& path, const ModelConfig& config);
+  Status Init(const std::string& path, const ModelConfig& config);
 
   // Create a context for execution for each instance of the
   // tensorflow model specified in 'paths'. The model can be either a
   // graphdef or savedmodel
-  tensorflow::Status CreateExecutionContexts(
+  Status CreateExecutionContexts(
       const tensorflow::ConfigProto& session_config,
       const std::unordered_map<std::string, std::string>& paths);
-  tensorflow::Status CreateExecutionContext(
+  Status CreateExecutionContext(
       const std::string& instance_name, const int gpu_device,
       const tensorflow::ConfigProto& session_config,
       const std::unordered_map<std::string, std::string>& paths);
@@ -57,7 +56,7 @@ class BaseBundle : public InferenceBackend {
   using IONameMap = std::unordered_map<std::string, std::string>;
 
   // Load model and create a corresponding session object.
-  virtual tensorflow::Status CreateSession(
+  virtual Status CreateSession(
       const tensorflow::SessionOptions& options, const int gpu_device,
       const std::string& model_path, tensorflow::Session** session,
       IONameMap* input_name_map, IONameMap* output_name_map) = 0;
@@ -94,7 +93,7 @@ class BaseBundle : public InferenceBackend {
     // an internal error that prevents any of the of requests from
     // completing. If an error is isolate to a single request payload
     // it will be reported in that payload.
-    tensorflow::Status Run(
+    Status Run(
         const BaseBundle* base, std::vector<Scheduler::Payload>* payloads);
 
     // Name of the model instance
@@ -124,7 +123,7 @@ class BaseBundle : public InferenceBackend {
   // execute for one or more requests.
   void Run(
       uint32_t runner_idx, std::vector<Scheduler::Payload>* payloads,
-      std::function<void(tensorflow::Status)> OnCompleteQueuedPayloads);
+      std::function<void(Status)> OnCompleteQueuedPayloads);
 
  private:
   TF_DISALLOW_COPY_AND_ASSIGN(BaseBundle);

--- a/src/servables/tensorflow/graphdef_bundle.h
+++ b/src/servables/tensorflow/graphdef_bundle.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -25,6 +25,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
+#include "src/core/status.h"
 #include "src/servables/tensorflow/base_bundle.h"
 
 namespace nvidia { namespace inferenceserver {
@@ -34,10 +35,9 @@ class GraphDefBundle : public BaseBundle {
   GraphDefBundle() = default;
   GraphDefBundle(GraphDefBundle&&) = default;
 
-  tensorflow::Status Init(
-      const tensorflow::StringPiece& path, const ModelConfig& config);
+  Status Init(const std::string& path, const ModelConfig& config);
 
-  tensorflow::Status CreateSession(
+  Status CreateSession(
       const tensorflow::SessionOptions& options, const int gpu_device,
       const std::string& model_path, tensorflow::Session** session,
       IONameMap* input_name_map, IONameMap* output_name_map) override;

--- a/src/servables/tensorflow/graphdef_bundle_source_adapter.h
+++ b/src/servables/tensorflow/graphdef_bundle_source_adapter.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -28,7 +28,6 @@
 #include "src/servables/tensorflow/graphdef_bundle.h"
 #include "src/servables/tensorflow/graphdef_bundle.pb.h"
 #include "tensorflow/core/lib/core/status.h"
-#include "tensorflow/core/platform/macros.h"
 #include "tensorflow_serving/core/loader.h"
 #include "tensorflow_serving/core/simple_loader.h"
 #include "tensorflow_serving/core/storage_path.h"

--- a/src/servables/tensorflow/graphdef_bundle_test.cc
+++ b/src/servables/tensorflow/graphdef_bundle_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -26,6 +26,7 @@
 
 #include "src/servables/tensorflow/graphdef_bundle.h"
 #include "src/core/constants.h"
+#include "src/core/status.h"
 #include "src/test/model_config_test_base.h"
 
 namespace nvidia { namespace inferenceserver { namespace test {
@@ -36,12 +37,11 @@ class GraphDefBundleTest : public ModelConfigTestBase {
 
 TEST_F(GraphDefBundleTest, ModelConfigSanity)
 {
-  BundleInitFunc init_func =
-      [](const std::string& path,
-         const ModelConfig& config) -> tensorflow::Status {
+  BundleInitFunc init_func = [](const std::string& path,
+                                const ModelConfig& config) -> Status {
     std::unique_ptr<GraphDefBundle> bundle(new GraphDefBundle());
-    tensorflow::Status status = bundle->Init(path, config);
-    if (status.ok()) {
+    Status status = bundle->Init(path, config);
+    if (status.IsOk()) {
       std::unordered_map<std::string, std::string> graphdef_paths;
 
       for (const auto& filename :

--- a/src/servables/tensorflow/loader.h
+++ b/src/servables/tensorflow/loader.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -25,6 +25,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
+#include "src/core/status.h"
 #include "tensorflow/cc/saved_model/loader.h"
 #include "tensorflow/cc/saved_model/tag_constants.h"
 
@@ -39,7 +40,7 @@ namespace nvidia { namespace inferenceserver {
 /// \param bundle Returns the SavedModelBundle
 /// \param sig If non-nullptr returns the signature of the model
 /// \return Error status.
-tensorflow::Status LoadSavedModel(
+Status LoadSavedModel(
     const std::string& model_name, const std::string& model_path,
     const tensorflow::SessionOptions& session_options,
     std::unique_ptr<tensorflow::SavedModelBundle>* bundle,

--- a/src/servables/tensorflow/savedmodel_bundle.h
+++ b/src/servables/tensorflow/savedmodel_bundle.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -25,6 +25,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
+#include "src/core/status.h"
 #include "src/servables/tensorflow/base_bundle.h"
 #include "tensorflow/core/protobuf/meta_graph.pb.h"
 
@@ -35,16 +36,15 @@ class SavedModelBundle : public BaseBundle {
   SavedModelBundle() = default;
   SavedModelBundle(SavedModelBundle&&) = default;
 
-  tensorflow::Status Init(
-      const tensorflow::StringPiece& path, const ModelConfig& config);
+  Status Init(const std::string& path, const ModelConfig& config);
 
-  tensorflow::Status CreateSession(
+  Status CreateSession(
       const tensorflow::SessionOptions& options, const int gpu_device,
       const std::string& model_path, tensorflow::Session** session,
       IONameMap* input_name_map, IONameMap* output_name_map) override;
 
  private:
-  tensorflow::Status ValidateSequenceControl(
+  Status ValidateSequenceControl(
       const ModelSequenceBatching::Control::Kind control_kind,
       const tensorflow::SignatureDef& sig);
 

--- a/src/servables/tensorflow/savedmodel_bundle_source_adapter.h
+++ b/src/servables/tensorflow/savedmodel_bundle_source_adapter.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -28,7 +28,6 @@
 #include "src/servables/tensorflow/savedmodel_bundle.h"
 #include "src/servables/tensorflow/savedmodel_bundle.pb.h"
 #include "tensorflow/core/lib/core/status.h"
-#include "tensorflow/core/platform/macros.h"
 #include "tensorflow_serving/core/loader.h"
 #include "tensorflow_serving/core/simple_loader.h"
 #include "tensorflow_serving/core/storage_path.h"

--- a/src/servables/tensorflow/savedmodel_bundle_test.cc
+++ b/src/servables/tensorflow/savedmodel_bundle_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -26,6 +26,7 @@
 
 #include "src/servables/tensorflow/savedmodel_bundle.h"
 #include "src/core/constants.h"
+#include "src/core/status.h"
 #include "src/test/model_config_test_base.h"
 
 namespace nvidia { namespace inferenceserver { namespace test {
@@ -36,12 +37,11 @@ class SavedModelBundleTest : public ModelConfigTestBase {
 
 TEST_F(SavedModelBundleTest, ModelConfigSanity)
 {
-  BundleInitFunc init_func =
-      [](const std::string& path,
-         const ModelConfig& config) -> tensorflow::Status {
+  BundleInitFunc init_func = [](const std::string& path,
+                                const ModelConfig& config) -> Status {
     std::unique_ptr<SavedModelBundle> bundle(new SavedModelBundle());
-    tensorflow::Status status = bundle->Init(path, config);
-    if (status.ok()) {
+    Status status = bundle->Init(path, config);
+    if (status.IsOk()) {
       std::unordered_map<std::string, std::string> savedmodel_paths;
 
       for (const auto& filename : std::vector<std::string>{

--- a/src/servables/tensorflow/tf_utils.h
+++ b/src/servables/tensorflow/tf_utils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -29,7 +29,6 @@
 #include "src/core/model_config.pb.h"
 #include "tensorflow/core/framework/tensor_shape.pb.h"
 #include "tensorflow/core/framework/types.pb.h"
-#include "tensorflow/core/lib/core/errors.h"
 
 namespace nvidia { namespace inferenceserver {
 

--- a/src/servables/tensorrt/BUILD
+++ b/src/servables/tensorrt/BUILD
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -33,10 +33,6 @@ load("@protobuf_archive//:protobuf.bzl", "cc_proto_library")
 cc_proto_library(
     name = "plan_bundle_proto",
     srcs = ["plan_bundle.proto"],
-    deps = [
-        "@org_tensorflow//tensorflow/core:protos_all_cc",
-        "@protobuf_archive//:cc_wkt_protos",
-    ],
 )
 
 cc_library(
@@ -47,6 +43,7 @@ cc_library(
         ":loader",
         ":plan_utils",
         "//src/core:autofill_header",
+        "//src/core:status",
         "@org_tensorflow//tensorflow/core:lib",
     ],
 )
@@ -57,7 +54,7 @@ cc_library(
     hdrs = ["loader.h"],
     deps = [
         ":logging",
-        "@org_tensorflow//tensorflow/core:lib",
+        "//src/core:status",
     ],
 )
 
@@ -90,11 +87,10 @@ cc_library(
         "//src/core:constants",
         "//src/core:model_config_cuda",
         "//src/core:model_config_proto",
+        "//src/core:model_config_utils",
         "//src/core:provider",
         "//src/core:server_status",
-        "//src/core:model_config_utils",
-        "@org_tensorflow//tensorflow/c:c_api",
-        "@org_tensorflow//tensorflow/core:lib",
+        "//src/core:status",
     ],
 )
 
@@ -115,8 +111,6 @@ cc_library(
         "@tf_serving//tensorflow_serving/core:source_adapter",
         "@tf_serving//tensorflow_serving/core:storage_path",
         "@tf_serving//tensorflow_serving/util:optional",
-        "@org_tensorflow//tensorflow/core:core_cpu",
-        "@org_tensorflow//tensorflow/core:lib",
     ],
     alwayslink = 1,
 )
@@ -142,6 +136,7 @@ cc_test(
     deps = [
         ":plan_bundle",
         "//src/core:constants",
+        "//src/core:status",
         "//src/test:model_config_test_base",
         "//src/test:testmain",
         "@local_config_cuda//cuda:cudart",

--- a/src/servables/tensorrt/autofill.h
+++ b/src/servables/tensorrt/autofill.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -28,16 +28,16 @@
 #include <string>
 #include "src/core/autofill.h"
 #include "src/core/model_config.pb.h"
-#include "tensorflow/core/lib/core/errors.h"
+#include "src/core/status.h"
 
 namespace nvidia { namespace inferenceserver {
 
 class AutoFillPlan : public AutoFill {
  public:
-  static tensorflow::Status Create(
+  static Status Create(
       const std::string& model_name, const std::string& model_path,
       std::unique_ptr<AutoFillPlan>* autofill);
-  tensorflow::Status Fix(ModelConfig* config) override;
+  Status Fix(ModelConfig* config) override;
 
  private:
   AutoFillPlan(

--- a/src/servables/tensorrt/loader.cc
+++ b/src/servables/tensorrt/loader.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -31,7 +31,7 @@
 
 namespace nvidia { namespace inferenceserver {
 
-tensorflow::Status
+Status
 LoadPlan(
     const std::vector<char>& model_data, nvinfer1::IRuntime** runtime,
     nvinfer1::ICudaEngine** engine)
@@ -46,16 +46,18 @@ LoadPlan(
 
   *runtime = nvinfer1::createInferRuntime(tensorrt_logger);
   if (*runtime == nullptr) {
-    return tensorflow::errors::Internal("unable to create TensorRT runtime");
+    return Status(
+        RequestStatusCode::INTERNAL, "unable to create TensorRT runtime");
   }
 
   *engine = (*runtime)->deserializeCudaEngine(
       &model_data[0], model_data.size(), onnx_plugin_factory);
   if (*engine == nullptr) {
-    return tensorflow::errors::Internal("unable to create TensorRT engine");
+    return Status(
+        RequestStatusCode::INTERNAL, "unable to create TensorRT engine");
   }
 
-  return tensorflow::Status::OK();
+  return Status::Success;
 }
 
 }}  // namespace nvidia::inferenceserver

--- a/src/servables/tensorrt/loader.h
+++ b/src/servables/tensorrt/loader.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 #pragma once
 
 #include <NvInfer.h>
-#include "tensorflow/core/lib/core/errors.h"
+#include "src/core/status.h"
 
 namespace nvidia { namespace inferenceserver {
 
@@ -41,7 +41,7 @@ namespace nvidia { namespace inferenceserver {
 /// \param engine Returns the ICudaEngine object, or nullptr if failed
 /// to create
 /// \return Error status.
-tensorflow::Status LoadPlan(
+Status LoadPlan(
     const std::vector<char>& model_data, nvinfer1::IRuntime** runtime,
     nvinfer1::ICudaEngine** engine);
 

--- a/src/servables/tensorrt/plan_bundle.h
+++ b/src/servables/tensorrt/plan_bundle.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -30,7 +30,7 @@
 #include "src/core/backend.h"
 #include "src/core/model_config.pb.h"
 #include "src/core/scheduler.h"
-#include "tensorflow/core/lib/core/errors.h"
+#include "src/core/status.h"
 
 namespace nvidia { namespace inferenceserver {
 
@@ -39,14 +39,13 @@ class PlanBundle : public InferenceBackend {
   PlanBundle() = default;
   PlanBundle(PlanBundle&&) = default;
 
-  tensorflow::Status Init(
-      const tensorflow::StringPiece& path, const ModelConfig& config);
+  Status Init(const std::string& path, const ModelConfig& config);
 
   // Create a context for execution for each instance for the
   // serialized plans specified in 'models'.
-  tensorflow::Status CreateExecutionContexts(
+  Status CreateExecutionContexts(
       const std::unordered_map<std::string, std::vector<char>>& models);
-  tensorflow::Status CreateExecutionContext(
+  Status CreateExecutionContext(
       const std::string& instance_name, const int gpu_device,
       const std::unordered_map<std::string, std::vector<char>>& models);
 
@@ -55,7 +54,7 @@ class PlanBundle : public InferenceBackend {
   // execute for one or more requests.
   void Run(
       uint32_t runner_idx, std::vector<Scheduler::Payload>* payloads,
-      std::function<void(tensorflow::Status)> OnCompleteQueuedPayloads);
+      std::function<void(Status)> OnCompleteQueuedPayloads);
 
  private:
   TF_DISALLOW_COPY_AND_ASSIGN(PlanBundle);
@@ -79,14 +78,13 @@ class PlanBundle : public InferenceBackend {
 
     TF_DISALLOW_COPY_AND_ASSIGN(Context);
 
-    tensorflow::Status InitializeInputBinding(
+    Status InitializeInputBinding(
         const std::string& input_name, const DataType input_datatype,
         const DimsList& input_dims);
-    tensorflow::Status InitializeSequenceControlInputBindings(
-        const ModelConfig& config);
-    tensorflow::Status InitializeConfigInputBindings(
+    Status InitializeSequenceControlInputBindings(const ModelConfig& config);
+    Status InitializeConfigInputBindings(
         const ::google::protobuf::RepeatedPtrField<ModelInput>& ios);
-    tensorflow::Status InitializeConfigOutputBindings(
+    Status InitializeConfigOutputBindings(
         const ::google::protobuf::RepeatedPtrField<ModelOutput>& ios);
 
     // Run model to execute for one or more requests. This function
@@ -95,7 +93,7 @@ class PlanBundle : public InferenceBackend {
     // an internal error that prevents any of the of requests from
     // completing. If an error is isolate to a single request payload
     // it will be reported in that payload.
-    tensorflow::Status Run(std::vector<Scheduler::Payload>* payloads);
+    Status Run(std::vector<Scheduler::Payload>* payloads);
 
     // Name of the model instance
     const std::string name_;

--- a/src/servables/tensorrt/plan_bundle_source_adapter.cc
+++ b/src/servables/tensorrt/plan_bundle_source_adapter.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -51,8 +51,11 @@ CreatePlanBundle(
   const auto model_name = tensorflow::io::Basename(model_path);
 
   ModelConfig model_config;
-  TF_RETURN_IF_ERROR(ModelRepositoryManager::GetModelConfig(
-      std::string(model_name), &model_config));
+  Status status = ModelRepositoryManager::GetModelConfig(
+      std::string(model_name), &model_config);
+  if (!status.IsOk()) {
+    return tensorflow::errors::Internal(status.Message());
+  }
 
   // Read all the plan files in 'path'. GetChildren() returns all
   // descendants instead for cloud storage like GCS, so filter out all
@@ -78,15 +81,16 @@ CreatePlanBundle(
   // Create the bundle for the model and all the execution contexts
   // requested for this model.
   bundle->reset(new PlanBundle);
-  tensorflow::Status status = (*bundle)->Init(path, model_config);
-  if (status.ok()) {
+  status = (*bundle)->Init(path, model_config);
+  if (status.IsOk()) {
     status = (*bundle)->CreateExecutionContexts(models);
   }
-  if (!status.ok()) {
+  if (!status.IsOk()) {
     bundle->reset();
+    return tensorflow::errors::Internal(status.Message());
   }
 
-  return status;
+  return tensorflow::Status::OK();
 }
 
 }  // namespace

--- a/src/servables/tensorrt/plan_bundle_source_adapter.h
+++ b/src/servables/tensorrt/plan_bundle_source_adapter.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -28,7 +28,6 @@
 #include "src/servables/tensorrt/plan_bundle.h"
 #include "src/servables/tensorrt/plan_bundle.pb.h"
 #include "tensorflow/core/lib/core/status.h"
-#include "tensorflow/core/platform/macros.h"
 #include "tensorflow_serving/core/loader.h"
 #include "tensorflow_serving/core/simple_loader.h"
 #include "tensorflow_serving/core/source_adapter.h"

--- a/src/servables/tensorrt/plan_bundle_test.cc
+++ b/src/servables/tensorrt/plan_bundle_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -26,6 +26,7 @@
 
 #include "src/servables/tensorrt/plan_bundle.h"
 #include "src/core/constants.h"
+#include "src/core/status.h"
 #include "src/test/model_config_test_base.h"
 
 namespace nvidia { namespace inferenceserver { namespace test {
@@ -36,12 +37,11 @@ class PlanBundleTest : public ModelConfigTestBase {
 
 TEST_F(PlanBundleTest, ModelConfigSanity)
 {
-  BundleInitFunc init_func =
-      [](const std::string& path,
-         const ModelConfig& config) -> tensorflow::Status {
+  BundleInitFunc init_func = [](const std::string& path,
+                                const ModelConfig& config) -> Status {
     std::unique_ptr<PlanBundle> bundle(new PlanBundle());
-    tensorflow::Status status = bundle->Init(path, config);
-    if (status.ok()) {
+    Status status = bundle->Init(path, config);
+    if (status.IsOk()) {
       std::unordered_map<std::string, std::vector<char>> plan_blobs;
 
       for (const auto& filename :

--- a/src/test/BUILD
+++ b/src/test/BUILD
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -47,6 +47,7 @@ cc_library(
         "//src/core:logging",
         "//src/core:model_config_proto",
         "//src/core:model_config_utils",
+        "//src/core:status",
         "@com_google_googletest//:gtest",
         "@org_tensorflow//tensorflow/core:testlib",
         "@tf_serving//tensorflow_serving/config:platform_config_proto",

--- a/src/test/model_config_test_base.cc
+++ b/src/test/model_config_test_base.cc
@@ -48,16 +48,16 @@ ModelConfigTestBase::ValidateInit(
 
   ModelConfig config;
   tfs::PlatformConfigMap platform_map;
-  tensorflow::Status status =
+  Status status =
       GetNormalizedModelConfig(model_path, platform_map, autofill, &config);
-  if (!status.ok()) {
-    result->append(status.ToString());
+  if (!status.IsOk()) {
+    result->append(status.AsString());
     return false;
   }
 
   status = ValidateModelConfig(config, std::string());
-  if (!status.ok()) {
-    result->append(status.ToString());
+  if (!status.IsOk()) {
+    result->append(status.AsString());
     return false;
   }
 
@@ -65,8 +65,8 @@ ModelConfigTestBase::ValidateInit(
   const std::string version_path = tensorflow::io::JoinPath(model_path, "1");
 
   status = init_func(version_path, config);
-  if (!status.ok()) {
-    result->append(status.ToString());
+  if (!status.IsOk()) {
+    result->append(status.AsString());
     return false;
   }
 

--- a/src/test/model_config_test_base.h
+++ b/src/test/model_config_test_base.h
@@ -28,6 +28,7 @@
 
 #include <gtest/gtest.h>
 #include "src/core/model_config.pb.h"
+#include "src/core/status.h"
 #include "tensorflow/core/lib/io/path.h"
 #include "tensorflow/core/platform/env.h"
 
@@ -36,7 +37,7 @@ namespace nvidia { namespace inferenceserver { namespace test {
 class ModelConfigTestBase : public ::testing::Test {
  public:
   using BundleInitFunc =
-      std::function<tensorflow::Status(const std::string&, const ModelConfig&)>;
+      std::function<Status(const std::string&, const ModelConfig&)>;
 
   bool ValidateInit(
       const std::string& path, bool autofill, BundleInitFunc init_func,


### PR DESCRIPTION
A large but shallow change to replace tensorflow::Status with nvidia::inferenceserver::Status except where we are actually interacting with the TF or TFS API.