### PR TITLE
Verify all backends get o/p datatype from model output

### DIFF
--- a/src/backends/onnx/onnx_backend.cc
+++ b/src/backends/onnx/onnx_backend.cc
@@ -322,9 +322,9 @@ OnnxBackend::Context::ValidateInputs(
     } else if (onnx_data_type != iit->second.type_) {
       return Status(
           RequestStatusCode::INVALID_ARG,
-          "unable to load model '" + model_name + "', input '" + io.name() +
-              "' data-type " + OnnxDataTypeName(iit->second.type_) +
-              " doesn't match configuration data-type " +
+          "unable to load model '" + model_name + ", unexpected datatype " +
+              DataType_Name(ConvertFromOnnxDataType(iit->second.type_)) +
+              " for input '" + io.name() + "', expecting " +
               DataType_Name(io.data_type()));
     }
 
@@ -365,9 +365,9 @@ OnnxBackend::Context::ValidateOutputs(
     } else if (onnx_data_type != iit->second.type_) {
       return Status(
           RequestStatusCode::INVALID_ARG,
-          "unable to load model '" + model_name + "', output '" + io.name() +
-              "' data-type " + OnnxDataTypeName(iit->second.type_) +
-              " doesn't match configuration data-type " +
+          "unable to load model '" + model_name + ", unexpected datatype " +
+              DataType_Name(ConvertFromOnnxDataType(iit->second.type_)) +
+              " for output '" + io.name() + "', expecting " +
               DataType_Name(io.data_type()));
     }
 

--- a/src/backends/tensorrt/plan_backend.cc
+++ b/src/backends/tensorrt/plan_backend.cc
@@ -352,17 +352,17 @@ PlanBackend::Context::InitializeInputBinding(
         RequestStatusCode::INVALID_ARG,
         "unexpected datatype " + DataType_Name(dt) +
             " for input '" + input_name + "', expecting " +
-            DataType_Name(input_datatype);
+            DataType_Name(input_datatype));
   }
 
   nvinfer1::Dims engine_dims = engine_->getBindingDimensions(index);
   if (!CompareDims(engine_dims, model_config_dims)) {
     return Status(
         RequestStatusCode::INVALID_ARG,
-        "unexpected shape for input '" + io.name() +
+        "unexpected shape for input '" + input_name +
             "', model configuration shape is " +
             DimsListToString(model_config_dims) + ", inference shape is " +
-            DimsListToString(engine_dims));
+            DimsDebugString(engine_dims));
   }
 
   const int64_t byte_size = GetByteSize(max_batch_size_, dt, model_config_dims);
@@ -480,7 +480,7 @@ PlanBackend::Context::InitializeConfigOutputBindings(
           "unexpected shape for output '" + io.name() +
               "', model configuration shape is " +
               DimsListToString(model_config_dims) + ", inference shape is " +
-              DimsListToString(engine_dims));
+              DimsDebugString(engine_dims));
     }
 
     const int64_t byte_size =

--- a/src/backends/tensorrt/plan_backend.cc
+++ b/src/backends/tensorrt/plan_backend.cc
@@ -350,18 +350,19 @@ PlanBackend::Context::InitializeInputBinding(
   if (dt != input_datatype) {
     return Status(
         RequestStatusCode::INVALID_ARG,
-        "input '" + input_name + "' datatype is " +
-            DataType_Name(input_datatype) + ", model specifies " +
-            DataType_Name(dt) + " for " + name_);
+        "unexpected datatype " + DataType_Name(dt) +
+            " for input '" + input_name + "', expecting " +
+            DataType_Name(input_datatype);
   }
 
   nvinfer1::Dims engine_dims = engine_->getBindingDimensions(index);
   if (!CompareDims(engine_dims, model_config_dims)) {
     return Status(
         RequestStatusCode::INVALID_ARG,
-        "input '" + input_name + "' dims " + DimsDebugString(engine_dims) +
-            " don't match configuration dims " +
-            DimsListToString(model_config_dims) + " for " + name_);
+        "unexpected shape for input '" + io.name() +
+            "', model configuration shape is " +
+            DimsListToString(model_config_dims) + ", inference shape is " +
+            DimsListToString(engine_dims));
   }
 
   const int64_t byte_size = GetByteSize(max_batch_size_, dt, model_config_dims);
@@ -464,9 +465,9 @@ PlanBackend::Context::InitializeConfigOutputBindings(
     if (dt != io.data_type()) {
       return Status(
           RequestStatusCode::INVALID_ARG,
-          "output '" + io.name() + "' datatype is " +
-              DataType_Name(io.data_type()) + ", model specifies " +
-              DataType_Name(dt) + " for " + name_);
+          "unexpected datatype " + DataType_Name(dt) +
+              " for inference output '" + io.name() + "', expecting " +
+              DataType_Name(io.data_type()));
     }
 
     const DimsList& model_config_dims =
@@ -476,9 +477,10 @@ PlanBackend::Context::InitializeConfigOutputBindings(
     if (!CompareDims(engine_dims, model_config_dims)) {
       return Status(
           RequestStatusCode::INVALID_ARG,
-          "output '" + io.name() + "' dims " + DimsDebugString(engine_dims) +
-              " don't match configuration dims " +
-              DimsListToString(model_config_dims) + " for " + name_);
+          "unexpected shape for output '" + io.name() +
+              "', model configuration shape is " +
+              DimsListToString(model_config_dims) + ", inference shape is " +
+              DimsListToString(engine_dims));
     }
 
     const int64_t byte_size =


### PR DESCRIPTION
Fix output datatpe mismatch error messages for consistency across all backends.
Verified all backends rely on model output for datatype (either during Init or Runtime)