### PR TITLE
Fix output validation for LibTorch backend

### DIFF
--- a/src/backends/pytorch/libtorch_backend.cc
+++ b/src/backends/pytorch/libtorch_backend.cc
@@ -613,8 +613,21 @@ LibTorchBackend::Context::Run(
   // Run...
   RETURN_IF_ERROR(Execute(&inputs_, &outputs_));
 
-  // TODO Verify Output shape and number are valid after model execution
+  // TODO Verify Output shape and datatype after model execution
 
+  for (const auto& output : base->Config().output()) {
+    const std::string& name = output.name();
+    std::string index_str = name.substr(name.find(deliminator) + 2);
+    int op_index = std::atoi(index_str.c_str());
+    if ((op_index < 0) || (op_index >= outputs_.size())) {
+      return Status(
+          RequestStatusCode::INVALID_ARG,
+          "The output " + name +
+              " in the model config refers to an output index which doesn't "
+              "exist. This model has " +
+              std::to_string(outputs_.size() - 1) + " outputs");
+    }
+  }
   // Prepare set of Outputs requested for
   std::set<std::string> required_outputs;
   for (auto& payload : *payloads) {

--- a/src/backends/pytorch/libtorch_backend.cc
+++ b/src/backends/pytorch/libtorch_backend.cc
@@ -613,12 +613,22 @@ LibTorchBackend::Context::Run(
   // Run...
   RETURN_IF_ERROR(Execute(&inputs_, &outputs_));
 
+  // TODO Verify Output shape and number are valid after model execution
+
+  // Prepare set of Outputs requested for
+  std::set<std::string> required_outputs;
+  for (auto& payload : *payloads) {
+    const InferRequestHeader& request_header =
+        payload.request_provider_->RequestHeader();
+    for (const auto& output : request_header.output()) {
+      required_outputs.insert(output.name());
+    }
+  }
+
   // Make sure each output is of the expected size and copy it into
   // the payload responses.
-  for (const auto& output : base->Config().output()) {
-    const std::string& name = output.name();
+  for (const auto& name : required_outputs) {
     std::string index_str = name.substr(name.find(deliminator) + 2);
-
     int op_index = std::atoi(index_str.c_str());
 
     const ModelOutput* output_config;

--- a/src/backends/pytorch/libtorch_backend.cc
+++ b/src/backends/pytorch/libtorch_backend.cc
@@ -496,11 +496,10 @@ LibTorchBackend::Context::GetOutputTensor(
     DataType rec_dtype = ConvertTorchTypeToDataType(output_flat.scalar_type());
     if (dtype != rec_dtype) {
       return Status(
-          RequestStatusCode::INTERNAL,
-          "DataType " + DataType_Name(rec_dtype) +
-              " does not match expected DataType " + DataType_Name(dtype) +
-              " (for OUTPUT__" + std::to_string(op_index) +
-              ") specified in model config");
+          RequestStatusCode::INVALID_ARG,
+          "unexpected datatype " + DataType_Name(rec_dtype) +
+              " for inference output 'OUTPUT__" + std::to_string(op_index) +
+              "', expecting " + DataType_Name(dtype));
     }
 
     *byte_size = output_flat.nbytes();

--- a/src/backends/pytorch/libtorch_backend.cc
+++ b/src/backends/pytorch/libtorch_backend.cc
@@ -707,10 +707,17 @@ LibTorchBackend::Context::Run(
     // Checked at initialization time to make sure that STRING is not
     // being used for an output, so can just assume fixed-sized here.
     const DataType dtype = output_config->data_type();
+
+    // If a reshape is provided for the input then use that when
+    // validating that the model matches what is expected.
+    const DimsList& output_dims = (output_config->has_reshape())
+                                      ? output_config->reshape().shape()
+                                      : output_config->dims();
+
     RETURN_IF_ERROR(ReadFixedSizedOutputTensor(
         &outputs_, name, op_index, dtype,
         GetDataTypeByteSize(output_config->data_type()), total_batch_size,
-        payloads, output_config->dims()));
+        payloads, output_dims));
   }
 
   return Status::Success;

--- a/src/backends/pytorch/libtorch_backend.h
+++ b/src/backends/pytorch/libtorch_backend.h
@@ -125,8 +125,8 @@ class LibTorchBackend : public InferenceBackend {
 
     Status GetOutputTensor(
         std::vector<torch::Tensor>* outputs_, const int& op_index,
-        const DataType dtype, void** content, size_t* byte_size,
-        std::vector<int64_t>* content_shape);
+        const std::string& name, const DataType dtype, void** content,
+        size_t* byte_size, std::vector<int64_t>* content_shape);
 
     Status Execute(
         std::vector<torch::jit::IValue>* inputs_,

--- a/src/backends/pytorch/libtorch_backend.h
+++ b/src/backends/pytorch/libtorch_backend.h
@@ -142,9 +142,8 @@ class LibTorchBackend : public InferenceBackend {
     int max_batch_size_;
 
     std::shared_ptr<torch::jit::script::Module> torch_model_;
-    std::vector<torch::jit::IValue> inputs_;
-    std::vector<torch::Tensor> outputs_;
     torch::Device device_;
+    std::unordered_map<std::string, int> io_index_map_;
   };
 
   std::vector<std::unique_ptr<Context>> contexts_;

--- a/src/backends/pytorch/libtorch_backend.h
+++ b/src/backends/pytorch/libtorch_backend.h
@@ -143,7 +143,8 @@ class LibTorchBackend : public InferenceBackend {
 
     std::shared_ptr<torch::jit::script::Module> torch_model_;
     torch::Device device_;
-    std::unordered_map<std::string, int> io_index_map_;
+    std::unordered_map<std::string, int> input_index_map_;
+    std::unordered_map<std::string, int> output_index_map_;
   };
 
   std::vector<std::unique_ptr<Context>> contexts_;

--- a/src/backends/pytorch/libtorch_backend.h
+++ b/src/backends/pytorch/libtorch_backend.h
@@ -116,7 +116,7 @@ class LibTorchBackend : public InferenceBackend {
         std::vector<torch::Tensor>* outputs_, const std::string& name,
         const int& op_index, const DataType dtype, const size_t dtype_byte_size,
         const size_t total_batch_size,
-        std::vector<Scheduler::Payload>* payloads);
+        std::vector<Scheduler::Payload>* payloads, const DimsList& dims);
 
     Status SetInputTensor(
         std::vector<torch::jit::IValue>* inputs_, const std::string& name,


### PR DESCRIPTION
- [x] Extract model outputs only for the **Requested outputs** (Subset of those in model config).
- [x] Check **Datatype** of outputs after execution with that from model config.
- [x] Check **Shape** of outputs after execution with that from model config.
- [x] Check **Index** of outputs is valid for the number of outputs after execution.