### PR TITLE
Make output optional for LibTorch model config

### DIFF
--- a/qa/L0_libtorch_unknown_op/lt_unknown_op_client.py
+++ b/qa/L0_libtorch_unknown_op/lt_unknown_op_client.py
@@ -1,0 +1,131 @@
+#!/usr/bin/python
+
+# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import argparse
+import numpy as np
+import os
+from builtins import range
+from tensorrtserver.api import *
+import tensorrtserver.api.server_status_pb2 as server_status
+
+FLAGS = None
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-m', '--model_name', type=str, required=True,
+                        help='Name of the model to test')
+    FLAGS = parser.parse_args()
+
+    protocol = ProtocolType.from_str("http")
+
+    # We use a simple model that takes 1 input tensors of 1 integer
+    # and returns variable number of (1, 2 or 3) output tensors
+    # of 1 integer each. Each output tensor is same as the input
+    model_name = FLAGS.model_name
+    version = 1
+    batch_size = 1
+    verbose = 1
+
+    ctx = InferContext("localhost:8000", protocol, model_name, version, verbose)
+
+    for if_type in (InferContext.ResultFormat.RAW, (InferContext.ResultFormat.CLASS, 1)):
+        input0_data = np.array([0], dtype=np.int32)
+
+        # Send inference request to the inference server.
+        result = ctx.run({ 'INPUT__0' : (input0_data,) },
+                         { 'OUTPUT__0' : if_type,
+                           'OUTPUT__1' : if_type },
+                         batch_size)
+
+        # We expect there to be exactly 2 results (each with batch-size 1).
+        # Verify the identity calculated by the model.
+        assert len([ k for k in results.keys() if 'OUTPUT__' in k]) == 2
+        output0_data = result['OUTPUT__0'][0]
+        output1_data = result['OUTPUT__1'][0]
+        if if_type == InferContext.ResultFormat.RAW:
+            assert np.equal(input0_data, output0_data).all() == True
+            assert np.equal(input0_data, output1_data).all() == True
+        else:
+            assert input0_data[0] == output0_data[1]
+            assert input0_data[0] == output1_data[1]
+
+        #  Similarly, this must have 1 o/p
+        input0_data = np.array([-1], dtype=np.int32)
+        result = ctx.run({ 'INPUT__0' : (input0_data,) },
+                         { 'OUTPUT__0' : if_type},
+                         batch_size)
+        assert len([ k for k in results.keys() if 'OUTPUT__' in k]) == 1
+        output0_data = result['OUTPUT__0'][0]
+        if if_type == InferContext.ResultFormat.RAW:
+            assert np.equal(input0_data, output0_data).all() == True
+        else:
+            assert input0_data[0] == output0_data[1]
+
+        #  Similarly, this must have 3 o/p
+        input0_data = np.array([1], dtype=np.int32)
+        result = ctx.run({ 'INPUT__0' : (input0_data,) },
+                         { 'OUTPUT__0' : if_type,
+                           'OUTPUT__1' : if_type,
+                           'OUTPUT__2' : if_type },
+                         batch_size)
+        assert len([ k for k in results.keys() if 'OUTPUT__' in k]) == 3
+        output0_data = result['OUTPUT__0'][0]
+        output1_data = result['OUTPUT__1'][0]
+        output2_data = result['OUTPUT__2'][0]
+        if if_type == InferContext.ResultFormat.RAW:
+            assert np.equal(input0_data, output0_data).all() == True
+            assert np.equal(input0_data, output1_data).all() == True
+            assert np.equal(input0_data, output2_data).all() == True
+        else:
+            assert input0_data[0] == output0_data[1]
+            assert input0_data[0] == output1_data[1]
+            assert input0_data[0] == output2_data[1]
+
+        #  Similarly, this must have 1 2x2 o/p
+        input0_data = np.array([2], dtype=np.int32)
+        result = ctx.run({ 'INPUT__0' : (input0_data,) },
+                         { 'OUTPUT__0' : if_type},
+                         batch_size)
+        assert len([ k for k in results.keys() if 'OUTPUT__' in k]) == 1
+        output0_data = result['OUTPUT__0'][0]
+        if if_type == InferContext.ResultFormat.RAW:
+            assert output0_data.shape == (2,2)
+            assert np.equal(output0_data.flatten(), np.ones(4, dtype=np.int32)).all() == True
+
+        #  Similarly, this must have 1 float o/p
+        input0_data = np.array([3], dtype=np.int32)
+        result = ctx.run({ 'INPUT__0' : (input0_data,) },
+                         { 'OUTPUT__0' : if_type},
+                         batch_size)
+        assert len([ k for k in results.keys() if 'OUTPUT__' in k]) == 1
+        output0_data = result['OUTPUT__0'][0]
+        if if_type == InferContext.ResultFormat.RAW:
+            assert output0_data.dtype == 'float32'
+            assert output0_data[0] == 1.0
+        else:
+            assert output0_data[1] == 1.0

--- a/qa/L0_libtorch_unknown_op/test.sh
+++ b/qa/L0_libtorch_unknown_op/test.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+LIBTORCH_VAR_OP_CLIENT=lt_unknown_op_client.py
+
+DATADIR=/data/inferenceserver
+
+SERVER=/opt/tensorrtserver/bin/trtserver
+SERVER_ARGS=--model-store=$DATADIR/libtorch_unknown_store
+SERVER_LOG="./inference_server.log"
+source ../common/util.sh
+
+run_server
+if [ "$SERVER_PID" == "0" ]; then
+    echo -e "\n***\n*** Failed to start $SERVER\n***"
+    cat $SERVER_LOG
+    exit 1
+fi
+
+RET=0
+CLIENT_LOG=client.log
+rm -f ./client.log
+
+set +e
+for i in \
+        libtorch_zero_unknown_int32 ; do
+    echo "Model: $i" >>$CLIENT_LOG
+    python $LIBTORCH_VAR_OP_CLIENT -m $i >>$CLIENT_LOG 2>&1
+    if [ $? -ne 0 ]; then
+        RET=1
+    fi
+done
+
+set -e
+
+kill $SERVER_PID
+wait $SERVER_PID
+
+if [ $RET -eq 0 ]; then
+    echo -e "\n***\n*** Test Passed\n***"
+else
+    cat $CLIENT_LOG
+    echo -e "\n***\n*** Test FAILED\n***"
+fi
+
+exit $RET

--- a/src/backends/pytorch/libtorch_backend.cc
+++ b/src/backends/pytorch/libtorch_backend.cc
@@ -115,8 +115,9 @@ ConvertTorchTypeToDataType(const torch::ScalarType& ttype)
       return TYPE_FP32;
     case torch::kDouble:
       return TYPE_FP64;
+    default:
+      return TYPE_FP32;
   }
-  return TYPE_FP32;
 }
 
 Status

--- a/src/backends/pytorch/libtorch_backend.cc
+++ b/src/backends/pytorch/libtorch_backend.cc
@@ -633,16 +633,12 @@ LibTorchBackend::Context::Run(
   // Make sure each output is of the expected size and copy it into
   // the payload responses.
 
-
   //  When no Output in Model Config:
-  LOG_VERBOSE(1) << "No. of Output from Config: "
-                 << base->Config().output().size();
   if (base->Config().output().size() == 0) {
     for (size_t i = 0; i < outputs_.size(); i++) {
       torch::ScalarType ttype = outputs_[i].scalar_type();
 
       const std::string& name = "OUTPUT__" + std::to_string(i);
-      LOG_VERBOSE(1) << name + " has dtype: " << ttype;
       const DataType dtype = ConvertTorchTypeToDataType(ttype);
       RETURN_IF_ERROR(ReadFixedSizedOutputTensor(
           &outputs_, name, i, dtype, GetDataTypeByteSize(dtype),

--- a/src/backends/pytorch/libtorch_backend.cc
+++ b/src/backends/pytorch/libtorch_backend.cc
@@ -450,7 +450,7 @@ LibTorchBackend::Context::ReadFixedSizedOutputTensor(
         payload.response_provider_->RequiresOutput(name)) {
       void* buffer;
       Status status = payload.response_provider_->AllocateOutputBuffer(
-          name, &buffer, expected_byte_size, content_shape);
+          name, &buffer, expected_byte_size, content_shape, dtype);
       if (status.IsOk()) {
         if (device_ == torch::kCPU) {
           memcpy(buffer, (char*)content + content_offset, expected_byte_size);

--- a/src/core/backend.cc
+++ b/src/core/backend.cc
@@ -56,7 +56,7 @@ Status
 InferenceBackend::GetOutput(
     const std::string& name, const ModelOutput** output) const
 {
-  if ((output_map_.size() == 0) && (platform_name_ == "pytorch_libtorch")) {
+  if ((output_map_.size() == 0) && (config_.platform() == "pytorch_libtorch")) {
     *output = nullptr;
     return Status::Success;
   } else {
@@ -107,7 +107,6 @@ InferenceBackend::SetModelConfig(
     }
   }
 
-  platform_name_ = config.platform();
   return Status::Success;
 }
 

--- a/src/core/backend.cc
+++ b/src/core/backend.cc
@@ -56,14 +56,20 @@ Status
 InferenceBackend::GetOutput(
     const std::string& name, const ModelOutput** output) const
 {
-  const auto itr = output_map_.find(name);
-  if (itr == output_map_.end()) {
-    return Status(
-        RequestStatusCode::INVALID_ARG, "unexpected inference output '" + name +
-                                            "' for model '" + Name() + "'");
-  }
+  if ((output_map_.size() == 0) && (platform_name_ == "pytorch_libtorch")) {
+    *output = nullptr;
+    return Status::Success;
+  } else {
+    const auto itr = output_map_.find(name);
+    if (itr == output_map_.end()) {
+      return Status(
+          RequestStatusCode::INVALID_ARG, "unexpected inference output '" +
+                                              name + "' for model '" + Name() +
+                                              "'");
+    }
 
-  *output = &itr->second;
+    *output = &itr->second;
+  }
   return Status::Success;
 }
 
@@ -101,6 +107,7 @@ InferenceBackend::SetModelConfig(
     }
   }
 
+  platform_name_ = config.platform();
   return Status::Success;
 }
 

--- a/src/core/backend.h
+++ b/src/core/backend.h
@@ -121,9 +121,6 @@ class InferenceBackend {
 
   // Map from output name to the model configuration for that output.
   std::unordered_map<std::string, ModelOutput> output_map_;
-
-  // Platform name
-  std::string platform_name_;
 };
 
 }}  // namespace nvidia::inferenceserver

--- a/src/core/backend.h
+++ b/src/core/backend.h
@@ -121,6 +121,9 @@ class InferenceBackend {
 
   // Map from output name to the model configuration for that output.
   std::unordered_map<std::string, ModelOutput> output_map_;
+
+  // Platform name
+  std::string platform_name_;
 };
 
 }}  // namespace nvidia::inferenceserver

--- a/src/core/provider.cc
+++ b/src/core/provider.cc
@@ -673,11 +673,11 @@ GRPCInferResponseProvider::MutableResponseHeader()
 Status
 GRPCInferResponseProvider::AllocateOutputBuffer(
     const std::string& name, void** content, size_t content_byte_size,
-    const std::vector<int64_t>& content_shape)
+    const std::vector<int64_t>& content_shape, const DataType dtype)
 {
   Output* output;
   RETURN_IF_ERROR(CheckAndSetIfBufferedOutput(
-      name, content, content_byte_size, content_shape, &output));
+      name, content, content_byte_size, content_shape, &output, dtype));
 
   // Must always add a raw output into the list so that the number and
   // order of raw output entries equals the output meta-data. But
@@ -732,13 +732,13 @@ HTTPInferResponseProvider::MutableResponseHeader()
 Status
 HTTPInferResponseProvider::AllocateOutputBuffer(
     const std::string& name, void** content, size_t content_byte_size,
-    const std::vector<int64_t>& content_shape)
+    const std::vector<int64_t>& content_shape, const DataType dtype)
 {
   *content = nullptr;
 
   Output* output;
   RETURN_IF_ERROR(CheckAndSetIfBufferedOutput(
-      name, content, content_byte_size, content_shape, &output));
+      name, content, content_byte_size, content_shape, &output, dtype));
 
   if ((output->ptr_ == nullptr) && (content_byte_size > 0)) {
     // Reserve requested space in evbuffer...
@@ -811,13 +811,13 @@ DelegatingInferResponseProvider::MutableResponseHeader()
 Status
 DelegatingInferResponseProvider::AllocateOutputBuffer(
     const std::string& name, void** content, size_t content_byte_size,
-    const std::vector<int64_t>& content_shape)
+    const std::vector<int64_t>& content_shape, const DataType dtype)
 {
   *content = nullptr;
 
   Output* output;
   RETURN_IF_ERROR(CheckAndSetIfBufferedOutput(
-      name, content, content_byte_size, content_shape, &output));
+      name, content, content_byte_size, content_shape, &output, dtype));
 
   if ((output->buffer_ == nullptr) && (content_byte_size > 0)) {
     char* buffer = new char[content_byte_size];

--- a/src/core/provider.h
+++ b/src/core/provider.h
@@ -243,7 +243,7 @@ class InferResponseProvider {
   // request. The output must be listed in the request header.
   virtual Status AllocateOutputBuffer(
       const std::string& name, void** content, size_t content_byte_size,
-      const std::vector<int64_t>& content_shape, const DataType dtype) = 0;
+      const std::vector<int64_t>& content_shape, const DataType dtype = TYPE_FP32) = 0;
 
   // Get the address and byte-size of an output buffer. Error is
   // returned if the buffer is not already allocated.
@@ -326,7 +326,7 @@ class InternalInferResponseProvider : public InferResponseProvider {
   InferResponseHeader* MutableResponseHeader() override;
   Status AllocateOutputBuffer(
       const std::string& name, void** content, size_t content_byte_size,
-      const std::vector<int64_t>& content_shape) override;
+      const std::vector<int64_t>& content_shape, const DataType dtype = TYPE_FP32) override;
 
   // Retrieve the data buffer of output 'name'.
   Status GetSystemMemory(
@@ -357,7 +357,7 @@ class GRPCInferResponseProvider : public InferResponseProvider {
   InferResponseHeader* MutableResponseHeader() override;
   Status AllocateOutputBuffer(
       const std::string& name, void** content, size_t content_byte_size,
-      const std::vector<int64_t>& content_shape) override;
+      const std::vector<int64_t>& content_shape, const DataType dtype = TYPE_FP32) override;
 
  private:
   GRPCInferResponseProvider(
@@ -386,7 +386,7 @@ class HTTPInferResponseProvider : public InferResponseProvider {
   InferResponseHeader* MutableResponseHeader() override;
   Status AllocateOutputBuffer(
       const std::string& name, void** content, size_t content_byte_size,
-      const std::vector<int64_t>& content_shape) override;
+      const std::vector<int64_t>& content_shape, const DataType dtype = TYPE_FP32) override;
 
  private:
   HTTPInferResponseProvider(
@@ -412,7 +412,7 @@ class DelegatingInferResponseProvider : public InferResponseProvider {
   InferResponseHeader* MutableResponseHeader() override;
   Status AllocateOutputBuffer(
       const std::string& name, void** content, size_t content_byte_size,
-      const std::vector<int64_t>& content_shape) override;
+      const std::vector<int64_t>& content_shape, const DataType dtype = TYPE_FP32) override;
 
  private:
   DelegatingInferResponseProvider(

--- a/src/core/provider.h
+++ b/src/core/provider.h
@@ -243,7 +243,7 @@ class InferResponseProvider {
   // request. The output must be listed in the request header.
   virtual Status AllocateOutputBuffer(
       const std::string& name, void** content, size_t content_byte_size,
-      const std::vector<int64_t>& content_shape) = 0;
+      const std::vector<int64_t>& content_shape, const DataType dtype) = 0;
 
   // Get the address and byte-size of an output buffer. Error is
   // returned if the buffer is not already allocated.
@@ -275,7 +275,8 @@ class InferResponseProvider {
   // allocate space for it and point to that space with 'content'
   Status CheckAndSetIfBufferedOutput(
       const std::string& name, void** content, size_t content_byte_size,
-      const std::vector<int64_t>& content_shape, Output** output);
+      const std::vector<int64_t>& content_shape, Output** output,
+      const DataType dtype);
 
  protected:
   const InferRequestHeader& request_header_;
@@ -292,6 +293,7 @@ class InferResponseProvider {
     size_t cls_count_;
     void* ptr_;
     size_t byte_size_;
+    DataType dtype_;
 
     // Created buffer for non-RAW results
     std::unique_ptr<char[]> buffer_;

--- a/src/core/provider.h
+++ b/src/core/provider.h
@@ -243,7 +243,8 @@ class InferResponseProvider {
   // request. The output must be listed in the request header.
   virtual Status AllocateOutputBuffer(
       const std::string& name, void** content, size_t content_byte_size,
-      const std::vector<int64_t>& content_shape, const DataType dtype = TYPE_FP32) = 0;
+      const std::vector<int64_t>& content_shape,
+      const DataType dtype = TYPE_FP32) = 0;
 
   // Get the address and byte-size of an output buffer. Error is
   // returned if the buffer is not already allocated.
@@ -326,7 +327,8 @@ class InternalInferResponseProvider : public InferResponseProvider {
   InferResponseHeader* MutableResponseHeader() override;
   Status AllocateOutputBuffer(
       const std::string& name, void** content, size_t content_byte_size,
-      const std::vector<int64_t>& content_shape, const DataType dtype = TYPE_FP32) override;
+      const std::vector<int64_t>& content_shape,
+      const DataType dtype = TYPE_FP32) override;
 
   // Retrieve the data buffer of output 'name'.
   Status GetSystemMemory(
@@ -357,7 +359,8 @@ class GRPCInferResponseProvider : public InferResponseProvider {
   InferResponseHeader* MutableResponseHeader() override;
   Status AllocateOutputBuffer(
       const std::string& name, void** content, size_t content_byte_size,
-      const std::vector<int64_t>& content_shape, const DataType dtype = TYPE_FP32) override;
+      const std::vector<int64_t>& content_shape,
+      const DataType dtype = TYPE_FP32) override;
 
  private:
   GRPCInferResponseProvider(
@@ -386,7 +389,8 @@ class HTTPInferResponseProvider : public InferResponseProvider {
   InferResponseHeader* MutableResponseHeader() override;
   Status AllocateOutputBuffer(
       const std::string& name, void** content, size_t content_byte_size,
-      const std::vector<int64_t>& content_shape, const DataType dtype = TYPE_FP32) override;
+      const std::vector<int64_t>& content_shape,
+      const DataType dtype = TYPE_FP32) override;
 
  private:
   HTTPInferResponseProvider(
@@ -412,7 +416,8 @@ class DelegatingInferResponseProvider : public InferResponseProvider {
   InferResponseHeader* MutableResponseHeader() override;
   Status AllocateOutputBuffer(
       const std::string& name, void** content, size_t content_byte_size,
-      const std::vector<int64_t>& content_shape, const DataType dtype = TYPE_FP32) override;
+      const std::vector<int64_t>& content_shape,
+      const DataType dtype = TYPE_FP32) override;
 
  private:
   DelegatingInferResponseProvider(


### PR DESCRIPTION
- [x] Make the specification of Output in config.pbtxt optional for the LibTorch models
> This allows support for models with variable number of Outputs.
- [ ] Add tests for both Raw and Class based Output

**Note:** If no output is specified in model configuration all the outputs of the model are processed and made available. The client still needs to request for the output he wants. The output naming convention is **OUTPUT_0** ... **OUTPUT_<n-1>** when there are **n** outputs.