### PR TITLE
Fix GetNextInputContent() in request provider ...

### DIFF
--- a/src/core/provider.cc
+++ b/src/core/provider.cc
@@ -212,10 +212,7 @@ InferRequestProvider::GetNextInputContent(
              input_content.second + 1, content_byte_size) == nullptr);
     if (!force_contiguous || isLastChunk) {
       *content = input_content.first->BufferAt(
-          input_content.second, content_byte_size);
-      if (*content_byte_size != 0) {
-        input_content.second++;
-      }
+          input_content.second++, content_byte_size);
     } else {
       size_t total_size = 0;
       size_t start_idx = input_content.second;

--- a/src/core/provider.h
+++ b/src/core/provider.h
@@ -44,8 +44,7 @@ class SystemMemory {
   // maintaining internal state such that one buffer can be shared
   // across multiple providers.
   // 'idx' zero base index. Valid indices are continuous.
-  // 'byte_size' returns the byte size of the chunk of bytes. Returns 0 if
-  // 'idx' is out of range.
+  // 'byte_size' returns the byte size of the chunk of bytes.
   // Return the pointer to the data block. Returns nullptr if 'idx' is
   // out of range
   virtual const char* BufferAt(size_t idx, size_t* byte_size) const = 0;


### PR DESCRIPTION
Buffer index should always be incremented regardless of the buffer size read.