### PR TITLE
Allow autofill for multiple model versions

### DIFF
--- a/src/backends/caffe2/autofill.cc
+++ b/src/backends/caffe2/autofill.cc
@@ -59,19 +59,14 @@ AutoFillNetDef::Create(
   std::set<std::string> version_dirs;
   RETURN_IF_ERROR(GetDirectorySubdirs(model_path, &version_dirs));
 
-  // There must be at least one version directory that we can inspect
-  // to attempt to determine the platform. For now we only handle the
-  // case where there is one version directory.
+  // There must be at least one version directory that we can inspect to
+  // attempt to determine the platform. For now we allow multiple versions
+  // and only inspect the first verison directory to ensure it is valid.
+  // We can add more aggressive checks later.
   if (version_dirs.size() == 0) {
     return Status(
         RequestStatusCode::INTERNAL, "unable to autofill for '" + model_name +
                                          "' due to no version directories");
-  }
-
-  if (version_dirs.size() != 1) {
-    return Status(
-        RequestStatusCode::INTERNAL,
-        "unable to autofill for '" + model_name + "' due to multiple versions");
   }
 
   const auto version_path = JoinPath({model_path, *(version_dirs.begin())});

--- a/src/backends/onnx/autofill.cc
+++ b/src/backends/onnx/autofill.cc
@@ -299,10 +299,6 @@ AutoFillOnnx::Create(
   std::set<std::string> version_dirs;
   RETURN_IF_ERROR(GetDirectorySubdirs(model_path, &version_dirs));
 
-  // There must be at least one version directory that we can inspect to
-  // attempt to determine the platform. For now we allow multiple versions
-  // and only inspect the first verison directory to ensure it is valid.
-  // We can add more aggressive checks later.
   if (version_dirs.size() == 0) {
     return Status(
         RequestStatusCode::INTERNAL, "unable to autofill for '" + model_name +

--- a/src/backends/onnx/autofill.cc
+++ b/src/backends/onnx/autofill.cc
@@ -299,6 +299,10 @@ AutoFillOnnx::Create(
   std::set<std::string> version_dirs;
   RETURN_IF_ERROR(GetDirectorySubdirs(model_path, &version_dirs));
 
+  // There must be at least one version directory that we can inspect to
+  // attempt to determine the platform. For now we allow multiple versions
+  // and only inspect the first verison directory to ensure it is valid.
+  // We can add more aggressive checks later.
   if (version_dirs.size() == 0) {
     return Status(
         RequestStatusCode::INTERNAL, "unable to autofill for '" + model_name +

--- a/src/backends/pytorch/autofill.cc
+++ b/src/backends/pytorch/autofill.cc
@@ -59,19 +59,14 @@ AutoFillPyTorch::Create(
   std::set<std::string> version_dirs;
   RETURN_IF_ERROR(GetDirectorySubdirs(model_path, &version_dirs));
 
-  // There must be at least one version directory that we can inspect
-  // to attempt to determine the platform. For now we only handle the
-  // case where there is one version directory.
+  // There must be at least one version directory that we can inspect to
+  // attempt to determine the platform. For now we allow multiple versions
+  // and only inspect the first verison directory to ensure it is valid.
+  // We can add more aggressive checks later.
   if (version_dirs.size() == 0) {
     return Status(
         RequestStatusCode::INTERNAL, "unable to autofill for '" + model_name +
                                          "' due to no version directories");
-  }
-
-  if (version_dirs.size() != 1) {
-    return Status(
-        RequestStatusCode::INTERNAL,
-        "unable to autofill for '" + model_name + "' due to multiple versions");
   }
 
   const auto version_path = JoinPath({model_path, *(version_dirs.begin())});

--- a/src/backends/tensorflow/autofill.cc
+++ b/src/backends/tensorflow/autofill.cc
@@ -255,19 +255,14 @@ AutoFillSavedModel::Create(
   std::set<std::string> version_dirs;
   RETURN_IF_ERROR(GetDirectorySubdirs(model_path, &version_dirs));
 
-  // There must be at least one version directory that we can inspect
-  // to attempt to determine the platform. For now we only handle the
-  // case where there is one version directory.
+  // There must be at least one version directory that we can inspect to
+  // attempt to determine the platform. For now we allow multiple versions
+  // and only inspect the first verison directory to ensure it is valid.
+  // We can add more aggressive checks later.
   if (version_dirs.size() == 0) {
     return Status(
         RequestStatusCode::INTERNAL, "unable to autofill for '" + model_name +
                                          "' due to no version directories");
-  }
-
-  if (version_dirs.size() != 1) {
-    return Status(
-        RequestStatusCode::INTERNAL,
-        "unable to autofill for '" + model_name + "' due to multiple versions");
   }
 
   const auto version_path = JoinPath({model_path, *(version_dirs.begin())});
@@ -331,14 +326,10 @@ AutoFillGraphDef::Create(
   std::set<std::string> version_dirs;
   RETURN_IF_ERROR(GetDirectorySubdirs(model_path, &version_dirs));
 
-  // There must be at least one version directory that we can inspect
-  // to attempt to determine the platform. For now we only handle the
-  // case where there is one version directory.
-  if (version_dirs.size() != 1) {
-    return Status(
-        RequestStatusCode::INTERNAL,
-        "unable to autofill for '" + model_name + "' due to multiple versions");
-  }
+  // There must be at least one version directory that we can inspect to
+  // attempt to determine the platform. For now we allow multiple versions
+  // and only inspect the first verison directory to ensure it is valid.
+  // We can add more aggressive checks later.
 
   const auto version_path = JoinPath({model_path, *(version_dirs.begin())});
 

--- a/src/backends/tensorrt/autofill.cc
+++ b/src/backends/tensorrt/autofill.cc
@@ -133,19 +133,14 @@ AutoFillPlan::Create(
   std::set<std::string> version_dirs;
   RETURN_IF_ERROR(GetDirectorySubdirs(model_path, &version_dirs));
 
-  // There must be at least one version directory that we can inspect
-  // to attempt to determine the platform. For now we only handle the
-  // case where there is one version directory.
+  // There must be at least one version directory that we can inspect to
+  // attempt to determine the platform. For now we allow multiple versions
+  // and only inspect the first verison directory to ensure it is valid.
+  // We can add more aggressive checks later.
   if (version_dirs.size() == 0) {
     return Status(
         RequestStatusCode::INTERNAL, "unable to autofill for '" + model_name +
                                          "' due to no version directories");
-  }
-
-  if (version_dirs.size() != 1) {
-    return Status(
-        RequestStatusCode::INTERNAL,
-        "unable to autofill for '" + model_name + "' due to multiple versions");
   }
 
   const auto version_path = JoinPath({model_path, *(version_dirs.begin())});


### PR DESCRIPTION
Relax Autofill check to allow for multiple model versions. 
PS: Need to add aggressive checks across versions to make it more robust. Currently uses only the first version of the model.