### PR TITLE
Remove duplicate percentile report. Fix underflow in "network misc" repot.

### DIFF
--- a/src/clients/c++/perf_client.cc
+++ b/src/clients/c++/perf_client.cc
@@ -1396,7 +1396,11 @@ InferenceProfiler::SummarizeLatency(
 
   // retrieve other interesting percentile
   summary.client_percentile_latency_ns.clear();
-  std::set<size_t> percentiles{50, 90, 95, 99, percentile_};
+  std::set<size_t> percentiles{50, 90, 95, 99};
+  if (extra_percentile_) {
+    percentiles.emplace(percentile_);
+  }
+  
   for (const auto percentile : percentiles) {
     size_t index = (percentile / 100.0) * (latencies.size() - 1) + 0.5;
     summary.client_percentile_latency_ns.emplace(percentile, latencies[index]);


### PR DESCRIPTION
Report percentiles in increment order, including user specified percentile.

<details><summary>p90 (duplicate percentile)</summary><p>

csv
```
Concurrency,Inferences/Second,Client Send,Network+Server Send/Recv,Server Queue,Server Compute,Client Recv,p50 latency,p90 latency,p95 latency,p99 latency
1,101,296,1102,48,8369,10,9889,10743,10796,10976
```
output
```
root@d3c067c510bb:/opt/tensorrtserver# qa/clients/perf_client -m resnet50_netdef -p 5000 -v --percentile 90 -d -f p90.csv
*** Measurement Settings ***
  Batch size: 1
  Measurement window: 5000 msec
  Latency limit: 0 msec
  Stabilizing using p90 latency

Request concurrency: 1
  Pass [1] throughput: 92 infer/sec. p90 latency: 11091 usec
  Pass [2] throughput: 99 infer/sec. p90 latency: 10884 usec
  Pass [3] throughput: 117 infer/sec. p90 latency: 10671 usec
  Pass [4] throughput: 99 infer/sec. p90 latency: 10869 usec
  Pass [5] throughput: 99 infer/sec. p90 latency: 10364 usec
  Pass [6] throughput: 101 infer/sec. p90 latency: 10743 usec
  Client: 
    Request count: 508
    Throughput: 101 infer/sec
    p50 latency: 9889 usec
    p90 latency: 10743 usec
    p95 latency: 10796 usec
    p99 latency: 10976 usec
    Avg HTTP time: 9776 usec (send 296 usec + response wait 9470 usec + receive 10 usec)
  Server: 
    Request count: 607
    Avg request latency: 8478 usec (overhead 61 usec + queue 48 usec + compute 8369 usec)

[ 0] SUCCESS
Inferences/Second vs. Client p90 Batch Latency
Concurrency: 1, 101 infer/sec, latency 10743 usec
```

</p></details>

<details><summary>p88 (sorted)</summary><p>

csv
```
Concurrency,Inferences/Second,Client Send,Network+Server Send/Recv,Server Queue,Server Compute,Client Recv,p50 latency,p88 latency,p90 latency,p95 latency,p99 latency
1,97,281,1293,56,8641,10,10695,10922,10940,11025,11248
```
output
```
root@d3c067c510bb:/opt/tensorrtserver# qa/clients/perf_client -m resnet50_netdef -p 5000 -v --percentile 88 -d -f p88.csv
*** Measurement Settings ***
  Batch size: 1
  Measurement window: 5000 msec
  Latency limit: 0 msec
  Stabilizing using p88 latency

Request concurrency: 1
  Pass [1] throughput: 97 infer/sec. p88 latency: 10898 usec
  Pass [2] throughput: 127 infer/sec. p88 latency: 7937 usec
  Pass [3] throughput: 108 infer/sec. p88 latency: 10853 usec
  Pass [4] throughput: 94 infer/sec. p88 latency: 10922 usec
  Pass [5] throughput: 97 infer/sec. p88 latency: 10922 usec
  Client: 
    Request count: 485
    Throughput: 97 infer/sec
    p50 latency: 10695 usec
    p88 latency: 10922 usec
    p90 latency: 10940 usec
    p95 latency: 11025 usec
    p99 latency: 11248 usec
    Avg HTTP time: 10075 usec (send 281 usec + response wait 9784 usec + receive 10 usec)
  Server: 
    Request count: 590
    Avg request latency: 8759 usec (overhead 62 usec + queue 56 usec + compute 8641 usec)

[ 0] SUCCESS
Inferences/Second vs. Client p88 Batch Latency
Concurrency: 1, 97 infer/sec, latency 10922 usec
```

</p></details>