### PR TITLE
Code change for compilation on JetPack 4.2

### DIFF
--- a/src/backends/tensorrt/CMakeLists.txt
+++ b/src/backends/tensorrt/CMakeLists.txt
@@ -57,4 +57,6 @@ add_dependencies(tensorrt-backend-library proto-library)
 
 if(${TRTIS_ENABLE_GPU})
   target_include_directories(tensorrt-backend-library PRIVATE ${CUDA_INCLUDE_DIRS})
+  target_include_directories(tensorrt-backend-library PRIVATE "/usr/include/aarch64-linux-gpu")
+  target_link_directories(tensorrt-backend-library PRIVATE "/usr/lib/aarch64-linux-gnu")
 endif() # TRTIS_ENABLE_GPU

--- a/src/backends/tensorrt/logging.cc
+++ b/src/backends/tensorrt/logging.cc
@@ -48,9 +48,12 @@ TensorRTLogger::log(Severity severity, const char* msg)
     case Severity::kINFO:
       LOG_INFO << msg;
       break;
+// Unavailable in trt 5063
+#ifdef TENSORRT_5142
     case Severity::kVERBOSE:
       LOG_VERBOSE(1) << msg;
       break;
+#endif
   }
 }
 

--- a/src/backends/tensorrt/plan_backend.cc
+++ b/src/backends/tensorrt/plan_backend.cc
@@ -303,6 +303,8 @@ PlanBackend::CreateExecutionContext(
   // sizes. Graphs are most likely to help for small batch sizes so by
   // default build for batch sizes 1, 2, 3, 4, 6, 8, 12, 16. If any
   // build fails don't attempt for any larger batch sizes.
+// Cuda graph is not supported in CUDA 10.0
+#ifdef CUDA_1001
   const bool use_cuda_graphs = Config().optimization().cuda().graphs();
   if (use_cuda_graphs) {
     if (context->BuildCudaGraph(1)) {
@@ -315,6 +317,7 @@ PlanBackend::CreateExecutionContext(
       }
     }
   }
+#endif
 
   LOG_INFO << "Created instance " << instance_name << " on GPU " << gpu_device
            << " (" << cc << ") with stream priority " << cuda_stream_priority;
@@ -576,6 +579,8 @@ PlanBackend::Run(
   OnCompleteQueuedPayloads(contexts_[runner_idx]->Run(payloads));
 }
 
+// Cuda graph is not supported in CUDA 10.0
+#ifdef CUDA_1001
 bool
 PlanBackend::Context::BuildCudaGraph(const int batch_size)
 {
@@ -617,6 +622,7 @@ PlanBackend::Context::BuildCudaGraph(const int batch_size)
 
   return captured;
 }
+#endif
 
 Status
 PlanBackend::Context::Run(std::vector<Scheduler::Payload>* payloads)

--- a/src/core/model_repository_manager.h
+++ b/src/core/model_repository_manager.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <mutex>
+#include <functional>
 #include "src/core/model_config.h"
 #include "src/core/model_config.pb.h"
 #include "src/core/server_status.pb.h"

--- a/src/core/provider.cc
+++ b/src/core/provider.cc
@@ -24,6 +24,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#include <numeric>
 #include "src/core/provider.h"
 
 #include "src/core/backend.h"
@@ -279,7 +280,7 @@ AddClassResults(
   std::vector<size_t> idx(entry_cnt);
 
   for (size_t i = 0; i < batch_size; ++i) {
-    iota(idx.begin(), idx.end(), 0);
+    std::iota(idx.begin(), idx.end(), 0);
     sort(idx.begin(), idx.end(), [&probs](size_t i1, size_t i2) {
       return probs[i1] > probs[i2];
     });

--- a/src/nvrpc/ThreadPool.h
+++ b/src/nvrpc/ThreadPool.h
@@ -60,6 +60,7 @@
 
 #include <future>
 #include <queue>
+#include <functional>
 
 namespace nvrpc {
 


### PR DESCRIPTION
(note: this PR is just a proof of concept, not meant for merge, at least for now)

### Basic code change:
1. Add missing header for `gcc (Ubuntu/Linaro 7.4.0-1ubuntu1~18.04.1) 7.4.0`
2. Remove codes unsupported on CUDA 10.0 and TensorRT 5.0.6.3
3. Supply libraries and headers during compile time and runtime

### Compilation steps:
1. Install necessary packages
`sudo apt-get install libcurl4-openssl-dev pkg-config libssl-dev libre2-dev`
2. Native compile cmake 3.14
follow instructions on https://cmake.org/install/
3. Follow cmake build instructions https://docs.nvidia.com/deeplearning/sdk/tensorrt-inference-server-master-branch-guide/docs/build.html#configure-inference-server
```
mkdir builddir
cd builddir
cmake -DTRTIS_ENABLE_TENSORRT=ON -DTRTIS_ENABLE_GPU=ON ../build
make -j16 trtis ; make -j16 trtis
```
4. Server launch instructions.
`LD_PRELOAD=/usr/local/cuda/targets/aarch64-linux/lib/stubs/libnvidia-ml.so LD_LIBRARY_PATH=$LD_LIBRARY_PATH:../lib ./trtserver --model-store=/your/model/store`

### Known issues:
1. gRPC protocol gives error
`tensorrtserver.api.InferenceServerException: [ 0] GRPC client failed: 14: Socket closed`
2. Have not tried docker
nvidia-docker does not work on Jetpack yet: https://github.com/NVIDIA/nvidia-docker/issues/214#issuecomment-499595584
3. `libnvidia-ml.so` complaints
```
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
WARNING:

You should always run with libnvidia-ml.so that is installed with your
NVIDIA Display Driver. By default it's installed in /usr/lib and /usr/lib64.
libnvidia-ml.so in GDK package is a stub library that is attached only for
build purposes (e.g. machine that you build your application doesn't have
to have Display Driver installed).
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
E0625 22:25:13.589567 14175 metrics.cc:348] failed to get device from PCI Bus ID: NVML_ERROR 1
```
