### PR TITLE
Support for using system Shared Memory for I/O 

### DIFF
--- a/src/core/api.proto
+++ b/src/core/api.proto
@@ -94,6 +94,24 @@ message InferRequestHeader
     //@@       for tensors with a non-fixed-size datatype (like STRING).
     //@@
     uint64 batch_byte_size = 3;
+
+    //@@  .. cpp:var:: message SharedMemoryIO
+    //@@
+    //@@     Unique identity of the location in shared memory to read input
+    //@@     tensors. If present, do no provide the data directly in the request
+    //@@     payload, it will be ignored. User responsible for the creation,
+    //@@     deletion and writing to shared memory.
+    //@@
+    message SharedMemoryIO
+    {
+      //@@    .. cpp:var:: key_t shm_key
+      //@@
+      //@@     The unique key used to refer to a specific location in shared
+      //@@     memory. Optional for tensors. Required to read tensors from
+      //@@     shared memory. If provided, tensor data read from this location.
+      //@@
+      key_t shm_key = 1;
+    }
   }
 
   //@@  .. cpp:var:: message Output
@@ -132,6 +150,23 @@ message InferRequestHeader
     //@@       highest probabilities will be returned.
     //@@
     Class cls = 3;
+
+    //@@  .. cpp:var:: message SharedMemoryIO
+    //@@
+    //@@     Unique identity of the location in shared memory to write output
+    //@@     tensors. User responsible for the creation, deletion and reading
+    //@@     from shared memory.
+    //@@
+    message SharedMemoryIO
+    {
+      //@@    .. cpp:var:: key_t shm_key
+      //@@
+      //@@     The unique key used to refer to a specific location in shared
+      //@@     memory. Optional for tensors. Required to write tensors to
+      //@@     shared memory. If provided, tensor data read from this location.
+      //@@
+      key_t shm_key = 1;
+    }
   }
 
   //@@  .. cpp:var:: uint64 id
@@ -269,7 +304,8 @@ message InferResponseHeader
     //@@       If specified deliver results for this output as raw tensor data.
     //@@       The actual output data is delivered in the HTTP body for an HTTP
     //@@       request, or in the :cpp:var:`InferResponse` message for a gRPC
-    //@@       request. Only one of 'raw' and 'batch_classes' may be specified.
+    //@@       request. Only one of 'raw', 'batch_classes' and 'SharedMemoryIO'
+    //@@       may be specified.
     //@@
     Raw raw = 2;
 
@@ -277,10 +313,27 @@ message InferResponseHeader
     //@@
     //@@       If specified deliver results for this output as classifications.
     //@@       There is one :cpp:var:`Classes` object for each batch entry in
-    //@@       the output. Only one of 'raw' and 'batch_classes' may be
-    //@@       specified.
+    //@@       the output. Only one of 'raw', 'batch_classes' and
+    //@@       'SharedMemoryIO' may be specified.
     //@@
     repeated Classes batch_classes = 3;
+
+    //@@  .. cpp:var:: message SharedMemoryIO
+    //@@
+    //@@     Unique identity of the location in shared memory to write output
+    //@@     tensors. User responsible for the creation, deletion and reading
+    //@@     from shared memory.
+    //@@
+    message SharedMemoryIO
+    {
+      //@@    .. cpp:var:: key_t shm_key
+      //@@
+      //@@     The unique key used to refer to a specific location in shared
+      //@@     memory. Optional for tensors. Required to write tensors to
+      //@@     shared memory. If provided, tensor data read from this location.
+      //@@
+      key_t shm_key = 1;
+    }
   }
 
   //@@  .. cpp:var:: uint64 id

--- a/src/core/api.proto
+++ b/src/core/api.proto
@@ -111,6 +111,16 @@ message InferRequestHeader
       //@@     shared memory. If provided, tensor data read from this location.
       //@@
       key_t shm_key = 1;
+
+      //@@    .. cpp:var:: key_t shm_key
+      //@@
+      //@@     The offset for the next element in the batch. Only required if
+      //@@     batch_size > 1. n-1 offsets required (we know first element has
+      //@@     offset of 0), where n is number of elements in the batch.
+      //@@     element0 start = 0, end = offset0;
+      //@@     element1 start = offset0, end = offset1; and so on.
+      //@@
+      repeated uint64 offset = 1;
     }
   }
 
@@ -166,6 +176,16 @@ message InferRequestHeader
       //@@     shared memory. If provided, tensor data read from this location.
       //@@
       key_t shm_key = 1;
+
+      //@@    .. cpp:var:: key_t shm_key
+      //@@
+      //@@     The offset for the next element in the batch. Only required if
+      //@@     batch_size > 1. n-1 offsets required (we know first element has
+      //@@     offset of 0), where n is number of elements in the batch.
+      //@@     element0 start = 0, end = offset0;
+      //@@     element1 start = offset0, end = offset1; and so on.
+      //@@
+      repeated uint64 offset = 1;
     }
   }
 
@@ -333,6 +353,16 @@ message InferResponseHeader
       //@@     shared memory. If provided, tensor data read from this location.
       //@@
       key_t shm_key = 1;
+
+      //@@    .. cpp:var:: key_t shm_key
+      //@@
+      //@@     The offset for the next element in the batch. Only required if
+      //@@     batch_size > 1. n-1 offsets required (we know first element has
+      //@@     offset of 0), where n is number of elements in the batch.
+      //@@     element0 start = 0, end = offset0;
+      //@@     element1 start = offset0, end = offset1; and so on.
+      //@@
+      repeated uint64 offset = 1;
     }
   }
 

--- a/src/core/api.proto
+++ b/src/core/api.proto
@@ -95,14 +95,11 @@ message InferRequestHeader
     //@@
     uint64 batch_byte_size = 3;
 
-    //@@  .. cpp:var:: message SharedMemoryIO
+    //@@      .. cpp:var:: message SharedMemoryElement
     //@@
-    //@@     Unique identity of the location in shared memory to read input
-    //@@     tensors. If present, do no provide the data directly in the request
-    //@@     payload, it will be ignored. User responsible for the creation,
-    //@@     deletion and writing to shared memory.
+    //@@         The Meta-data for the Input shared memory to read element from.
     //@@
-    message SharedMemoryIO
+    message SharedMemoryElement
     {
       //@@    .. cpp:var:: key_t shm_key
       //@@
@@ -112,16 +109,40 @@ message InferRequestHeader
       //@@
       key_t shm_key = 1;
 
-      //@@    .. cpp:var:: key_t shm_key
+      //@@    .. cpp:var:: uint64 offset
       //@@
-      //@@     The offset for the next element in the batch. Only required if
-      //@@     batch_size > 1. n-1 offsets required (we know first element has
-      //@@     offset of 0), where n is number of elements in the batch.
-      //@@     element0 start = 0, end = offset0;
-      //@@     element1 start = offset0, end = offset1; and so on.
+      //@@     The offset for the each element.
+      //@@     element0 start = offset0, end = offset0 + size;
       //@@
-      repeated uint64 offset = 1;
+      uint64 offset = 2;
+
+      //@@    .. cpp:var:: uint64 byte_size
+      //@@
+      //@@     Size of the element in the batch of the input tensor, in bytes.
+      //@@
+      uint64 byte_size = 3;
     }
+
+    //@@    .. cpp:var:: message SharedMemoryIO
+    //@@
+    //@@       Meta-data for an input batch to be read from shared memory.
+    //@@
+    message SharedMemoryIO
+    {
+      //@@      .. cpp:var:: SharedMemoryElement element (repeated)
+      //@@
+      //@@         No. of elements required is number of elements in the batch.
+      //@@
+      repeated SharedMemoryElement element = 1;
+    }
+
+    //@@    .. cpp:var:: SharedMemoryIO shm_io
+    //@@
+    //@@       Unique identity of the location in shared memory to read input
+    //@@       tensors. User responsible for the creation, deletion and writing
+    //@@       to shared memory. If specified, input data is read from here.
+    //@@
+    SharedMemoryIO shm_io = 4;
   }
 
   //@@  .. cpp:var:: message Output
@@ -161,32 +182,54 @@ message InferRequestHeader
     //@@
     Class cls = 3;
 
-    //@@  .. cpp:var:: message SharedMemoryIO
+    //@@      .. cpp:var:: message SharedMemoryElement
     //@@
-    //@@     Unique identity of the location in shared memory to write output
-    //@@     tensors. User responsible for the creation, deletion and reading
-    //@@     from shared memory.
+    //@@         The Meta-data for the Output shared memory to write element to.
     //@@
-    message SharedMemoryIO
+    message SharedMemoryElement
     {
       //@@    .. cpp:var:: key_t shm_key
       //@@
       //@@     The unique key used to refer to a specific location in shared
       //@@     memory. Optional for tensors. Required to write tensors to
-      //@@     shared memory. If provided, tensor data read from this location.
+      //@@     shared memory. If provided, tensor data written to this location.
       //@@
       key_t shm_key = 1;
 
-      //@@    .. cpp:var:: key_t shm_key
+      //@@    .. cpp:var:: uint64 offset
       //@@
-      //@@     The offset for the next element in the batch. Only required if
-      //@@     batch_size > 1. n-1 offsets required (we know first element has
-      //@@     offset of 0), where n is number of elements in the batch.
-      //@@     element0 start = 0, end = offset0;
-      //@@     element1 start = offset0, end = offset1; and so on.
+      //@@     The offset for the each element.
+      //@@     element0 start = offset0, end = offset0 + size;
       //@@
-      repeated uint64 offset = 1;
+      uint64 offset = 2;
+
+      //@@    .. cpp:var:: uint64 byte_size
+      //@@
+      //@@     Size of the element in the batch of the input tensor, in bytes.
+      //@@
+      uint64 byte_size = 3;
     }
+
+    //@@    .. cpp:var:: message SharedMemoryIO
+    //@@
+    //@@       Meta-data for an output batch to be written to shared memory.
+    //@@
+    message SharedMemoryIO
+    {
+      //@@      .. cpp:var:: SharedMemoryElement element (repeated)
+      //@@
+      //@@         No. of elements required is number of elements in the batch.
+      //@@
+      repeated SharedMemoryElement element = 1;
+    }
+
+    //@@    .. cpp:var:: SharedMemoryIO shm_io
+    //@@
+    //@@       Unique identity of the location in shared memory to write output
+    //@@       tensors. User responsible for the creation, deletion and reading
+    //@@       from shared memory. If specified, output data is written to here.
+    //@@
+    SharedMemoryIO shm_io = 4;
   }
 
   //@@  .. cpp:var:: uint64 id
@@ -324,8 +367,9 @@ message InferResponseHeader
     //@@       If specified deliver results for this output as raw tensor data.
     //@@       The actual output data is delivered in the HTTP body for an HTTP
     //@@       request, or in the :cpp:var:`InferResponse` message for a gRPC
-    //@@       request. Only one of 'raw', 'batch_classes' and 'SharedMemoryIO'
-    //@@       may be specified.
+    //@@       request. Only one of 'raw' and 'batch_classes' may be
+    //@@       specified. If 'SharedMemoryIO' is present in request then
+    //@@       neither is specified.
     //@@
     Raw raw = 2;
 
@@ -333,37 +377,11 @@ message InferResponseHeader
     //@@
     //@@       If specified deliver results for this output as classifications.
     //@@       There is one :cpp:var:`Classes` object for each batch entry in
-    //@@       the output. Only one of 'raw', 'batch_classes' and
-    //@@       'SharedMemoryIO' may be specified.
+    //@@       the output. Only one of 'raw' and 'batch_classes' may be
+    //@@       specified. If 'SharedMemoryIO' is present in request then
+    //@@       neither is specified.
     //@@
     repeated Classes batch_classes = 3;
-
-    //@@  .. cpp:var:: message SharedMemoryIO
-    //@@
-    //@@     Unique identity of the location in shared memory to write output
-    //@@     tensors. User responsible for the creation, deletion and reading
-    //@@     from shared memory.
-    //@@
-    message SharedMemoryIO
-    {
-      //@@    .. cpp:var:: key_t shm_key
-      //@@
-      //@@     The unique key used to refer to a specific location in shared
-      //@@     memory. Optional for tensors. Required to write tensors to
-      //@@     shared memory. If provided, tensor data read from this location.
-      //@@
-      key_t shm_key = 1;
-
-      //@@    .. cpp:var:: key_t shm_key
-      //@@
-      //@@     The offset for the next element in the batch. Only required if
-      //@@     batch_size > 1. n-1 offsets required (we know first element has
-      //@@     offset of 0), where n is number of elements in the batch.
-      //@@     element0 start = 0, end = offset0;
-      //@@     element1 start = offset0, end = offset1; and so on.
-      //@@
-      repeated uint64 offset = 1;
-    }
   }
 
   //@@  .. cpp:var:: uint64 id

--- a/src/core/api.proto
+++ b/src/core/api.proto
@@ -30,12 +30,12 @@ package nvidia.inferenceserver;
 
 //@@.. cpp:namespace:: nvidia::inferenceserver
 
-//@@.. cpp:var:: message InferSharedMemoryBlock
+//@@.. cpp:var:: message InferSharedMemory
 //@@
 //@@   The meta-data for the shared memory from which to read the input
 //@@   data and/or write the output data.
 //@@
-message InferSharedMemoryBlock
+message InferSharedMemory
 {
   //@@  .. cpp:var:: string shm_key
   //@@
@@ -47,7 +47,7 @@ message InferSharedMemoryBlock
   //@@  .. cpp:var:: uint64 offset
   //@@
   //@@     The offset from the start of the shared memory region.
-  //@@     block0 start = offset0, end = offset0 + size;
+  //@@     start = offset, end = offset + size;
   //@@
   uint64 offset = 2;
 
@@ -56,21 +56,6 @@ message InferSharedMemoryBlock
   //@@     Size of the memory block, in bytes.
   //@@
   uint64 byte_size = 3;
-}
-
-//@@.. cpp:var:: message InferSharedMemory
-//@@
-//@@   Meta-data for I/O of batch from shared memory.
-//@@
-message InferSharedMemory
-{
-  //@@  .. cpp:var:: InferSharedMemoryBlock block (repeated)
-  //@@
-  //@@     One or more contiguous shared memory blocks that compose the
-  //@@     entire shared memory. The No. of memory blocks required is the
-  //@@     size of the batch.
-  //@@
-  repeated InferSharedMemoryBlock block = 1;
 }
 
 //@@

--- a/src/core/api.proto
+++ b/src/core/api.proto
@@ -30,6 +30,49 @@ package nvidia.inferenceserver;
 
 //@@.. cpp:namespace:: nvidia::inferenceserver
 
+//@@.. cpp:var:: message InferSharedMemoryBlock
+//@@
+//@@   The meta-data for the shared memory from which to read the input
+//@@   data and/or write the output data.
+//@@
+message InferSharedMemoryBlock
+{
+  //@@  .. cpp:var:: string shm_key
+  //@@
+  //@@     The name of the shared memory region that holds the input data
+  //@@     (or where the output data should be written).
+  //@@
+  string shm_key = 1;
+
+  //@@  .. cpp:var:: uint64 offset
+  //@@
+  //@@     The offset from the start of the shared memory region.
+  //@@     block0 start = offset0, end = offset0 + size;
+  //@@
+  uint64 offset = 2;
+
+  //@@  .. cpp:var:: uint64 byte_size
+  //@@
+  //@@     Size of the memory block, in bytes.
+  //@@
+  uint64 byte_size = 3;
+}
+
+//@@.. cpp:var:: message InferSharedMemory
+//@@
+//@@   Meta-data for I/O of batch from shared memory.
+//@@
+message InferSharedMemory
+{
+  //@@  .. cpp:var:: InferSharedMemoryBlock block (repeated)
+  //@@
+  //@@     One or more contiguous shared memory blocks that compose the
+  //@@     entire shared memory. The No. of memory blocks required is the
+  //@@     size of the batch.
+  //@@
+  repeated InferSharedMemoryBlock block = 1;
+}
+
 //@@
 //@@.. cpp:var:: message InferRequestHeader
 //@@
@@ -95,54 +138,13 @@ message InferRequestHeader
     //@@
     uint64 batch_byte_size = 3;
 
-    //@@      .. cpp:var:: message SharedMemoryElement
+    //@@    .. cpp:var:: InferSharedMemory shared_memory
     //@@
-    //@@         The Meta-data for the Input shared memory to read element from.
+    //@@       It is the location in shared memory that contains the tensor data
+    //@@       for this input. Using shared memory is optional but if this
+    //@@       message is used, all fields are required.
     //@@
-    message SharedMemoryElement
-    {
-      //@@    .. cpp:var:: key_t shm_key
-      //@@
-      //@@     The unique key used to refer to a specific location in shared
-      //@@     memory. Optional for tensors. Required to read tensors from
-      //@@     shared memory. If provided, tensor data read from this location.
-      //@@
-      key_t shm_key = 1;
-
-      //@@    .. cpp:var:: uint64 offset
-      //@@
-      //@@     The offset for the each element.
-      //@@     element0 start = offset0, end = offset0 + size;
-      //@@
-      uint64 offset = 2;
-
-      //@@    .. cpp:var:: uint64 byte_size
-      //@@
-      //@@     Size of the element in the batch of the input tensor, in bytes.
-      //@@
-      uint64 byte_size = 3;
-    }
-
-    //@@    .. cpp:var:: message SharedMemoryIO
-    //@@
-    //@@       Meta-data for an input batch to be read from shared memory.
-    //@@
-    message SharedMemoryIO
-    {
-      //@@      .. cpp:var:: SharedMemoryElement element (repeated)
-      //@@
-      //@@         No. of elements required is number of elements in the batch.
-      //@@
-      repeated SharedMemoryElement element = 1;
-    }
-
-    //@@    .. cpp:var:: SharedMemoryIO shm_io
-    //@@
-    //@@       Unique identity of the location in shared memory to read input
-    //@@       tensors. User responsible for the creation, deletion and writing
-    //@@       to shared memory. If specified, input data is read from here.
-    //@@
-    SharedMemoryIO shm_io = 4;
+    InferSharedMemory shared_memory = 4;
   }
 
   //@@  .. cpp:var:: message Output
@@ -182,54 +184,13 @@ message InferRequestHeader
     //@@
     Class cls = 3;
 
-    //@@      .. cpp:var:: message SharedMemoryElement
+    //@@    .. cpp:var:: InferSharedMemory shared_memory
     //@@
-    //@@         The Meta-data for the Output shared memory to write element to.
+    //@@       It is the location in shared memory that the result tensor data
+    //@@       for this output will be written. Using shared memory is optional
+    //@@       but if this message is used, all fields are required.
     //@@
-    message SharedMemoryElement
-    {
-      //@@    .. cpp:var:: key_t shm_key
-      //@@
-      //@@     The unique key used to refer to a specific location in shared
-      //@@     memory. Optional for tensors. Required to write tensors to
-      //@@     shared memory. If provided, tensor data written to this location.
-      //@@
-      key_t shm_key = 1;
-
-      //@@    .. cpp:var:: uint64 offset
-      //@@
-      //@@     The offset for the each element.
-      //@@     element0 start = offset0, end = offset0 + size;
-      //@@
-      uint64 offset = 2;
-
-      //@@    .. cpp:var:: uint64 byte_size
-      //@@
-      //@@     Size of the element in the batch of the input tensor, in bytes.
-      //@@
-      uint64 byte_size = 3;
-    }
-
-    //@@    .. cpp:var:: message SharedMemoryIO
-    //@@
-    //@@       Meta-data for an output batch to be written to shared memory.
-    //@@
-    message SharedMemoryIO
-    {
-      //@@      .. cpp:var:: SharedMemoryElement element (repeated)
-      //@@
-      //@@         No. of elements required is number of elements in the batch.
-      //@@
-      repeated SharedMemoryElement element = 1;
-    }
-
-    //@@    .. cpp:var:: SharedMemoryIO shm_io
-    //@@
-    //@@       Unique identity of the location in shared memory to write output
-    //@@       tensors. User responsible for the creation, deletion and reading
-    //@@       from shared memory. If specified, output data is written to here.
-    //@@
-    SharedMemoryIO shm_io = 4;
+    InferSharedMemory shared_memory = 4;
   }
 
   //@@  .. cpp:var:: uint64 id
@@ -367,9 +328,7 @@ message InferResponseHeader
     //@@       If specified deliver results for this output as raw tensor data.
     //@@       The actual output data is delivered in the HTTP body for an HTTP
     //@@       request, or in the :cpp:var:`InferResponse` message for a gRPC
-    //@@       request. Only one of 'raw' and 'batch_classes' may be
-    //@@       specified. If 'SharedMemoryIO' is present in request then
-    //@@       neither is specified.
+    //@@       request. Only one of 'raw' and 'batch_classes' may be specified.
     //@@
     Raw raw = 2;
 
@@ -378,8 +337,7 @@ message InferResponseHeader
     //@@       If specified deliver results for this output as classifications.
     //@@       There is one :cpp:var:`Classes` object for each batch entry in
     //@@       the output. Only one of 'raw' and 'batch_classes' may be
-    //@@       specified. If 'SharedMemoryIO' is present in request then
-    //@@       neither is specified.
+    //@@       specified.
     //@@
     repeated Classes batch_classes = 3;
   }

--- a/src/core/api.proto
+++ b/src/core/api.proto
@@ -37,12 +37,12 @@ package nvidia.inferenceserver;
 //@@
 message InferSharedMemory
 {
-  //@@  .. cpp:var:: string shm_name
+  //@@  .. cpp:var:: string name
   //@@
   //@@     The name given during registration of a shared memory region that
   //@@     holds the input data (or where the output data should be written).
   //@@
-  string shm_name = 1;
+  string name = 1;
 
   //@@  .. cpp:var:: uint64 offset
   //@@

--- a/src/core/api.proto
+++ b/src/core/api.proto
@@ -30,6 +30,34 @@ package nvidia.inferenceserver;
 
 //@@.. cpp:namespace:: nvidia::inferenceserver
 
+//@@.. cpp:var:: message InferSharedMemory
+//@@
+//@@   The meta-data for the shared memory from which to read the input
+//@@   data and/or write the output data.
+//@@
+message InferSharedMemory
+{
+  //@@  .. cpp:var:: string shm_name
+  //@@
+  //@@     The name given during registration of a shared memory region that
+  //@@     holds the input data (or where the output data should be written).
+  //@@
+  string shm_name = 1;
+
+  //@@  .. cpp:var:: uint64 offset
+  //@@
+  //@@     The offset from the start of the shared memory region.
+  //@@     start = offset, end = offset + size;
+  //@@
+  uint64 offset = 2;
+
+  //@@  .. cpp:var:: uint64 byte_size
+  //@@
+  //@@     Size of the memory block, in bytes.
+  //@@
+  uint64 byte_size = 3;
+}
+
 //@@
 //@@.. cpp:var:: message InferRequestHeader
 //@@
@@ -95,12 +123,13 @@ message InferRequestHeader
     //@@
     uint64 batch_byte_size = 3;
 
-    //@@    .. cpp:var:: string shm_name
+    //@@    .. cpp:var:: InferSharedMemory shared_memory
     //@@
-    //@@       The name given by the user during registration of a shared memory
-    //@@       region that holds the input data.
+    //@@       It is the location in shared memory that contains the tensor data
+    //@@       for this input. Using shared memory is optional but if this
+    //@@       message is used, all fields are required.
     //@@
-    string shm_name = 4;
+    InferSharedMemory shared_memory = 4;
   }
 
   //@@  .. cpp:var:: message Output
@@ -140,12 +169,13 @@ message InferRequestHeader
     //@@
     Class cls = 3;
 
-    //@@    .. cpp:var:: string shm_name
+    //@@    .. cpp:var:: InferSharedMemory shared_memory
     //@@
-    //@@       The name given by the user during registration of a shared memory
-    //@@       region where the output data should be written.
+    //@@       It is the location in shared memory that the result tensor data
+    //@@       for this output will be written. Using shared memory is optional
+    //@@       but if this message is used, all fields are required.
     //@@
-    string shm_name = 4;
+    InferSharedMemory shared_memory = 4;
   }
 
   //@@  .. cpp:var:: uint64 id

--- a/src/core/api.proto
+++ b/src/core/api.proto
@@ -30,34 +30,6 @@ package nvidia.inferenceserver;
 
 //@@.. cpp:namespace:: nvidia::inferenceserver
 
-//@@.. cpp:var:: message InferSharedMemory
-//@@
-//@@   The meta-data for the shared memory from which to read the input
-//@@   data and/or write the output data.
-//@@
-message InferSharedMemory
-{
-  //@@  .. cpp:var:: string shm_key
-  //@@
-  //@@     The name of the shared memory region that holds the input data
-  //@@     (or where the output data should be written).
-  //@@
-  string shm_key = 1;
-
-  //@@  .. cpp:var:: uint64 offset
-  //@@
-  //@@     The offset from the start of the shared memory region.
-  //@@     start = offset, end = offset + size;
-  //@@
-  uint64 offset = 2;
-
-  //@@  .. cpp:var:: uint64 byte_size
-  //@@
-  //@@     Size of the memory block, in bytes.
-  //@@
-  uint64 byte_size = 3;
-}
-
 //@@
 //@@.. cpp:var:: message InferRequestHeader
 //@@
@@ -123,13 +95,12 @@ message InferRequestHeader
     //@@
     uint64 batch_byte_size = 3;
 
-    //@@    .. cpp:var:: InferSharedMemory shared_memory
+    //@@    .. cpp:var:: string shm_name
     //@@
-    //@@       It is the location in shared memory that contains the tensor data
-    //@@       for this input. Using shared memory is optional but if this
-    //@@       message is used, all fields are required.
+    //@@       The name given by the user during registration of a shared memory
+    //@@       region that holds the input data.
     //@@
-    InferSharedMemory shared_memory = 4;
+    string shm_name = 4;
   }
 
   //@@  .. cpp:var:: message Output
@@ -169,13 +140,12 @@ message InferRequestHeader
     //@@
     Class cls = 3;
 
-    //@@    .. cpp:var:: InferSharedMemory shared_memory
+    //@@    .. cpp:var:: string shm_name
     //@@
-    //@@       It is the location in shared memory that the result tensor data
-    //@@       for this output will be written. Using shared memory is optional
-    //@@       but if this message is used, all fields are required.
+    //@@       The name given by the user during registration of a shared memory
+    //@@       region where the output data should be written.
     //@@
-    InferSharedMemory shared_memory = 4;
+    string shm_name = 4;
   }
 
   //@@  .. cpp:var:: uint64 id

--- a/src/core/grpc_service.proto
+++ b/src/core/grpc_service.proto
@@ -59,7 +59,8 @@ service GRPCService
   //@@
   rpc Health(HealthRequest) returns (HealthResponse) {}
 
-  //@@  .. cpp:var:: rpc ModelControl(ModelControlRequest) returns (ModelControlResponse)
+  //@@  .. cpp:var:: rpc ModelControl(ModelControlRequest) returns
+  //@@     (ModelControlResponse)
   //@@
   //@@     Request to load / unload a specified model.
   //@@
@@ -268,32 +269,31 @@ message ModelControlResponse
 message InferSharedMemoryRegion
 {
   //@@
-  //@@  .. cpp:var:: string model_name
+  //@@  .. cpp:var:: string name
   //@@
-  //@@     The target shared memory region name (different from the shm_key)
-  //@@     that the user will use to refer to the specified region.
+  //@@     The name for this shared memory region.
   //@@
-  string shm_name = 1;
+  string name = 1;
 
   //@@  .. cpp:var:: string shm_key
   //@@
   //@@     The name of the shared memory region that holds the input data
   //@@     (or where the output data should be written).
   //@@
-  string shm_key = 1;
+  string shm_key = 2;
 
   //@@  .. cpp:var:: uint64 offset
   //@@
   //@@     The offset from the start of the shared memory region.
   //@@     start = offset, end = offset + size;
   //@@
-  uint64 offset = 2;
+  uint64 offset = 3;
 
   //@@  .. cpp:var:: uint64 byte_size
   //@@
   //@@     Size of the memory block, in bytes.
   //@@
-  uint64 byte_size = 3;
+  uint64 byte_size = 4;
 }
 
 //@@
@@ -321,21 +321,21 @@ message SharedMemoryControlRequest
     REGISTER = 1;
   }
 
-  //@@  .. cpp:var:: InferSharedMemoryRegion shared_memory_region
-  //@@
-  //@@     It is the region in shared memory that the user wishes to register.
-  //@@     All fields are needed to REGISTER the shared memory region.
-  //@@     Only 'shm_name' is needed to UNREGISTER the shared memory region.
-  //@@
-  InferSharedMemoryRegion shared_memory_region = 1;
-
   //@@
   //@@  .. cpp:var:: Type type
   //@@
   //@@     The control type that states whether to register or unregister the
   //@@     specified shared memory region.
   //@@
-  Type type = 2;
+  Type type = 1;
+
+  //@@  .. cpp:var:: InferSharedMemoryRegion shared_memory_region
+  //@@
+  //@@     The shared memory region to register or unregister.
+  //@@     All fields are needed to REGISTER the shared memory region.
+  //@@     Only 'name' is needed to UNREGISTER the shared memory region.
+  //@@
+  InferSharedMemoryRegion shared_memory_region = 2;
 }
 
 //@@
@@ -343,7 +343,7 @@ message SharedMemoryControlRequest
 //@@
 //@@   Response message for SharedMemoryControl gRPC endpoint.
 //@@
-message SharedMemoryControl Response
+message SharedMemoryControlResponse
 {
   //@@
   //@@  .. cpp:var:: RequestStatus request_status

--- a/src/core/grpc_service.proto
+++ b/src/core/grpc_service.proto
@@ -65,6 +65,12 @@ service GRPCService
   //@@
   rpc ModelControl(ModelControlRequest) returns (ModelControlResponse) {}
 
+  //@@  .. cpp:var:: rpc ShmControl(ShmControlRequest) returns (ShmControlResponse)
+  //@@
+  //@@     Request to register / unregister a specified shared memory region.
+  //@@
+  rpc ShmControl(ShmControlRequest) returns (ShmControlResponse) {}
+
   //@@  .. cpp:var:: rpc Infer(InferRequest) returns (InferResponse)
   //@@
   //@@     Request inference using a specific model. [ To handle large input
@@ -241,6 +247,100 @@ message ModelControlRequest
 //@@   Response message for ModelControl gRPC endpoint.
 //@@
 message ModelControlResponse
+{
+  //@@
+  //@@  .. cpp:var:: RequestStatus request_status
+  //@@
+  //@@     The status of the request, indicating success or failure.
+  //@@
+  RequestStatus request_status = 1;
+}
+
+//@@.. cpp:var:: message InferSharedMemory
+//@@
+//@@   The meta-data for the shared memory from which to read the input
+//@@   data and/or write the output data.
+//@@
+message InferSharedMemory
+{
+  //@@  .. cpp:var:: string shm_key
+  //@@
+  //@@     The name of the shared memory region that holds the input data
+  //@@     (or where the output data should be written).
+  //@@
+  string shm_key = 1;
+
+  //@@  .. cpp:var:: uint64 offset
+  //@@
+  //@@     The offset from the start of the shared memory region.
+  //@@     start = offset, end = offset + size;
+  //@@
+  uint64 offset = 2;
+
+  //@@  .. cpp:var:: uint64 byte_size
+  //@@
+  //@@     Size of the memory block, in bytes.
+  //@@
+  uint64 byte_size = 3;
+}
+
+//@@
+//@@.. cpp:var:: message ShmControlRequest
+//@@
+//@@   Request message for managing registered shared memory regions in TRTIS.
+//@@
+message ShmControlRequest
+{
+  //@@  .. cpp:enum:: Type
+  //@@
+  //@@     Types of control operation
+  //@@
+  enum Type {
+    //@@    .. cpp:enumerator:: Type::UNREGISTER = 0
+    //@@
+    //@@       To unregister the specified shared memory region.
+    //@@
+    UNREGISTER = 0;
+
+    //@@    .. cpp:enumerator:: Type::REGISTER = 1
+    //@@
+    //@@       To register the specified shared memory region. If used the
+    //@@       InferSharedMemory message and all its fields are required.
+    //@@
+    REGISTER = 1;
+  }
+
+  //@@
+  //@@  .. cpp:var:: string model_name
+  //@@
+  //@@     The target shared memory region name (different from the shm_key)
+  //@@     that the user will use to refer to the specified region.
+  //@@
+  string shm_name = 1;
+
+  //@@
+  //@@  .. cpp:var:: Type type
+  //@@
+  //@@     The control type that states whether to register or unregister the
+  //@@     specified shared memory region.
+  //@@
+  Type type = 2;
+
+  //@@    .. cpp:var:: InferSharedMemory shared_memory
+  //@@
+  //@@       It is the location in shared memory that the user wishes to
+  //@@       register. Only needed for REGISTER requests. All fields are
+  //@@       required.
+  //@@
+  InferSharedMemory shared_memory = 4;
+}
+
+//@@
+//@@.. cpp:var:: message ShmControlResponse
+//@@
+//@@   Response message for ShmControl gRPC endpoint.
+//@@
+message ShmControlResponse
 {
   //@@
   //@@  .. cpp:var:: RequestStatus request_status

--- a/src/core/grpc_service.proto
+++ b/src/core/grpc_service.proto
@@ -65,7 +65,8 @@ service GRPCService
   //@@
   rpc ModelControl(ModelControlRequest) returns (ModelControlResponse) {}
 
-  //@@  .. cpp:var:: rpc ShmControl(ShmControlRequest) returns (ShmControlResponse)
+  //@@  .. cpp:var:: rpc ShmControl(ShmControlRequest) returns
+  //@@     (ShmControlResponse)
   //@@
   //@@     Request to register / unregister a specified shared memory region.
   //@@

--- a/src/core/grpc_service.proto
+++ b/src/core/grpc_service.proto
@@ -65,12 +65,15 @@ service GRPCService
   //@@
   rpc ModelControl(ModelControlRequest) returns (ModelControlResponse) {}
 
-  //@@  .. cpp:var:: rpc ShmControl(ShmControlRequest) returns
-  //@@     (ShmControlResponse)
+  //@@  .. cpp:var:: rpc SharedMemoryControl(SharedMemoryControlRequest) returns
+  //@@     (SharedMemoryControlResponse)
   //@@
   //@@     Request to register / unregister a specified shared memory region.
   //@@
-  rpc ShmControl(ShmControlRequest) returns (ShmControlResponse) {}
+  rpc SharedMemoryControl(SharedMemoryControlRequest)
+      returns (SharedMemoryControlResponse)
+  {
+  }
 
   //@@  .. cpp:var:: rpc Infer(InferRequest) returns (InferResponse)
   //@@
@@ -257,13 +260,21 @@ message ModelControlResponse
   RequestStatus request_status = 1;
 }
 
-//@@.. cpp:var:: message InferSharedMemory
+//@@.. cpp:var:: message InferSharedMemoryRegion
 //@@
-//@@   The meta-data for the shared memory from which to read the input
+//@@   The meta-data for the shared memory region from which to read the input
 //@@   data and/or write the output data.
 //@@
-message InferSharedMemory
+message InferSharedMemoryRegion
 {
+  //@@
+  //@@  .. cpp:var:: string model_name
+  //@@
+  //@@     The target shared memory region name (different from the shm_key)
+  //@@     that the user will use to refer to the specified region.
+  //@@
+  string shm_name = 1;
+
   //@@  .. cpp:var:: string shm_key
   //@@
   //@@     The name of the shared memory region that holds the input data
@@ -286,15 +297,15 @@ message InferSharedMemory
 }
 
 //@@
-//@@.. cpp:var:: message ShmControlRequest
+//@@.. cpp:var:: message SharedMemoryControlRequest
 //@@
 //@@   Request message for managing registered shared memory regions in TRTIS.
 //@@
-message ShmControlRequest
+message SharedMemoryControlRequest
 {
   //@@  .. cpp:enum:: Type
   //@@
-  //@@     Types of control operation
+  //@@     Types of control operations for shared memory
   //@@
   enum Type {
     //@@    .. cpp:enumerator:: Type::UNREGISTER = 0
@@ -305,19 +316,18 @@ message ShmControlRequest
 
     //@@    .. cpp:enumerator:: Type::REGISTER = 1
     //@@
-    //@@       To register the specified shared memory region. If used the
-    //@@       InferSharedMemory message and all its fields are required.
+    //@@       To register the specified shared memory region.
     //@@
     REGISTER = 1;
   }
 
+  //@@  .. cpp:var:: InferSharedMemoryRegion shared_memory_region
   //@@
-  //@@  .. cpp:var:: string model_name
+  //@@     It is the region in shared memory that the user wishes to register.
+  //@@     All fields are needed to REGISTER the shared memory region.
+  //@@     Only 'shm_name' is needed to UNREGISTER the shared memory region.
   //@@
-  //@@     The target shared memory region name (different from the shm_key)
-  //@@     that the user will use to refer to the specified region.
-  //@@
-  string shm_name = 1;
+  InferSharedMemoryRegion shared_memory_region = 1;
 
   //@@
   //@@  .. cpp:var:: Type type
@@ -326,22 +336,14 @@ message ShmControlRequest
   //@@     specified shared memory region.
   //@@
   Type type = 2;
-
-  //@@    .. cpp:var:: InferSharedMemory shared_memory
-  //@@
-  //@@       It is the location in shared memory that the user wishes to
-  //@@       register. Only needed for REGISTER requests. All fields are
-  //@@       required.
-  //@@
-  InferSharedMemory shared_memory = 4;
 }
 
 //@@
-//@@.. cpp:var:: message ShmControlResponse
+//@@.. cpp:var:: message SharedMemoryControlResponse
 //@@
-//@@   Response message for ShmControl gRPC endpoint.
+//@@   Response message for SharedMemoryControl gRPC endpoint.
 //@@
-message ShmControlResponse
+message SharedMemoryControl Response
 {
   //@@
   //@@  .. cpp:var:: RequestStatus request_status


### PR DESCRIPTION
Allow option to:

- Read (selected) Inputs from Shared Memory
- Write (selected) Outputs to Shared Memory

- [x] Update API request / response 
Support batching using offsets for each element with the same shm_key
Support for registering / unregistering SHM regions 