### PR TITLE
Ctrl+C prints complete concurrency

### DIFF
--- a/src/clients/c++/perf_client.cc
+++ b/src/clients/c++/perf_client.cc
@@ -141,15 +141,24 @@ volatile bool finished_inferencing = false;
 void
 SignalHandler(int signum)
 {
-  std::cout << "Interrupt signal (" << signum << ") received." << std::endl
-            << "Waiting for in-flight inferences to complete." << std::endl;
   // Upon invoking the SignalHandler for the first time early_exit flag is
   // invoked. On the subsequent invocations, if there are no in-flight inference
   // requests, the program exits.
-  if (!early_exit)
+  if (!early_exit) {
+    std::cout << "Interrupt signal (" << signum << ") received." << std::endl
+              << "Initializing early exit..." << std::endl;
     early_exit = true;
-  else if (finished_inferencing)
+  } else if (finished_inferencing) {
+    std::cout << "Another Interrupt signal (" << signum << ") received."
+              << std::endl
+              << "No in-flight inferences. Exitting immediately..."
+              << std::endl;
     exit(0);
+  } else {
+    std::cout << "Interrupt signal (" << signum << ") received." << std::endl
+              << "Still waiting for in-flight inferences to complete."
+              << std::endl;
+  }
 }
 
 typedef struct PerformanceStatusStruct {
@@ -590,7 +599,7 @@ ConcurrencyManager::ChangeConcurrencyLevel(
         new std::vector<nic::InferContext::Stat>());
     threads_concurrency_.emplace_back(new size_t(0));
 
-    // Worker maintians concurrency in different ways.
+    // Worker maintains concurrency in different ways.
     // For sequence models, multiple contexts must be created for multiple
     // concurrent sequences.
     // For non-sequence models, one context can send out multiple requests

--- a/src/clients/c++/perf_client.cc
+++ b/src/clients/c++/perf_client.cc
@@ -139,17 +139,15 @@ volatile bool early_exit = false;
 void
 SignalHandler(int signum)
 {
+  std::cout << "Interrupt signal (" << signum << ") received." << std::endl;
   // Upon invoking the SignalHandler for the first time early_exit flag is
-  // invoked. On the second invocation, the program exits immediately.
+  // invoked and client waits for in-flight inferences to complete before
+  // exiting. On the second invocation, the program exits immediately.
   if (!early_exit) {
-    std::cout << "Interrupt signal (" << signum << ") received." << std::endl
-              << "Initializing early exit..." << std::endl;
+    std::cout << "Waiting for in-flight inferences to complete." << std::endl;
     early_exit = true;
   } else {
-    std::cout << "Second Interrupt signal (" << signum << ") received."
-              << std::endl
-              << "Exiting immediately..."
-              << std::endl;
+    std::cout << "Exiting immediately..." << std::endl;
     exit(0);
   }
 }
@@ -2003,8 +2001,8 @@ main(int argc, char** argv)
 
   if (!err.IsOk()) {
     std::cerr << err << std::endl;
-    // In the case of early_exit, the thread doesn't returns to continue
-    // reporting the summary.
+    // In the case of early_exit, the thread does not return and continues to
+    // report the summary
     if (!early_exit) {
       return 1;
     }

--- a/src/clients/c++/perf_client.cc
+++ b/src/clients/c++/perf_client.cc
@@ -2012,8 +2012,9 @@ main(int argc, char** argv)
     std::cerr << err << std::endl;
     // In the case of early_exit, the thread doesn't returns to continue
     // reporting the summary.
-    if (!early_exit)
+    if (!early_exit) {
       return 1;
+    }
   }
   if (summary.size()) {
     // Can print more depending on verbose, but it seems too much information

--- a/src/clients/c++/perf_client.cc
+++ b/src/clients/c++/perf_client.cc
@@ -135,29 +135,22 @@ using TimestampVector =
 namespace {
 
 volatile bool early_exit = false;
-// The flag is set when there are no in-flight inferences to complete.
-volatile bool finished_inferencing = false;
 
 void
 SignalHandler(int signum)
 {
   // Upon invoking the SignalHandler for the first time early_exit flag is
-  // invoked. On the subsequent invocations, if there are no in-flight inference
-  // requests, the program exits.
+  // invoked. On the second invocation, the program exits immediately.
   if (!early_exit) {
     std::cout << "Interrupt signal (" << signum << ") received." << std::endl
               << "Initializing early exit..." << std::endl;
     early_exit = true;
-  } else if (finished_inferencing) {
-    std::cout << "Another Interrupt signal (" << signum << ") received."
+  } else {
+    std::cout << "Second Interrupt signal (" << signum << ") received."
               << std::endl
-              << "No in-flight inferences. Exitting immediately..."
+              << "Exiting immediately..."
               << std::endl;
     exit(0);
-  } else {
-    std::cout << "Interrupt signal (" << signum << ") received." << std::endl
-              << "Still waiting for in-flight inferences to complete."
-              << std::endl;
   }
 }
 
@@ -2007,7 +2000,7 @@ main(int argc, char** argv)
       }
     }
   }
-  finished_inferencing = true;
+
   if (!err.IsOk()) {
     std::cerr << err << std::endl;
     // In the case of early_exit, the thread doesn't returns to continue


### PR DESCRIPTION
With these changes the user can get the summary of the run even if they interrupts the execution. If printing/writing of the information is time consuming or the user wants to immediately stop the execution, they can again interrupt the execution, in which case the perf_client will exit without completing the summary dump.