### PR TITLE
Always check input/output signature to verify batching support

### DIFF
--- a/src/backends/tensorflow/autofill.cc
+++ b/src/backends/tensorflow/autofill.cc
@@ -75,21 +75,17 @@ AutoFillSavedModelImpl::Fix(ModelConfig* config)
   // Assume model doesn't support batching unless we see a batch
   // dimension (-1) on signature of every model input and output.
   bool sig_supports_batch = true;
-  if (config->input().size() == 0) {
-    for (const TRTISTF_IOList* itr = inputs; itr != nullptr; itr = itr->next_) {
-      TRTISTF_IO* io = itr->io_;
-      if ((io->shape_->rank_ == 0) || (io->shape_->dims_[0] != -1)) {
-        sig_supports_batch = false;
-      }
+  for (const TRTISTF_IOList* itr = inputs; itr != nullptr; itr = itr->next_) {
+    TRTISTF_IO* io = itr->io_;
+    if ((io->shape_->rank_ == 0) || (io->shape_->dims_[0] != -1)) {
+      sig_supports_batch = false;
     }
   }
-  if (config->output().size() == 0) {
-    for (const TRTISTF_IOList* itr = outputs; itr != nullptr;
-         itr = itr->next_) {
-      TRTISTF_IO* io = itr->io_;
-      if ((io->shape_->rank_ == 0) || (io->shape_->dims_[0] != -1)) {
-        sig_supports_batch = false;
-      }
+  for (const TRTISTF_IOList* itr = outputs; itr != nullptr;
+        itr = itr->next_) {
+    TRTISTF_IO* io = itr->io_;
+    if ((io->shape_->rank_ == 0) || (io->shape_->dims_[0] != -1)) {
+      sig_supports_batch = false;
     }
   }
 


### PR DESCRIPTION
Before this change, server that starts with `--strict-model-config=false` will fail to load a non-batch model that contains full config.pbtxt. Its `max_batch_size` will be overwritten to 1. Can reproduce with one of the QA non-batch saved model