### PR TITLE
Add --allow-gpu-metrics to control when GPU metrics are reported

### DIFF
--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -205,7 +205,6 @@ cc_library(
         "@com_github_libevent_libevent//:libevent",
         "@com_google_absl//absl/strings",
         "@prometheus//core:core",
-        "@prometheus//pull:pull",
     ],
 )
 
@@ -266,7 +265,6 @@ cc_library(
         "@org_tensorflow//tensorflow/contrib/tensorrt:trt_shape_function",
         "@org_tensorflow//tensorflow/core:lib",
         "@prometheus//core:core",
-        "@prometheus//pull:pull",
         "@tf_serving//tensorflow_serving/config:model_server_config_proto",
         "@tf_serving//tensorflow_serving/core:servable_state_monitor",
         "@tf_serving//tensorflow_serving/core:availability_preserving_policy",

--- a/src/core/metrics.h
+++ b/src/core/metrics.h
@@ -28,15 +28,17 @@
 
 #include <atomic>
 #include <thread>
-#include "prometheus/exposer.h"
 #include "prometheus/registry.h"
 
 namespace nvidia { namespace inferenceserver {
 
 class Metrics {
  public:
-  // Initialize metrics reporting on 'port'.
-  static void Initialize(uint32_t port);
+  // Enable reporting of GPU metrics
+  static void EnableGPUMetrics();
+
+  // Get the prometheus registry
+  static std::shared_ptr<prometheus::Registry> GetRegistry();
 
   // Get the UUID for a CUDA device. Return true and initialize 'uuid'
   // if a UUID is found, return false if a UUID cannot be returned.
@@ -102,11 +104,8 @@ class Metrics {
   Metrics();
   virtual ~Metrics();
   static Metrics* GetSingleton();
-  static std::shared_ptr<prometheus::Registry> GetRegistry();
   bool InitializeNvmlMetrics();
 
-  bool initialized_;
-  std::unique_ptr<prometheus::Exposer> exposer_;
   std::shared_ptr<prometheus::Registry> registry_;
 
   prometheus::Family<prometheus::Counter>& inf_success_family_;
@@ -131,6 +130,7 @@ class Metrics {
   std::vector<prometheus::Gauge*> gpu_power_limit_;
   std::vector<prometheus::Counter*> gpu_energy_consumption_;
 
+  bool gpu_metrics_enabled_;
   std::unique_ptr<std::thread> nvml_thread_;
   std::atomic<bool> nvml_thread_exit_;
 };

--- a/src/core/request_inprocess.cc
+++ b/src/core/request_inprocess.cc
@@ -434,7 +434,8 @@ InferInProcessContextImpl::InferRequestToInputMap(
 
 Error
 InferInProcessContextImpl::AsyncInfer(
-    std::shared_ptr<InferInProcessRequestImpl> request, std::function<void()> OnCompleteInfer)
+    std::shared_ptr<InferInProcessRequestImpl> request,
+    std::function<void()> OnCompleteInfer)
 {
   auto infer_stats =
       std::make_shared<ModelInferStats>(server_->StatusManager(), model_name_);


### PR DESCRIPTION
Also move prometheus HTTP reporting out of libtrtserver and into main
executable.