### PR TITLE
Update api/health/live conditional to be aligned with the doc. Update ensemble reshape test

### DIFF
--- a/qa/L0_infer_reshape/infer_reshape_test.py
+++ b/qa/L0_infer_reshape/infer_reshape_test.py
@@ -135,19 +135,6 @@ class InferReshapeTest(unittest.TestCase):
         self._trt_reshape(np.float32, input_shapes=([4,4],[2],[2,2,3],[1]),
                           output_shapes=([2,2,4],[1,2,1],[3,2,2],[1,1,1]))
 
-    def test_ensemble_zero_dimension_reshape(self):
-        for shapes in [([1],), ([1],[8])]:
-            for name in ["simple_reshape", "sequence_reshape", "fan_reshape"]:
-                # model that supports batching
-                for bs in (1, 8):
-                    try:
-                        iu.infer_zero(self, name, bs, np.float32, shapes, shapes)
-                        self.assertTrue(False, "Unexpected success in infer")
-                    except InferenceServerException as ex:
-                        self.assertEqual("inference:0", ex.server_id())
-                        self.assertTrue(
-                            "but model configuration specifies shape []" in ex.message())
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/qa/common/gen_qa_reshape_models.py
+++ b/qa/common/gen_qa_reshape_models.py
@@ -680,9 +680,24 @@ def create_ensemble_modelconfig(
                                     input_shapes[0], input_shapes[0], input_shapes[0]):
         return
 
+    # No reason to reshape ensemble inputs / outputs to empty as the inner models
+    # have to have non-empty shapes for inputs / outputs.
+    input_model_shapes_list = []
+    output_model_shapes_list = []
+    for idx in range(len(input_shapes)):
+        if len(input_model_shapes[idx]) == 0:
+            input_model_shapes_list.append(input_shapes[idx])
+        else:
+            input_model_shapes_list.append(input_model_shapes[idx])
+        if len(output_model_shapes[idx]) == 0:
+            output_model_shapes_list.append(output_shapes[idx])
+        else:
+            output_model_shapes_list.append(output_model_shapes[idx])
+
     emu.create_identity_ensemble_modelconfig(
         "reshape", models_dir, model_version, max_batch, dtype,
-        input_shapes, input_model_shapes, output_shapes, output_model_shapes)
+        input_shapes, tuple(input_model_shapes_list),
+        output_shapes, tuple(output_model_shapes_list))
 
 
 def create_onnx_modelfile(

--- a/src/core/server.cc
+++ b/src/core/server.cc
@@ -233,6 +233,7 @@ InferenceServer::HandleHealth(
   if (mode == "live") {
     *health =
         ((ready_state_ != ServerReadyState::SERVER_INVALID) &&
+         (ready_state_ != ServerReadyState::SERVER_INITIALIZING) &&
          (ready_state_ != ServerReadyState::SERVER_FAILED_TO_INITIALIZE));
     RequestStatusFactory::Create(
         request_status, request_id, id_, RequestStatusCode::SUCCESS);


### PR DESCRIPTION
Based on doc [here](https://github.com/NVIDIA/tensorrt-inference-server/blob/master/docs/http_grpc_api.rst#health), "live" should not return 200 when server is initializing.
Removing the "ensemble reshape error" test as it is a form of tensor shape mismatch, and this will be checked in ensemble config validation, which will be tested in L0_model_config (after another PR for enabling ensemble validation).