### PR TITLE
Add port options for Status, Health, profile, and Infer APIs

### DIFF
--- a/src/servers/grpc_server.cc
+++ b/src/servers/grpc_server.cc
@@ -26,6 +26,7 @@
 
 #include "src/servers/grpc_server.h"
 
+#include <map>
 #include "grpc++/security/server_credentials.h"
 #include "grpc++/server.h"
 #include "grpc++/server_builder.h"
@@ -252,98 +253,65 @@ GRPCServer::~GRPCServer()
 
 Status
 GRPCServer::Create(
-    InferenceServer* server, uint16_t port, int infer_thread_cnt,
-    int stream_infer_thread_cnt, std::unique_ptr<GRPCServer>* grpc_server)
+    InferenceServer* server,
+    const std::map<int32_t, std::vector<std::string>>& port_map,
+    int infer_thread_cnt, int stream_infer_thread_cnt,
+    std::vector<std::unique_ptr<GRPCServer>>* grpc_servers)
 {
-  // DLIS-162 - provide global defaults and cli overridable options
+  if (port_map.empty()) {
+    return Status(
+        RequestStatusCode::INVALID_ARG,
+        "GRPC is enabled but none of the service endpoints have a valid port "
+        "assignment");
+  }
   g_Resources = std::make_shared<AsyncResources>(
-      server,  // InferenceServer*,
-      1,       // infer threads
-      1        // mgmt threads
-  );
+      server, 1 /* infer threads */, 1 /* mgmt threads */);
+  grpc_servers->clear();
 
-  LOG_INFO << "Building nvrpc server";
-  const std::string addr = "0.0.0.0:" + std::to_string(port);
-  grpc_server->reset(
-      new GRPCServer(addr, infer_thread_cnt, stream_infer_thread_cnt));
+  for (auto const& ep_map : port_map) {
+    std::string addr = "0.0.0.0:" + std::to_string(ep_map.first);
+    LOG_INFO << "Starting a GRPCService at " << addr;
 
-  (*grpc_server)->GetBuilder().SetMaxMessageSize(MAX_GRPC_MESSAGE_SIZE);
+    grpc_servers->emplace_back(
+        new GRPCServer(addr, infer_thread_cnt, stream_infer_thread_cnt));
+    auto& grpc_server = grpc_servers->back();
 
-  LOG_INFO << "Register TensorRT GRPCService";
-  auto inferenceService = (*grpc_server)->RegisterAsyncService<GRPCService>();
+    grpc_server->GetBuilder().SetMaxMessageSize(MAX_GRPC_MESSAGE_SIZE);
 
-  LOG_INFO << "Register Infer RPC";
-  (*grpc_server)->rpcInfer_ = inferenceService->RegisterRPC<InferContext>(
-      &GRPCService::AsyncService::RequestInfer);
+    LOG_INFO << "Register TensorRT GRPCService";
+    auto inferenceService = grpc_server->RegisterAsyncService<GRPCService>();
 
-  LOG_INFO << "Register StreamInfer RPC";
-  (*grpc_server)->rpcStreamInfer_ =
-      inferenceService->RegisterRPC<StreamInferContext>(
-          &GRPCService::AsyncService::RequestStreamInfer);
+    for (auto ep_name : ep_map.second) {
+      if (ep_name == "infer") {
+        LOG_INFO << "Register Infer RPC";
+        grpc_server->rpcInfer_ = inferenceService->RegisterRPC<InferContext>(
+            &GRPCService::AsyncService::RequestInfer);
 
-  LOG_INFO << "Register Status RPC";
-  (*grpc_server)->rpcStatus_ = inferenceService->RegisterRPC<StatusContext>(
-      &GRPCService::AsyncService::RequestStatus);
+        LOG_INFO << "Register StreamInfer RPC";
+        grpc_server->rpcStreamInfer_ =
+            inferenceService->RegisterRPC<StreamInferContext>(
+                &GRPCService::AsyncService::RequestStreamInfer);
+      }
 
-  LOG_INFO << "Register Profile RPC";
-  (*grpc_server)->rpcProfile_ = inferenceService->RegisterRPC<ProfileContext>(
-      &GRPCService::AsyncService::RequestProfile);
+      if (ep_name == "status") {
+        LOG_INFO << "Register Status RPC";
+        grpc_server->rpcStatus_ = inferenceService->RegisterRPC<StatusContext>(
+            &GRPCService::AsyncService::RequestStatus);
+      }
 
-  LOG_INFO << "Register Health RPC";
-  (*grpc_server)->rpcHealth_ = inferenceService->RegisterRPC<HealthContext>(
-      &GRPCService::AsyncService::RequestHealth);
+      if (ep_name == "profile") {
+        LOG_INFO << "Register Profile RPC";
+        grpc_server->rpcProfile_ =
+            inferenceService->RegisterRPC<ProfileContext>(
+                &GRPCService::AsyncService::RequestProfile);
+      }
 
-  return Status::Success;
-}
-
-Status
-GRPCServer::CreateUniqueEndpointPorts(
-    InferenceServer* server, std::string endpoint_name, uint16_t port,
-    std::unique_ptr<GRPCServer>* grpc_server)
-{
-  // DLIS-162 - provide global defaults and cli overridable options
-  g_Resources = std::make_shared<AsyncResources>(
-      server,  // InferenceServer*,
-      1,       // infer threads
-      1        // mgmt threads
-  );
-
-  LOG_INFO << "Building nvrpc server";
-  const std::string addr = "0.0.0.0:" + std::to_string(port);
-  grpc_server->reset(new GRPCServer(addr));
-
-  (*grpc_server)->GetBuilder().SetMaxMessageSize(MAX_GRPC_MESSAGE_SIZE);
-
-  LOG_INFO << "Register TensorRT GRPCService";
-  auto inferenceService = (*grpc_server)->RegisterAsyncService<GRPCService>();
-
-  if (endpoint_name == "infer"){
-    LOG_INFO << "Register Infer RPC";
-    (*grpc_server)->rpcInfer_ = inferenceService->RegisterRPC<InferContext>(
-        &GRPCService::AsyncService::RequestInfer);
-
-    LOG_INFO << "Register StreamInfer RPC";
-    (*grpc_server)->rpcStreamInfer_ =
-        inferenceService->RegisterRPC<StreamInferContext>(
-            &GRPCService::AsyncService::RequestStreamInfer);
-  }
-
-  if (endpoint_name == "status"){
-    LOG_INFO << "Register Status RPC";
-    (*grpc_server)->rpcStatus_ = inferenceService->RegisterRPC<StatusContext>(
-        &GRPCService::AsyncService::RequestStatus);
-  }
-
-  if (endpoint_name == "profile"){
-    LOG_INFO << "Register Profile RPC";
-    (*grpc_server)->rpcProfile_ = inferenceService->RegisterRPC<ProfileContext>(
-        &GRPCService::AsyncService::RequestProfile);
-  }
-
-  if (endpoint_name == "health"){
-    LOG_INFO << "Register Health RPC";
-    (*grpc_server)->rpcHealth_ = inferenceService->RegisterRPC<HealthContext>(
-        &GRPCService::AsyncService::RequestHealth);
+      if (ep_name == "health") {
+        LOG_INFO << "Register Health RPC";
+        grpc_server->rpcHealth_ = inferenceService->RegisterRPC<HealthContext>(
+            &GRPCService::AsyncService::RequestHealth);
+      }
+    }
   }
 
   return Status::Success;

--- a/src/servers/grpc_server.h
+++ b/src/servers/grpc_server.h
@@ -38,8 +38,11 @@ class ServerStatus;
 class GRPCServer : private nvrpc::Server {
  public:
   static Status Create(
-      InferenceServer* server, uint16_t port, int infer_thread_cnt,
-      int stream_infer_thread_cnt, std::unique_ptr<GRPCServer>* grpc_server);
+      InferenceServer* server,
+      const std::map<int32_t, std::vector<std::string>>& port_map,
+      int infer_thread_cnt, int stream_infer_thread_cnt,
+      std::vector<std::unique_ptr<GRPCServer>>* grpc_servers);
+
   Status Start();
   Status Stop();
 

--- a/src/servers/http_server.h
+++ b/src/servers/http_server.h
@@ -36,6 +36,11 @@ class HTTPServer {
   static Status Create(
       InferenceServer* server, uint16_t port, int thread_cnt,
       std::unique_ptr<HTTPServer>* http_server);
+
+ public:
+  static Status CreateUniqueEndpointPorts(
+      InferenceServer* server, std::string endpoint_name, uint16_t port,
+      int thread_cnt, std::unique_ptr<HTTPServer>* http_server);
   virtual Status Start() = 0;
   virtual Status Stop() = 0;
 };

--- a/src/servers/http_server.h
+++ b/src/servers/http_server.h
@@ -34,13 +34,10 @@ class InferenceServer;
 class HTTPServer {
  public:
   static Status Create(
-      InferenceServer* server, uint16_t port, int thread_cnt,
-      std::unique_ptr<HTTPServer>* http_server);
+      InferenceServer* server,
+      const std::map<int32_t, std::vector<std::string>>& port_map,
+      int thread_cnt, std::vector<std::unique_ptr<HTTPServer>>* http_servers);
 
- public:
-  static Status CreateUniqueEndpointPorts(
-      InferenceServer* server, std::string endpoint_name, uint16_t port,
-      int thread_cnt, std::unique_ptr<HTTPServer>* http_server);
   virtual Status Start() = 0;
   virtual Status Stop() = 0;
 };

--- a/src/servers/main.cc
+++ b/src/servers/main.cc
@@ -297,13 +297,13 @@ StartHttpService(nvidia::inferenceserver::InferenceServer* server)
 }
 
 std::unique_ptr<nvidia::inferenceserver::GRPCServer>
-StartMultipleHttpService(nvidia::inferenceserver::InferenceServer* server, std::string endpoint_name)
+StartMultipleHttpService(nvidia::inferenceserver::InferenceServer* server, std::string endpoint_name, int32_t endpoint_port)
 {
   std::unique_ptr<nvidia::inferenceserver::GRPCServer> service;
   // TODO: Write CreateUniqueEndpointPorts in grpc_server.cc
   nvidia::inferenceserver::Status status =
       nvidia::inferenceserver::GRPCServer::CreateUniqueEndpointPorts(
-          server, grpc_endpoint_port, grpc_thread_cnt_, &service);
+          server, endpoint_name, endpoint_port, grpc_thread_cnt_, &service);
   if (status.IsOk()) {
     status = service->Start();
   }
@@ -316,13 +316,13 @@ StartMultipleHttpService(nvidia::inferenceserver::InferenceServer* server, std::
 }
 
 std::unique_ptr<nvidia::inferenceserver::HTTPServer>
-StartMultipleGrpcService(nvidia::inferenceserver::InferenceServer* server, std::string endpoint_name)
+StartMultipleGrpcService(nvidia::inferenceserver::InferenceServer* server, std::string endpoint_name, int32_t endpoint_port)
 {
   std::unique_ptr<nvidia::inferenceserver::HTTPServer> service;
   // TODO: Write CreateUniqueEndpointPorts in http_server.cc
   nvidia::inferenceserver::Status status =
       nvidia::inferenceserver::HTTPServer::CreateUniqueEndpointPorts(
-          server, http_endpoint_port, http_thread_cnt_, &service);
+          server, endpoint_name, endpoint_port, http_thread_cnt_, &service);
   if (status.IsOk()) {
     status = service->Start();
   }
@@ -362,7 +362,7 @@ StartEndpoints(nvidia::inferenceserver::InferenceServer* server)
                  << " for gRPC "<<endpoint_names[i]<<" requests";
 
         // Fix for grpc api ports
-        grpc_endpoint_services_[i] = StartMultipleGrpcService(server, endpoint_names[i]);
+        grpc_endpoint_services_[i] = StartMultipleGrpcService(server, endpoint_names[i], endpoint_ports[i]);
         if (grpc_endpoint_services_[i] == nullptr) {
           LOG_ERROR << "Failed to start gRPC "<<endpoint_names[i]<<" service";
           return false;
@@ -395,7 +395,7 @@ StartEndpoints(nvidia::inferenceserver::InferenceServer* server)
                  << " for HTTP "<<endpoint_names[i]<<" requests";
 
         // Fix for http api ports
-        http_endpoint_services_[i] = StartMultipleHttpService(server, endpoint_names[i]);
+        http_endpoint_services_[i] = StartMultipleHttpService(server, endpoint_names[i], endpoint_ports[i]);
         if (http_endpoint_services_[i] == nullptr) {
           LOG_ERROR << "Failed to start HTTP "<<endpoint_names[i]<<" service";
           return false;


### PR DESCRIPTION
Adding port options for API endpoints to be able to serve status, health, profile and infer at different (unique) ports. 
E.g.: --http-status-port, --grpc--status-port ... (status, health, profile, infer)
PS: retained naming convention for HTTP requests for consistency. 