### PR TITLE
Update model config in example model store

### DIFF
--- a/docs/examples/model_repository/densenet_onnx/config.pbtxt
+++ b/docs/examples/model_repository/densenet_onnx/config.pbtxt
@@ -1,12 +1,13 @@
 name: "densenet_onnx"
 platform: "onnxruntime_onnx"
-max_batch_size : 1
+max_batch_size : 0
 input [
   {
     name: "data_0"
     data_type: TYPE_FP32
     format: FORMAT_NCHW
     dims: [ 3, 224, 224 ]
+    reshape { shape: [ 1, 3, 224, 224 ] }
   }
 ]
 output [
@@ -14,7 +15,7 @@ output [
     name: "fc6_1"
     data_type: TYPE_FP32
     dims: [ 1000 ]
-    reshape { shape: [ 1000, 1, 1 ] }
+    reshape { shape: [ 1, 1000, 1, 1 ] }
     label_filename: "densenet_labels.txt"
   }
 ]


### PR DESCRIPTION
The ONNX model downloaded from ONNX model zoo has batch dimension 1 while TRTIS only allows batch dimension to be -1. So use reshape and set max_batch_size to be 0.