### PR TITLE
 Encapsulate TFS components in ModelRepositoryManager

### DIFF
--- a/src/core/model_repository_manager.cc
+++ b/src/core/model_repository_manager.cc
@@ -594,15 +594,15 @@ ModelRepositoryManager::GetBackendHandle(
   Platform platform;
   Status status = GetModelPlatform(model_name, &platform);
   if (status.IsOk()) {
-    handle->reset(
-        new BackendHandleImpl(platform, model_spec, singleton->core_.get()));
-
+    handle->reset(new BackendHandleImpl(platform, model_spec, core_.get()));
     if ((*handle)->GetInferenceBackend() == nullptr) {
       handle->reset();
-      status = Status(
-          RequestStatusCode::UNAVAILABLE,
-          "Inference request for unknown model '" + model_name + "'");
     }
+  }
+  if (*handle == nullptr) {
+    status = Status(
+        RequestStatusCode::UNAVAILABLE,
+        "Inference request for unknown model '" + model_name + "'");
   }
 
   return status;

--- a/src/core/model_repository_manager.cc
+++ b/src/core/model_repository_manager.cc
@@ -27,13 +27,31 @@
 
 #include "src/core/model_repository_manager.h"
 
+#include "src/core/backend.h"
 #include "src/core/constants.h"
 #include "src/core/logging.h"
 #include "src/core/model_config_utils.h"
+#include "src/core/server_status.h"
+#include "src/servables/caffe2/netdef_bundle.h"
+#include "src/servables/caffe2/netdef_bundle.pb.h"
+#include "src/servables/custom/custom_bundle.h"
+#include "src/servables/custom/custom_bundle.pb.h"
+#include "src/servables/ensemble/ensemble_bundle.h"
+#include "src/servables/ensemble/ensemble_bundle.pb.h"
+#include "src/servables/tensorflow/graphdef_bundle.h"
+#include "src/servables/tensorflow/graphdef_bundle.pb.h"
+#include "src/servables/tensorflow/savedmodel_bundle.h"
+#include "src/servables/tensorflow/savedmodel_bundle.pb.h"
+#include "src/servables/tensorrt/plan_bundle.h"
+#include "src/servables/tensorrt/plan_bundle.pb.h"
 #include "tensorflow/core/lib/io/path.h"
 #include "tensorflow/core/platform/env.h"
 #include "tensorflow/core/platform/file_statistics.h"
 #include "tensorflow_serving/config/model_server_config.pb.h"
+#include "tensorflow_serving/config/platform_config.pb.h"
+#include "tensorflow_serving/core/availability_preserving_policy.h"
+#include "tensorflow_serving/core/servable_handle.h"
+#include "tensorflow_serving/model_servers/server_core.h"
 
 namespace nvidia { namespace inferenceserver {
 
@@ -45,6 +63,138 @@ struct ModelRepositoryManager::ModelInfo {
 };
 
 namespace {
+
+void
+BuildPlatformConfigMap(
+    const std::string& version, const std::string& model_store_path,
+    const bool strict_model_config, const float tf_gpu_memory_fraction,
+    const bool tf_allow_soft_placement, PlatformConfigMap* platform_configs,
+    tfs::PlatformConfigMap* tfs_platform_configs)
+{
+  ::google::protobuf::Any graphdef_source_adapter_config;
+  ::google::protobuf::Any saved_model_source_adapter_config;
+  ::google::protobuf::Any plan_source_adapter_config;
+  ::google::protobuf::Any netdef_source_adapter_config;
+  ::google::protobuf::Any custom_source_adapter_config;
+  ::google::protobuf::Any ensemble_source_adapter_config;
+
+  //// Tensorflow GraphDef
+  {
+    GraphDefBundleSourceAdapterConfig graphdef_config;
+
+    graphdef_config.set_autofill(!strict_model_config);
+
+    // Tensorflow session config
+    if (tf_gpu_memory_fraction == 0.0) {
+      graphdef_config.mutable_session_config()
+          ->mutable_gpu_options()
+          ->set_allow_growth(true);
+    } else {
+      graphdef_config.mutable_session_config()
+          ->mutable_gpu_options()
+          ->set_per_process_gpu_memory_fraction(tf_gpu_memory_fraction);
+    }
+
+    graphdef_config.mutable_session_config()->set_allow_soft_placement(
+        tf_allow_soft_placement);
+    graphdef_source_adapter_config.PackFrom(graphdef_config);
+  }
+
+  //// Tensorflow SavedModel
+  {
+    SavedModelBundleSourceAdapterConfig saved_model_config;
+
+    saved_model_config.set_autofill(!strict_model_config);
+
+    if (tf_gpu_memory_fraction == 0.0) {
+      saved_model_config.mutable_session_config()
+          ->mutable_gpu_options()
+          ->set_allow_growth(true);
+    } else {
+      saved_model_config.mutable_session_config()
+          ->mutable_gpu_options()
+          ->set_per_process_gpu_memory_fraction(tf_gpu_memory_fraction);
+    }
+
+    saved_model_config.mutable_session_config()->set_allow_soft_placement(
+        tf_allow_soft_placement);
+    saved_model_source_adapter_config.PackFrom(saved_model_config);
+  }
+
+  //// Caffe NetDef
+  {
+    NetDefBundleSourceAdapterConfig netdef_config;
+    netdef_config.set_autofill(!strict_model_config);
+    netdef_source_adapter_config.PackFrom(netdef_config);
+  }
+
+  //// TensorRT
+  {
+    PlanBundleSourceAdapterConfig plan_config;
+    plan_config.set_autofill(!strict_model_config);
+    plan_source_adapter_config.PackFrom(plan_config);
+  }
+
+  //// Custom
+  {
+    CustomBundleSourceAdapterConfig custom_config;
+    custom_config.set_inference_server_version(version);
+    custom_config.set_model_repository_path(model_store_path);
+    custom_source_adapter_config.PackFrom(custom_config);
+  }
+
+  //// Ensemble
+  {
+    EnsembleBundleSourceAdapterConfig ensemble_config;
+    ensemble_source_adapter_config.PackFrom(ensemble_config);
+  }
+
+  (*platform_configs)[kTensorFlowGraphDefPlatform] =
+      graphdef_source_adapter_config;
+  (*platform_configs)[kTensorFlowSavedModelPlatform] =
+      saved_model_source_adapter_config;
+  (*platform_configs)[kCaffe2NetDefPlatform] = netdef_source_adapter_config;
+  (*platform_configs)[kTensorRTPlanPlatform] = plan_source_adapter_config;
+  (*platform_configs)[kCustomPlatform] = custom_source_adapter_config;
+  (*platform_configs)[kEnsemblePlatform] = ensemble_source_adapter_config;
+
+  // Must also return the configs in format required by TFS for
+  // ServerCore.
+  (*(*tfs_platform_configs
+          ->mutable_platform_configs())[kTensorFlowGraphDefPlatform]
+        .mutable_source_adapter_config()) = graphdef_source_adapter_config;
+  (*(*tfs_platform_configs
+          ->mutable_platform_configs())[kTensorFlowSavedModelPlatform]
+        .mutable_source_adapter_config()) = saved_model_source_adapter_config;
+  (*(*tfs_platform_configs->mutable_platform_configs())[kCaffe2NetDefPlatform]
+        .mutable_source_adapter_config()) = netdef_source_adapter_config;
+  (*(*tfs_platform_configs->mutable_platform_configs())[kTensorRTPlanPlatform]
+        .mutable_source_adapter_config()) = plan_source_adapter_config;
+  (*(*tfs_platform_configs->mutable_platform_configs())[kCustomPlatform]
+        .mutable_source_adapter_config()) = custom_source_adapter_config;
+  (*(*tfs_platform_configs->mutable_platform_configs())[kEnsemblePlatform]
+        .mutable_source_adapter_config()) = ensemble_source_adapter_config;
+}
+
+ModelReadyState
+ManagerStateToModelReadyState(tfs::ServableState::ManagerState manager_state)
+{
+  switch (manager_state) {
+    case tfs::ServableState::ManagerState::kLoading:
+      return ModelReadyState::MODEL_LOADING;
+      break;
+    case tfs::ServableState::ManagerState::kUnloading:
+      return ModelReadyState::MODEL_UNLOADING;
+      break;
+    case tfs::ServableState::ManagerState::kAvailable:
+      return ModelReadyState::MODEL_READY;
+      break;
+    default:
+      return ModelReadyState::MODEL_UNAVAILABLE;
+      break;
+  }
+  return ModelReadyState::MODEL_UNKNOWN;
+}
 
 int64_t
 GetModifiedTime(const std::string& path)
@@ -111,18 +261,97 @@ IsModified(const std::string& path, int64_t* last_ns)
 
 ModelRepositoryManager* ModelRepositoryManager::singleton = nullptr;
 
-ModelRepositoryManager::ModelRepositoryManager(
-    const std::string& repository_path,
-    const PlatformConfigMap& platform_config_map, const bool autofill)
-    : repository_path_(repository_path),
-      platform_config_map_(platform_config_map), autofill_(autofill)
+class BackendHandleImpl : public ModelRepositoryManager::BackendHandle {
+ public:
+  ~BackendHandleImpl() = default;
+  BackendHandleImpl(
+      const Platform& platform, const tfs::ModelSpec& model_spec,
+      tfs::ServerCore* core);
+  InferenceBackend* GetInferenceBackend() override { return is_; }
+
+ private:
+  InferenceBackend* is_;
+  tfs::ServableHandle<GraphDefBundle> graphdef_bundle_;
+  tfs::ServableHandle<PlanBundle> plan_bundle_;
+  tfs::ServableHandle<NetDefBundle> netdef_bundle_;
+  tfs::ServableHandle<SavedModelBundle> saved_model_bundle_;
+  tfs::ServableHandle<CustomBundle> custom_bundle_;
+  tfs::ServableHandle<EnsembleBundle> ensemble_bundle_;
+};
+
+BackendHandleImpl::BackendHandleImpl(
+    const Platform& platform, const tfs::ModelSpec& model_spec,
+    tfs::ServerCore* core)
 {
+  tensorflow::Status tfstatus;
+  is_ = nullptr;
+
+  switch (platform) {
+    case Platform::PLATFORM_TENSORFLOW_GRAPHDEF:
+      tfstatus = core->GetServableHandle(model_spec, &(graphdef_bundle_));
+      if (tfstatus.ok()) {
+        is_ = static_cast<InferenceBackend*>(graphdef_bundle_.get());
+      }
+      break;
+    case Platform::PLATFORM_TENSORFLOW_SAVEDMODEL:
+      tfstatus = core->GetServableHandle(model_spec, &(saved_model_bundle_));
+      if (tfstatus.ok()) {
+        is_ = static_cast<InferenceBackend*>(saved_model_bundle_.get());
+      }
+      break;
+    case Platform::PLATFORM_TENSORRT_PLAN:
+      tfstatus = core->GetServableHandle(model_spec, &(plan_bundle_));
+      if (tfstatus.ok()) {
+        is_ = static_cast<InferenceBackend*>(plan_bundle_.get());
+      }
+      break;
+    case Platform::PLATFORM_CAFFE2_NETDEF:
+      tfstatus = core->GetServableHandle(model_spec, &(netdef_bundle_));
+      if (tfstatus.ok()) {
+        is_ = static_cast<InferenceBackend*>(netdef_bundle_.get());
+      }
+      break;
+    case Platform::PLATFORM_CUSTOM:
+      tfstatus = core->GetServableHandle(model_spec, &(custom_bundle_));
+      if (tfstatus.ok()) {
+        is_ = static_cast<InferenceBackend*>(custom_bundle_.get());
+      }
+      break;
+    case Platform::PLATFORM_ENSEMBLE:
+      tfstatus = core->GetServableHandle(model_spec, &(ensemble_bundle_));
+      if (tfstatus.ok()) {
+        is_ = static_cast<InferenceBackend*>(ensemble_bundle_.get());
+      }
+      break;
+    default:
+      break;
+  }
+}
+
+ModelRepositoryManager::ModelRepositoryManager(
+    const std::shared_ptr<ServerStatusManager>& status_manager,
+    const std::string& repository_path,
+    const PlatformConfigMap& platform_config_map, const bool autofill,
+    const bool polling_enabled)
+    : repository_path_(repository_path),
+      platform_config_map_(platform_config_map), autofill_(autofill),
+      polling_enabled_(polling_enabled), status_manager_(status_manager)
+{
+}
+
+ModelRepositoryManager::~ModelRepositoryManager()
+{
+  singleton = nullptr;
 }
 
 Status
 ModelRepositoryManager::Create(
-    const std::string& repository_path,
-    const PlatformConfigMap& platform_config_map, const bool autofill)
+    const std::string& server_version,
+    const std::shared_ptr<ServerStatusManager>& status_manager,
+    const std::string& repository_path, const bool strict_model_config,
+    const float tf_gpu_memory_fraction, const bool tf_allow_soft_placement,
+    const uint32_t repository_poll_secs, const bool polling_enabled,
+    std::unique_ptr<ModelRepositoryManager>* model_repository_manager)
 {
   if (singleton != nullptr) {
     return Status(
@@ -130,8 +359,80 @@ ModelRepositoryManager::Create(
         "ModelRepositoryManager singleton already created");
   }
 
-  singleton = new ModelRepositoryManager(
-      repository_path, platform_config_map, autofill);
+  // For ServerCore Options, we leave servable_state_monitor_creator unspecified
+  // so the default servable_state_monitor_creator will be used.
+  tfs::ServerCore::Options options;
+
+  // Set some default values in Options
+  options.aspired_version_policy = std::unique_ptr<tfs::AspiredVersionPolicy>(
+      new tfs::AvailabilityPreservingPolicy);
+
+  // If not polling the model repository then set the poll secs to 0
+  // in TFS so that repository is only checked a single time at
+  // startup.
+  // [TODO] Remove 'repository_poll_secs' parameter once ModelRepositoryManager
+  // is improved as model version will also be monitored and polled
+  // on PollAndUpdate()
+  options.max_num_load_retries = 0;
+  options.file_system_poll_wait_seconds = repository_poll_secs;
+
+  PlatformConfigMap platform_config_map;
+
+  BuildPlatformConfigMap(
+      server_version, repository_path, strict_model_config,
+      tf_gpu_memory_fraction, tf_allow_soft_placement, &platform_config_map,
+      &options.platform_config_map);
+
+  LOG_VERBOSE(1) << options.platform_config_map.DebugString();
+
+  // Not setting the singleton / smart pointer directly because error on TFS
+  // core creation may not be considered as initialization failure. So only
+  // setting it before core creation to simplify clean up
+  std::unique_ptr<ModelRepositoryManager> local_manager(
+      new ModelRepositoryManager(
+          status_manager, repository_path, platform_config_map,
+          !strict_model_config, polling_enabled));
+
+  // Similar to PollAndUpdate(), but simplier
+  std::set<std::string> added, deleted, modified, unmodified;
+  if (polling_enabled) {
+    RETURN_IF_ERROR(
+        local_manager->Poll(&added, &deleted, &modified, &unmodified));
+  }
+  if (!deleted.empty() || !modified.empty() || !unmodified.empty()) {
+    return Status(
+        RequestStatusCode::INTERNAL,
+        "Unexpected initial state for model repository");
+  }
+
+  for (const auto& name : added) {
+    tfs::ModelConfig* tfs_config =
+        options.model_server_config.mutable_model_config_list()->add_config();
+    Status status = local_manager->GetTFSModelConfig(name, tfs_config);
+    if (!status.IsOk()) {
+      return Status(
+          RequestStatusCode::INTERNAL,
+          "Internal: model repository manager inconsistency");
+    }
+
+    ModelConfig model_config;
+    RETURN_IF_ERROR(
+        local_manager->GetModelConfigFromInstance(name, &model_config));
+    status = local_manager->status_manager_->InitForModel(name, model_config);
+    if (!status.IsOk()) {
+      return status;
+    }
+  }
+
+  LOG_VERBOSE(1) << options.model_server_config.DebugString();
+
+  // Create the server core. We assume that any failure is due to a
+  // model not loading correctly so we just continue if not exiting on
+  // error.
+  *model_repository_manager = std::move(local_manager);
+  singleton = model_repository_manager->get();
+  RETURN_IF_TF_ERROR(
+      tfs::ServerCore::Create(std::move(options), &singleton->core_));
 
   return Status::Success;
 }
@@ -140,56 +441,171 @@ Status
 ModelRepositoryManager::GetModelConfig(
     const std::string& name, ModelConfig* model_config)
 {
-  std::lock_guard<std::mutex> lock(singleton->infos_mu_);
+  return singleton->GetModelConfigFromInstance(name, model_config);
+}
 
-  const auto itr = singleton->infos_.find(name);
-  if (itr == singleton->infos_.end()) {
-    return Status(
-        RequestStatusCode::NOT_FOUND,
-        "no configuration for model '" + name + "'");
+Status
+ModelRepositoryManager::PollAndUpdate()
+{
+  if (!polling_enabled_) {
+    return Status(RequestStatusCode::INVALID, "polling is disabled");
+  }
+  std::set<std::string> added, deleted, modified, unmodified;
+  RETURN_IF_ERROR(Poll(&added, &deleted, &modified, &unmodified));
+  // Nothing to do if no model adds, deletes or modifies.
+  if (added.empty() && deleted.empty() && modified.empty()) {
+    return Status::Success;
   }
 
-  *model_config = itr->second->model_config_;
+  // [TODO] Once the model repository manager is improved,
+  // model load / unload should be done in separate thread
+
+  // There was a change in the model repository so need to
+  // create a new TFS model configuration and reload it into the
+  // server to cause the appropriate models to be loaded and
+  // unloaded.
+  tfs::ModelServerConfig msc;
+  msc.mutable_model_config_list();
+
+  // Added models should be loaded and be initialized for status
+  // reporting.
+  for (const auto& name : added) {
+    tfs::ModelConfig* tfs_config =
+        msc.mutable_model_config_list()->add_config();
+    RETURN_IF_ERROR(GetTFSModelConfig(name, tfs_config));
+    ModelConfig model_config;
+    RETURN_IF_ERROR(GetModelConfigFromInstance(name, &model_config));
+    RETURN_IF_ERROR(status_manager_->InitForModel(name, model_config));
+  }
+
+  // Keep unmodified models...
+  for (const auto& name : unmodified) {
+    tfs::ModelConfig* tfs_config =
+        msc.mutable_model_config_list()->add_config();
+    RETURN_IF_ERROR(GetTFSModelConfig(name, tfs_config));
+  }
+
+  RETURN_IF_TF_ERROR(core_->ReloadConfig(msc));
+
+  // If there are any modified model, (re)load them to pick up
+  // the changes. We want to keep the current status information
+  // so don't re-init it.
+  if (!modified.empty()) {
+    for (const auto& name : modified) {
+      tfs::ModelConfig* tfs_config =
+          msc.mutable_model_config_list()->add_config();
+      RETURN_IF_ERROR(GetTFSModelConfig(name, tfs_config));
+      ModelConfig model_config;
+      RETURN_IF_ERROR(GetModelConfigFromInstance(name, &model_config));
+      RETURN_IF_ERROR(
+          status_manager_->UpdateConfigForModel(name, model_config));
+    }
+
+    RETURN_IF_TF_ERROR(core_->ReloadConfig(msc));
+  }
   return Status::Success;
 }
 
 Status
-ModelRepositoryManager::GetTFSModelConfig(
-    const std::string& name, tfs::ModelConfig* tfs_model_config)
+ModelRepositoryManager::LoadUnloadModel(
+    const std::string& model_name, ActionType type,
+    std::function<void(Status)> OnCompleteUpdate)
 {
-  std::lock_guard<std::mutex> lock(singleton->infos_mu_);
-
-  const auto itr = singleton->infos_.find(name);
-  if (itr == singleton->infos_.end()) {
+  if (polling_enabled_) {
     return Status(
-        RequestStatusCode::NOT_FOUND,
-        "no TFS configuration for model '" + name + "'");
+        RequestStatusCode::INVALID,
+        "explicit model load / unload is not allowed if polling is enabled");
   }
-
-  *tfs_model_config = itr->second->tfs_model_config_;
-  return Status::Success;
+  // [TODO] model load / unload should be done in separate thread
+  Status status = Status(RequestStatusCode::UNSUPPORTED, "not implemented");
+  OnCompleteUpdate(status);
+  return status;
 }
 
 Status
-ModelRepositoryManager::GetModelPlatform(
-    const std::string& name, Platform* platform)
+ModelRepositoryManager::UnloadAllModels()
 {
-  std::lock_guard<std::mutex> lock(singleton->infos_mu_);
-
-  const auto itr = singleton->infos_.find(name);
-  if (itr == singleton->infos_.end()) {
-    *platform = Platform::PLATFORM_UNKNOWN;
-  } else {
-    *platform = itr->second->platform_;
-  }
-
-  if (*platform == Platform::PLATFORM_UNKNOWN) {
+  // Reload an empty configuration to cause all models to unload.
+  tfs::ModelServerConfig msc;
+  msc.mutable_model_config_list();
+  tensorflow::Status tfstatus = core_->ReloadConfig(msc);
+  if (!tfstatus.ok()) {
     return Status(
-        RequestStatusCode::NOT_FOUND,
-        "unknown platform for model '" + name + "'");
+        RequestStatusCode::INTERNAL,
+        "Failed to gracefully unload models: " + tfstatus.error_message());
+  }
+  return Status::Success;
+}
+
+const ModelRepositoryManager::ModelMap
+ModelRepositoryManager::GetLiveBackendStates()
+{
+  // [TODO] maintain its own ModelMap
+  ModelMap res;
+  const tfs::ServableStateMonitor& monitor = *(core_->servable_state_monitor());
+  const auto& live_models = monitor.GetLiveServableStates();
+  for (const auto& m : live_models) {
+    VersionStateMap map;
+    for (const auto& v : m.second) {
+      map[v.first] =
+          ManagerStateToModelReadyState(v.second.state.manager_state);
+    }
+    res[m.first] = map;
+  }
+  return res;
+}
+
+const ModelRepositoryManager::VersionStateMap
+ModelRepositoryManager::GetVersionStates(const std::string& model_name)
+{
+  VersionStateMap res;
+  const tfs::ServableStateMonitor& monitor = *(core_->servable_state_monitor());
+  const tensorflow::serving::ServableStateMonitor::VersionMap
+      versions_and_states = monitor.GetVersionStates(model_name);
+  for (const auto& version_and_state : versions_and_states) {
+    const int64_t version = version_and_state.first;
+    const tensorflow::serving::ServableState& servable_state =
+        version_and_state.second.state;
+
+    ModelReadyState ready_state =
+        ManagerStateToModelReadyState(servable_state.manager_state);
+
+    if (ready_state != ModelReadyState::MODEL_UNKNOWN) {
+      res[version] = ready_state;
+    }
+  }
+  return res;
+}
+
+Status
+ModelRepositoryManager::GetBackendHandle(
+    const std::string& model_name, const int64_t model_version,
+    std::unique_ptr<BackendHandle>* handle)
+{
+  // Create the model-spec. A negative version indicates that the
+  // latest version of the model should be used.
+  tfs::ModelSpec model_spec;
+  model_spec.set_name(model_name);
+  if (model_version >= 0) {
+    model_spec.mutable_version()->set_value(model_version);
   }
 
-  return Status::Success;
+  // Get the InferenceBackend appropriate for the request.
+  Platform platform;
+  Status status = GetModelPlatform(model_name, &platform);
+  if (status.IsOk()) {
+    handle->reset(
+        new BackendHandleImpl(platform, model_spec, singleton->core_.get()));
+
+    if ((*handle)->GetInferenceBackend() == nullptr) {
+      handle->reset();
+      status = Status(
+          RequestStatusCode::UNAVAILABLE,
+          "Inference request for unknown model '" + model_name + "'");
+    }
+  }
+
+  return status;
 }
 
 Status
@@ -198,7 +614,7 @@ ModelRepositoryManager::Poll(
     std::set<std::string>* modified, std::set<std::string>* unmodified)
 {
   // Serialize all polling operation...
-  std::lock_guard<std::mutex> lock(singleton->poll_mu_);
+  std::lock_guard<std::mutex> lock(poll_mu_);
 
   added->clear();
   deleted->clear();
@@ -213,8 +629,8 @@ ModelRepositoryManager::Poll(
   // Each subdirectory of repository path is a model directory from
   // which we read the model configuration.
   std::vector<std::string> children;
-  RETURN_IF_TF_ERROR(tensorflow::Env::Default()->GetChildren(
-      singleton->repository_path_, &children));
+  RETURN_IF_TF_ERROR(
+      tensorflow::Env::Default()->GetChildren(repository_path_, &children));
 
   // GetChildren() returns all descendants instead for cloud storage
   // like GCS.  In such case we should filter out all non-direct
@@ -226,8 +642,7 @@ ModelRepositoryManager::Poll(
   }
 
   for (const auto& child : real_children) {
-    const auto full_path =
-        tensorflow::io::JoinPath(singleton->repository_path_, child);
+    const auto full_path = tensorflow::io::JoinPath(repository_path_, child);
     if (!tensorflow::Env::Default()->IsDirectory(full_path).ok()) {
       continue;
     }
@@ -237,8 +652,8 @@ ModelRepositoryManager::Poll(
     // (re)load, normalize and validate the configuration.
     bool need_load = false;
     int64_t mtime_ns;
-    const auto iitr = singleton->infos_.find(child);
-    if (iitr == singleton->infos_.end()) {
+    const auto iitr = infos_.find(child);
+    if (iitr == infos_.end()) {
       added->insert(child);
       mtime_ns = GetModifiedTime(std::string(full_path));
       need_load = true;
@@ -279,8 +694,7 @@ ModelRepositoryManager::Poll(
       // the model configuration (autofill) from the model
       // definition. In all cases normalize and validate the config.
       RETURN_IF_ERROR(GetNormalizedModelConfig(
-          full_path, singleton->platform_config_map_, singleton->autofill_,
-          &model_config));
+          full_path, platform_config_map_, autofill_, &model_config));
       RETURN_IF_ERROR(ValidateModelConfig(model_config, std::string()));
 
       model_info->platform_ = GetPlatform(model_config.platform());
@@ -331,7 +745,7 @@ ModelRepositoryManager::Poll(
 
   // Anything in 'infos_' that is not in "added", "modified", or
   // "unmodified" is deleted.
-  for (const auto& pr : singleton->infos_) {
+  for (const auto& pr : infos_) {
     if ((added->find(pr.first) == added->end()) &&
         (modified->find(pr.first) == modified->end()) &&
         (unmodified->find(pr.first) == unmodified->end())) {
@@ -342,8 +756,65 @@ ModelRepositoryManager::Poll(
   // Swap the new infos in place under a short-lived lock and only if
   // there were no errors encountered during polling.
   {
-    std::lock_guard<std::mutex> lock(singleton->infos_mu_);
-    singleton->infos_.swap(new_infos);
+    std::lock_guard<std::mutex> lock(infos_mu_);
+    infos_.swap(new_infos);
+  }
+
+  return Status::Success;
+}
+
+
+Status
+ModelRepositoryManager::GetModelConfigFromInstance(
+    const std::string& name, ModelConfig* model_config)
+{
+  std::lock_guard<std::mutex> lock(infos_mu_);
+
+  const auto itr = infos_.find(name);
+  if (itr == infos_.end()) {
+    return Status(
+        RequestStatusCode::NOT_FOUND,
+        "no configuration for model '" + name + "'");
+  }
+
+  *model_config = itr->second->model_config_;
+  return Status::Success;
+}
+
+Status
+ModelRepositoryManager::GetTFSModelConfig(
+    const std::string& name, tfs::ModelConfig* tfs_model_config)
+{
+  std::lock_guard<std::mutex> lock(infos_mu_);
+
+  const auto itr = infos_.find(name);
+  if (itr == infos_.end()) {
+    return Status(
+        RequestStatusCode::NOT_FOUND,
+        "no TFS configuration for model '" + name + "'");
+  }
+
+  *tfs_model_config = itr->second->tfs_model_config_;
+  return Status::Success;
+}
+
+Status
+ModelRepositoryManager::GetModelPlatform(
+    const std::string& name, Platform* platform)
+{
+  std::lock_guard<std::mutex> lock(infos_mu_);
+
+  const auto itr = infos_.find(name);
+  if (itr == infos_.end()) {
+    *platform = Platform::PLATFORM_UNKNOWN;
+  } else {
+    *platform = itr->second->platform_;
+  }
+
+  if (*platform == Platform::PLATFORM_UNKNOWN) {
+    return Status(
+        RequestStatusCode::NOT_FOUND,
+        "unknown platform for model '" + name + "'");
   }
 
   return Status::Success;

--- a/src/core/server.cc
+++ b/src/core/server.cc
@@ -38,6 +38,7 @@
 #include <vector>
 
 #include "src/core/api.pb.h"
+#include "src/core/backend.h"
 #include "src/core/constants.h"
 #include "src/core/logging.h"
 #include "src/core/model_config.h"
@@ -49,26 +50,7 @@
 #include "src/core/request_status.h"
 #include "src/core/server.h"
 #include "src/core/server_status.pb.h"
-#include "src/servables/caffe2/netdef_bundle.h"
-#include "src/servables/caffe2/netdef_bundle.pb.h"
-#include "src/servables/custom/custom_bundle.h"
-#include "src/servables/custom/custom_bundle.pb.h"
-#include "src/servables/ensemble/ensemble_bundle.h"
-#include "src/servables/ensemble/ensemble_bundle.pb.h"
-#include "src/servables/tensorflow/graphdef_bundle.h"
-#include "src/servables/tensorflow/graphdef_bundle.pb.h"
-#include "src/servables/tensorflow/savedmodel_bundle.h"
-#include "src/servables/tensorflow/savedmodel_bundle.pb.h"
-#include "src/servables/tensorrt/plan_bundle.h"
-#include "src/servables/tensorrt/plan_bundle.pb.h"
 #include "tensorflow/core/platform/env.h"
-#include "tensorflow_serving/config/model_server_config.pb.h"
-#include "tensorflow_serving/config/platform_config.pb.h"
-#include "tensorflow_serving/core/availability_preserving_policy.h"
-#include "tensorflow_serving/core/servable_handle.h"
-#include "tensorflow_serving/model_servers/server_core.h"
-
-namespace tfs = tensorflow::serving;
 
 namespace nvidia { namespace inferenceserver {
 
@@ -88,118 +70,6 @@ class ScopedAtomicIncrement {
  private:
   std::atomic<uint64_t>& counter_;
 };
-
-void
-BuildPlatformConfigMap(
-    const std::string& version, const std::string& model_store_path,
-    const bool strict_model_config, const float tf_gpu_memory_fraction,
-    const bool tf_allow_soft_placement, PlatformConfigMap* platform_configs,
-    tfs::PlatformConfigMap* tfs_platform_configs)
-{
-  ::google::protobuf::Any graphdef_source_adapter_config;
-  ::google::protobuf::Any saved_model_source_adapter_config;
-  ::google::protobuf::Any plan_source_adapter_config;
-  ::google::protobuf::Any netdef_source_adapter_config;
-  ::google::protobuf::Any custom_source_adapter_config;
-  ::google::protobuf::Any ensemble_source_adapter_config;
-
-  //// Tensorflow GraphDef
-  {
-    GraphDefBundleSourceAdapterConfig graphdef_config;
-
-    graphdef_config.set_autofill(!strict_model_config);
-
-    // Tensorflow session config
-    if (tf_gpu_memory_fraction == 0.0) {
-      graphdef_config.mutable_session_config()
-          ->mutable_gpu_options()
-          ->set_allow_growth(true);
-    } else {
-      graphdef_config.mutable_session_config()
-          ->mutable_gpu_options()
-          ->set_per_process_gpu_memory_fraction(tf_gpu_memory_fraction);
-    }
-
-    graphdef_config.mutable_session_config()->set_allow_soft_placement(
-        tf_allow_soft_placement);
-    graphdef_source_adapter_config.PackFrom(graphdef_config);
-  }
-
-  //// Tensorflow SavedModel
-  {
-    SavedModelBundleSourceAdapterConfig saved_model_config;
-
-    saved_model_config.set_autofill(!strict_model_config);
-
-    if (tf_gpu_memory_fraction == 0.0) {
-      saved_model_config.mutable_session_config()
-          ->mutable_gpu_options()
-          ->set_allow_growth(true);
-    } else {
-      saved_model_config.mutable_session_config()
-          ->mutable_gpu_options()
-          ->set_per_process_gpu_memory_fraction(tf_gpu_memory_fraction);
-    }
-
-    saved_model_config.mutable_session_config()->set_allow_soft_placement(
-        tf_allow_soft_placement);
-    saved_model_source_adapter_config.PackFrom(saved_model_config);
-  }
-
-  //// Caffe NetDef
-  {
-    NetDefBundleSourceAdapterConfig netdef_config;
-    netdef_config.set_autofill(!strict_model_config);
-    netdef_source_adapter_config.PackFrom(netdef_config);
-  }
-
-  //// TensorRT
-  {
-    PlanBundleSourceAdapterConfig plan_config;
-    plan_config.set_autofill(!strict_model_config);
-    plan_source_adapter_config.PackFrom(plan_config);
-  }
-
-  //// Custom
-  {
-    CustomBundleSourceAdapterConfig custom_config;
-    custom_config.set_inference_server_version(version);
-    custom_config.set_model_repository_path(model_store_path);
-    custom_source_adapter_config.PackFrom(custom_config);
-  }
-
-  //// Ensemble
-  {
-    EnsembleBundleSourceAdapterConfig ensemble_config;
-    ensemble_source_adapter_config.PackFrom(ensemble_config);
-  }
-
-  (*platform_configs)[kTensorFlowGraphDefPlatform] =
-      graphdef_source_adapter_config;
-  (*platform_configs)[kTensorFlowSavedModelPlatform] =
-      saved_model_source_adapter_config;
-  (*platform_configs)[kCaffe2NetDefPlatform] = netdef_source_adapter_config;
-  (*platform_configs)[kTensorRTPlanPlatform] = plan_source_adapter_config;
-  (*platform_configs)[kCustomPlatform] = custom_source_adapter_config;
-  (*platform_configs)[kEnsemblePlatform] = ensemble_source_adapter_config;
-
-  // Must also return the configs in format required by TFS for
-  // ServerCore.
-  (*(*tfs_platform_configs
-          ->mutable_platform_configs())[kTensorFlowGraphDefPlatform]
-        .mutable_source_adapter_config()) = graphdef_source_adapter_config;
-  (*(*tfs_platform_configs
-          ->mutable_platform_configs())[kTensorFlowSavedModelPlatform]
-        .mutable_source_adapter_config()) = saved_model_source_adapter_config;
-  (*(*tfs_platform_configs->mutable_platform_configs())[kCaffe2NetDefPlatform]
-        .mutable_source_adapter_config()) = netdef_source_adapter_config;
-  (*(*tfs_platform_configs->mutable_platform_configs())[kTensorRTPlanPlatform]
-        .mutable_source_adapter_config()) = plan_source_adapter_config;
-  (*(*tfs_platform_configs->mutable_platform_configs())[kCustomPlatform]
-        .mutable_source_adapter_config()) = custom_source_adapter_config;
-  (*(*tfs_platform_configs->mutable_platform_configs())[kEnsemblePlatform]
-        .mutable_source_adapter_config()) = ensemble_source_adapter_config;
-}
 
 }  // namespace
 
@@ -257,81 +127,22 @@ InferenceServer::Init()
     return false;
   }
 
-  // For ServerCore Options, we leave servable_state_monitor_creator unspecified
-  // so the default servable_state_monitor_creator will be used.
-  tfs::ServerCore::Options options;
-
-  // Set some default values in Options
-  options.aspired_version_policy = std::unique_ptr<tfs::AspiredVersionPolicy>(
-      new tfs::AvailabilityPreservingPolicy);
-
-  // If not polling the model repository then set the poll secs to 0
-  // in TFS so that repository is only checked a single time at
-  // startup.
-  options.max_num_load_retries = 0;
-  options.file_system_poll_wait_seconds = repository_poll_secs_;
-
-  PlatformConfigMap platform_configs;
-  BuildPlatformConfigMap(
-      version_, model_store_path_, strict_model_config_,
-      tf_gpu_memory_fraction_, tf_soft_placement_enabled_, &platform_configs,
-      &options.platform_config_map);
-  LOG_VERBOSE(1) << options.platform_config_map.DebugString();
-
-  // Create the global manager for the repository. Add all models'
-  // into the server core 'options' so that they are eagerly loaded
-  // below when ServerCore is created.
+  // Create the global manager for the repository. For now, all models are
+  // eagerly loaded below when the manager is created.
   status = ModelRepositoryManager::Create(
-      model_store_path_, platform_configs, !strict_model_config_);
+      version_, status_manager_, model_store_path_, strict_model_config_,
+      tf_gpu_memory_fraction_, tf_soft_placement_enabled_,
+      repository_poll_secs_, true /* polling */, &model_repository_manager_);
   if (!status.IsOk()) {
     LOG_ERROR << status.Message();
-    ready_state_ = ServerReadyState::SERVER_FAILED_TO_INITIALIZE;
-    return false;
-  }
-
-  std::set<std::string> added, deleted, modified, unmodified;
-  status =
-      ModelRepositoryManager::Poll(&added, &deleted, &modified, &unmodified);
-  if (!status.IsOk()) {
-    LOG_ERROR << status.Message();
-    ready_state_ = ServerReadyState::SERVER_FAILED_TO_INITIALIZE;
-    return false;
-  }
-
-  if (!deleted.empty() || !modified.empty() || !unmodified.empty()) {
-    LOG_ERROR << "Unexpected initial state for model repository";
-    ready_state_ = ServerReadyState::SERVER_FAILED_TO_INITIALIZE;
-    return false;
-  }
-
-  for (const auto& name : added) {
-    tfs::ModelConfig* tfs_config =
-        options.model_server_config.mutable_model_config_list()->add_config();
-    status = ModelRepositoryManager::GetTFSModelConfig(name, tfs_config);
-    if (!status.IsOk()) {
-      LOG_ERROR << "Internal: model repository manager inconsistency";
+    if (model_repository_manager_ == nullptr) {
       ready_state_ = ServerReadyState::SERVER_FAILED_TO_INITIALIZE;
-      return false;
+    } else {
+      // If error is returned while the manager is set, we assume the failure
+      // is due to a model not loading correctly so we just continue
+      // if not exiting on error.
+      ready_state_ = ServerReadyState::SERVER_READY;
     }
-
-    status = status_manager_->InitForModel(name);
-    if (!status.IsOk()) {
-      LOG_ERROR << status.Message();
-      ready_state_ = ServerReadyState::SERVER_FAILED_TO_INITIALIZE;
-      return false;
-    }
-  }
-
-  LOG_VERBOSE(1) << options.model_server_config.DebugString();
-
-  // Create the server core. We assume that any failure is due to a
-  // model not loading correctly so we just continue if not exiting on
-  // error.
-  tensorflow::Status tfstatus =
-      tfs::ServerCore::Create(std::move(options), &core_);
-  if (!tfstatus.ok()) {
-    LOG_ERROR << tfstatus;
-    ready_state_ = ServerReadyState::SERVER_READY;
     return false;
   }
 
@@ -344,28 +155,24 @@ InferenceServer::Stop()
 {
   ready_state_ = ServerReadyState::SERVER_EXITING;
 
-  if (core_ == nullptr) {
+  if (model_repository_manager_ == nullptr) {
     LOG_INFO << "No server context available. Exiting immediately.";
     return true;
   } else {
     LOG_INFO << "Waiting for in-flight inferences to complete.";
   }
 
-  // Reload an empty configuration to cause all models to unload.
-  tfs::ModelServerConfig msc;
-  msc.mutable_model_config_list();
-  tensorflow::Status tfstatus = core_->ReloadConfig(msc);
-  if (!tfstatus.ok()) {
-    LOG_ERROR << "Failed to gracefully unload models: " << tfstatus;
+  Status status = model_repository_manager_->UnloadAllModels();
+  if (!status.IsOk()) {
+    LOG_ERROR << status.Message();
   }
 
   // Wait for all in-flight requests to complete and all loaded models
   // to unload, or for the exit timeout to expire.
-  const tfs::ServableStateMonitor& monitor = *core_->servable_state_monitor();
   uint32_t exit_timeout_iters = exit_timeout_secs_;
 
   while (true) {
-    const auto& live_models = monitor.GetLiveServableStates();
+    const auto& live_models = model_repository_manager_->GetLiveBackendStates();
 
     LOG_INFO << "Timeout " << exit_timeout_iters << ": Found "
              << live_models.size() << " live models and "
@@ -373,8 +180,7 @@ InferenceServer::Stop()
     if (LOG_VERBOSE_IS_ON(1)) {
       for (const auto& m : live_models) {
         for (const auto& v : m.second) {
-          LOG_VERBOSE(1) << m.first << "v" << v.first << ": "
-                         << v.second.DebugString();
+          LOG_VERBOSE(1) << m.first << "v" << v.first << ": " << v.second;
         }
       }
     }
@@ -402,56 +208,7 @@ InferenceServer::PollModelRepository()
   // Look for changes and update the loaded model configurations
   // appropriately.
   if (ready_state_ == ServerReadyState::SERVER_READY) {
-    std::set<std::string> added, deleted, modified, unmodified;
-    RETURN_IF_ERROR(
-        ModelRepositoryManager::Poll(&added, &deleted, &modified, &unmodified));
-
-    // Nothing to do if no model adds, deletes or modifies.
-    if (added.empty() && deleted.empty() && modified.empty()) {
-      return Status::Success;
-    }
-
-    // There was a change in the model repository so need to
-    // create a new TFS model configuration and reload it into the
-    // server to cause the appropriate models to be loaded and
-    // unloaded.
-    tfs::ModelServerConfig msc;
-    msc.mutable_model_config_list();
-
-    // Added models should be loaded and be initialized for status
-    // reporting.
-    for (const auto& name : added) {
-      tfs::ModelConfig* tfs_config =
-          msc.mutable_model_config_list()->add_config();
-      RETURN_IF_ERROR(
-          ModelRepositoryManager::GetTFSModelConfig(name, tfs_config));
-      RETURN_IF_ERROR(status_manager_->InitForModel(name));
-    }
-
-    // Keep unmodified models...
-    for (const auto& name : unmodified) {
-      tfs::ModelConfig* tfs_config =
-          msc.mutable_model_config_list()->add_config();
-      RETURN_IF_ERROR(
-          ModelRepositoryManager::GetTFSModelConfig(name, tfs_config));
-    }
-
-    RETURN_IF_TF_ERROR(core_->ReloadConfig(msc));
-
-    // If there are any modified model, (re)load them to pick up
-    // the changes. We want to keep the current status information
-    // so don't re-init it.
-    if (!modified.empty()) {
-      for (const auto& name : modified) {
-        tfs::ModelConfig* tfs_config =
-            msc.mutable_model_config_list()->add_config();
-        RETURN_IF_ERROR(
-            ModelRepositoryManager::GetTFSModelConfig(name, tfs_config));
-        RETURN_IF_ERROR(status_manager_->UpdateConfigForModel(name));
-      }
-
-      RETURN_IF_TF_ERROR(core_->ReloadConfig(msc));
-    }
+    RETURN_IF_ERROR(model_repository_manager_->PollAndUpdate());
   }
 
   return Status::Success;
@@ -489,14 +246,10 @@ InferenceServer::HandleHealth(
     if (*health && strict_readiness_) {
       // Strict readiness... get the model status and make sure all
       // models are ready.
-      tfs::ServableStateMonitor* monitor = nullptr;
-      if (core_ != nullptr) {
-        monitor = core_->servable_state_monitor();
-      }
-
       ServerStatus server_status;
       Status status = status_manager_->Get(
-          &server_status, id_, ready_state_, UptimeNs(), monitor);
+          &server_status, id_, ready_state_, UptimeNs(),
+          model_repository_manager_.get());
 
       *health = status.IsOk();
       if (*health) {
@@ -619,23 +372,20 @@ InferenceServer::HandleStatus(
   ScopedAtomicIncrement inflight(inflight_request_counter_);
   const uint64_t request_id = NextRequestId();
 
-  tfs::ServableStateMonitor* monitor = nullptr;
-  if (core_ != nullptr) {
-    monitor = core_->servable_state_monitor();
-  }
-
   // If no specific model request just return the entire status
   // object.
   if (model_name.empty()) {
     RequestStatusFactory::Create(
         request_status, request_id, id_,
         status_manager_->Get(
-            server_status, id_, ready_state_, UptimeNs(), monitor));
+            server_status, id_, ready_state_, UptimeNs(),
+            model_repository_manager_.get()));
   } else {
     RequestStatusFactory::Create(
         request_status, request_id, id_,
         status_manager_->Get(
-            server_status, id_, ready_state_, UptimeNs(), model_name, monitor));
+            server_status, id_, ready_state_, UptimeNs(), model_name,
+            model_repository_manager_.get()));
   }
 }
 
@@ -654,93 +404,27 @@ InferenceServer::UptimeNs() const
 //
 class InferBackendHandleImpl : public InferenceServer::InferBackendHandle {
  public:
-  InferBackendHandleImpl() : is_(nullptr) {}
+  InferBackendHandleImpl() = default;
   Status Init(
       const std::string& model_name, const int64_t model_version,
-      tfs::ServerCore* core);
+      ModelRepositoryManager* model_repository_manager);
 
-  InferenceBackend* GetInferenceBackend() override { return is_; }
+  InferenceBackend* GetInferenceBackend() override
+  {
+    return backend_handle_->GetInferenceBackend();
+  }
 
  private:
-  InferenceBackend* is_;
-  tfs::ServableHandle<GraphDefBundle> graphdef_bundle_;
-  tfs::ServableHandle<PlanBundle> plan_bundle_;
-  tfs::ServableHandle<NetDefBundle> netdef_bundle_;
-  tfs::ServableHandle<SavedModelBundle> saved_model_bundle_;
-  tfs::ServableHandle<CustomBundle> custom_bundle_;
-  tfs::ServableHandle<EnsembleBundle> ensemble_bundle_;
+  std::unique_ptr<ModelRepositoryManager::BackendHandle> backend_handle_;
 };
 
 Status
 InferBackendHandleImpl::Init(
     const std::string& model_name, const int64_t model_version,
-    tfs::ServerCore* core)
+    ModelRepositoryManager* model_repository_manager)
 {
-  // Create the model-spec. A negative version indicates that the
-  // latest version of the model should be used.
-  tfs::ModelSpec model_spec;
-  model_spec.set_name(model_name);
-  if (model_version >= 0) {
-    model_spec.mutable_version()->set_value(model_version);
-  }
-
-  // Get the InferenceBackend appropriate for the request.
-  Platform platform;
-  Status status =
-      ModelRepositoryManager::GetModelPlatform(model_name, &platform);
-  if (status.IsOk()) {
-    tensorflow::Status tfstatus;
-    is_ = nullptr;
-
-    switch (platform) {
-      case Platform::PLATFORM_TENSORFLOW_GRAPHDEF:
-        tfstatus = core->GetServableHandle(model_spec, &(graphdef_bundle_));
-        if (tfstatus.ok()) {
-          is_ = static_cast<InferenceBackend*>(graphdef_bundle_.get());
-        }
-        break;
-      case Platform::PLATFORM_TENSORFLOW_SAVEDMODEL:
-        tfstatus = core->GetServableHandle(model_spec, &(saved_model_bundle_));
-        if (tfstatus.ok()) {
-          is_ = static_cast<InferenceBackend*>(saved_model_bundle_.get());
-        }
-        break;
-      case Platform::PLATFORM_TENSORRT_PLAN:
-        tfstatus = core->GetServableHandle(model_spec, &(plan_bundle_));
-        if (tfstatus.ok()) {
-          is_ = static_cast<InferenceBackend*>(plan_bundle_.get());
-        }
-        break;
-      case Platform::PLATFORM_CAFFE2_NETDEF:
-        tfstatus = core->GetServableHandle(model_spec, &(netdef_bundle_));
-        if (tfstatus.ok()) {
-          is_ = static_cast<InferenceBackend*>(netdef_bundle_.get());
-        }
-        break;
-      case Platform::PLATFORM_CUSTOM:
-        tfstatus = core->GetServableHandle(model_spec, &(custom_bundle_));
-        if (tfstatus.ok()) {
-          is_ = static_cast<InferenceBackend*>(custom_bundle_.get());
-        }
-        break;
-      case Platform::PLATFORM_ENSEMBLE:
-        tfstatus = core->GetServableHandle(model_spec, &(ensemble_bundle_));
-        if (tfstatus.ok()) {
-          is_ = static_cast<InferenceBackend*>(ensemble_bundle_.get());
-        }
-        break;
-      default:
-        break;
-    }
-  }
-
-  if (is_ == nullptr) {
-    status = Status(
-        RequestStatusCode::UNAVAILABLE,
-        "Inference request for unknown model '" + model_name + "'");
-  }
-
-  return status;
+  return model_repository_manager->GetBackendHandle(
+      model_name, model_version, &backend_handle_);
 }
 
 Status
@@ -749,7 +433,7 @@ InferenceServer::InferBackendHandle::Create(
     const int64_t model_version, std::shared_ptr<InferBackendHandle>* handle)
 {
   InferBackendHandleImpl* bh = new InferBackendHandleImpl();
-  Status status = bh->Init(model_name, model_version, server->core_.get());
+  Status status = bh->Init(model_name, model_version, server->ModelManager());
   if (status.IsOk()) {
     handle->reset(bh);
   }

--- a/src/core/server.h
+++ b/src/core/server.h
@@ -40,10 +40,6 @@
 #include "src/core/server_status.pb.h"
 #include "src/core/status.h"
 
-namespace tensorflow { namespace serving {
-class ServerCore;
-}}  // namespace tensorflow::serving
-
 namespace nvidia { namespace inferenceserver {
 
 // Inference server information.
@@ -144,6 +140,12 @@ class InferenceServer {
     return status_manager_;
   }
 
+  // Return the model repository manager for this server.
+  ModelRepositoryManager* ModelManager() const
+  {
+    return model_repository_manager_.get();
+  }
+
   // A handle to a backend.
   class InferBackendHandle {
    public:
@@ -186,8 +188,8 @@ class InferenceServer {
   // for all in-flight requests to complete before exiting.
   std::atomic<uint64_t> inflight_request_counter_;
 
-  std::unique_ptr<tensorflow::serving::ServerCore> core_;
   std::shared_ptr<ServerStatusManager> status_manager_;
+  std::unique_ptr<ModelRepositoryManager> model_repository_manager_;
 };
 
 }}  // namespace nvidia::inferenceserver

--- a/src/core/server_status.h
+++ b/src/core/server_status.h
@@ -32,10 +32,6 @@
 #include "src/core/server_status.pb.h"
 #include "src/core/status.h"
 
-namespace tensorflow { namespace serving {
-class ServableStateMonitor;
-}}  // namespace tensorflow::serving
-
 namespace nvidia { namespace inferenceserver {
 
 class MetricModelReporter;
@@ -179,23 +175,25 @@ class ServerStatusManager {
   explicit ServerStatusManager(const std::string& server_version);
 
   // Initialize status for a model.
-  Status InitForModel(const std::string& model_name);
+  Status InitForModel(
+      const std::string& model_name, const ModelConfig& model_config);
 
   // Update model config for an existing model.
-  Status UpdateConfigForModel(const std::string& model_name);
+  Status UpdateConfigForModel(
+      const std::string& model_name, const ModelConfig& model_config);
 
   // Get the entire server status, including status for all models.
   Status Get(
       ServerStatus* server_status, const std::string& server_id,
       ServerReadyState server_ready_state, uint64_t server_uptime_ns,
-      const tensorflow::serving::ServableStateMonitor* monitor) const;
+      ModelRepositoryManager* model_repository_manager) const;
 
   // Get the server status and the status for a single model.
   Status Get(
       ServerStatus* server_status, const std::string& server_id,
       ServerReadyState server_ready_state, uint64_t server_uptime_ns,
       const std::string& model_name,
-      const tensorflow::serving::ServableStateMonitor* monitor) const;
+      ModelRepositoryManager* model_repository_manager) const;
 
   // Add a duration to the Server Stat specified by 'kind'.
   void UpdateServerStat(uint64_t duration, ServerStatTimerScoped::Kind kind);


### PR DESCRIPTION
First step of removing TFS. The public functions in ModelRepositoryManager should be compatible with future steps, except for the part that relies on singleton.