### PR TITLE
Add control context in client library

### DIFF
--- a/src/clients/c++/request.cc
+++ b/src/clients/c++/request.cc
@@ -35,6 +35,7 @@ namespace nvidia { namespace inferenceserver { namespace client {
 ProfileContext::~ProfileContext() {}
 ServerHealthContext::~ServerHealthContext() {}
 ServerStatusContext::~ServerStatusContext() {}
+ControlContext::~ControlContext() {}
 InferContext::Input::~Input() {}
 InferContext::Output::~Output() {}
 InferContext::Result::~Result() {}

--- a/src/clients/c++/request.h
+++ b/src/clients/c++/request.h
@@ -705,8 +705,43 @@ class ProfileContext {
   virtual Error StartProfile() = 0;
 
   /// Stop profiling on the inference server.
-  // \return Error object indicating success or failure.
+  /// \return Error object indicating success or failure.
   virtual Error StopProfile() = 0;
+};
+
+//==============================================================================
+/// A ControlContext object is used to control the model loading / unloading
+/// on the inference server. Once created a ControlContext object can be used
+/// repeatedly.
+///
+/// A ControlContext object can use either HTTP protocol or GRPC protocol
+/// depending on the Create function (ControlHttpContext::Create or
+/// ControlGrpcContext::Create). For example:
+///
+/// \code
+///   std::unique_ptr<ControlContext> ctx;
+///   ControlGrpcContext::Create(&ctx, "localhost:8000");
+///   std::string model_name = "model";
+///   ctx->Load(model_name);
+///   ...
+///   ctx->Unload(model_name);
+///   ...
+/// \endcode
+///
+class ControlContext {
+ public:
+  virtual ~ControlContext() = 0;
+
+  /// Load a model on the inference server. If the model has been loaded,
+  /// it will be reloaded to use the latest configuration.
+  /// \param model_name The name of the model to be loaded.
+  /// \return Error object indicating success or failure.
+  virtual Error Load(const std::string& model_name) = 0;
+
+  /// Unload a model on the inference server.
+  /// \param model_name The name of the model to be unloaded.
+  /// \return Error object indicating success or failure.
+  virtual Error Unload(const std::string& model_name) = 0;
 };
 
 //==============================================================================

--- a/src/clients/c++/request.h
+++ b/src/clients/c++/request.h
@@ -732,13 +732,14 @@ class ControlContext {
  public:
   virtual ~ControlContext() = 0;
 
-  /// Load a model on the inference server. If the model has been loaded,
+  /// Load a model on the inference server. If the model is already loaded,
   /// it will be reloaded to use the latest configuration.
   /// \param model_name The name of the model to be loaded.
   /// \return Error object indicating success or failure.
   virtual Error Load(const std::string& model_name) = 0;
 
-  /// Unload a model on the inference server.
+  /// Unload a model from the inference server. Unloading a model that
+  /// is not loaded on server has no affect and success code will be returned.
   /// \param model_name The name of the model to be unloaded.
   /// \return Error object indicating success or failure.
   virtual Error Unload(const std::string& model_name) = 0;

--- a/src/clients/c++/request_grpc.h
+++ b/src/clients/c++/request_grpc.h
@@ -100,8 +100,8 @@ class ProfileGrpcContext {
 ////
 class ControlGrpcContext {
  public:
-  /// Create context that controls model ready state on a server using GRPC
-  /// protocol.
+  /// Create context that controls models to be loaded on a server and
+  /// to be unloaded from a server using GRPC.
   /// \param ctx Returns the new ControlContext object.
   /// \param server_url The inference server name and port.
   /// \param verbose If true generate verbose output when contacting

--- a/src/clients/c++/request_grpc.h
+++ b/src/clients/c++/request_grpc.h
@@ -96,6 +96,23 @@ class ProfileGrpcContext {
 };
 
 //==============================================================================
+//// ControlGrpcContext is the GRPC instantiation of ControlContext.
+////
+class ControlGrpcContext {
+ public:
+  /// Create context that controls model ready state on a server using GRPC
+  /// protocol.
+  /// \param ctx Returns the new ControlContext object.
+  /// \param server_url The inference server name and port.
+  /// \param verbose If true generate verbose output when contacting
+  /// the inference server.
+  /// \return Error object indicating success or failure.
+  static Error Create(
+      std::unique_ptr<ControlContext>* ctx, const std::string& server_url,
+      bool verbose = false);
+};
+
+//==============================================================================
 /// InferGrpcContext is the GRPC instantiation of InferContext.
 ///
 class InferGrpcContext {

--- a/src/clients/c++/request_http.h
+++ b/src/clients/c++/request_http.h
@@ -144,7 +144,8 @@ class ProfileHttpContext {
 ///
 class ControlHttpContext {
  public:
-  /// Create context that controls model ready state on a server using HTTP
+  /// Create context that controls models to be loaded on a server and
+  /// to be unloaded from a server using HTTP
   /// protocol.
   /// \param ctx Returns the new ControlContext object.
   /// \param server_url The inference server name and port.

--- a/src/clients/c++/request_http.h
+++ b/src/clients/c++/request_http.h
@@ -140,6 +140,25 @@ class ProfileHttpContext {
 };
 
 //==============================================================================
+/// ControlHttpContext is the HTTP instantiation of ControlContext.
+///
+class ControlHttpContext {
+ public:
+  /// Create context that controls model ready state on a server using HTTP
+  /// protocol.
+  /// \param ctx Returns the new ControlContext object.
+  /// \param server_url The inference server name and port.
+  /// \param headers Map of HTTP headers to use with the control
+  /// request. The map key/value indicates the header name/value.
+  /// \param verbose If true generate verbose output when contacting
+  /// the inference server.
+  /// \return Error object indicating success or failure.
+  static Error Create(
+      std::unique_ptr<ControlContext>* ctx, const std::string& server_url,
+      const std::map<std::string, std::string>& headers, bool verbose = false);
+};
+
+//==============================================================================
 /// InferHttpContext is the HTTP instantiation of InferContext.
 ///
 class InferHttpContext {

--- a/src/clients/python/__init__.py
+++ b/src/clients/python/__init__.py
@@ -96,6 +96,19 @@ _crequest_status_ctx_get = _crequest.ServerStatusContextGetServerStatus
 _crequest_status_ctx_get.restype = c_void_p
 _crequest_status_ctx_get.argtypes = [c_void_p, POINTER(c_char_p), POINTER(c_uint32)]
 
+_crequest_control_ctx_new = _crequest.ControlContextNew
+_crequest_control_ctx_new.restype = c_void_p
+_crequest_control_ctx_new.argtypes = [POINTER(c_void_p), _utf8, c_int,
+                                     POINTER(c_char_p), c_int, c_bool]
+_crequest_control_ctx_del = _crequest.ControlContextDelete
+_crequest_control_ctx_del.argtypes = [c_void_p]
+_crequest_control_ctx_load = _crequest.ControlContextLoad
+_crequest_control_ctx_load.restype = c_void_p
+_crequest_control_ctx_load.argtypes = [c_void_p, _utf8]
+_crequest_control_ctx_unload = _crequest.ControlContextUnload
+_crequest_control_ctx_unload.restype = c_void_p
+_crequest_control_ctx_unload.argtypes = [c_void_p, _utf8]
+
 _crequest_infer_ctx_new = _crequest.InferContextNew
 _crequest_infer_ctx_new.restype = c_void_p
 _crequest_infer_ctx_new.argtypes = [POINTER(c_void_p), _utf8, c_int,
@@ -516,6 +529,119 @@ class ServerStatusContext:
 
     def get_last_request_id(self):
         """Get the request ID of the most recent get_server_status() request.
+
+        Returns
+        -------
+        int
+            The request ID, or None if a request has not yet been made
+            or if the last request was not successful.
+
+        """
+        return self._last_request_id
+
+
+class ControlContext:
+    """Performs a model control request to an inference server.
+
+    Parameters
+    ----------
+    url : str
+        The inference server URL, e.g. localhost:8000.
+
+    protocol : ProtocolType
+        The protocol used to communicate with the server.
+
+    verbose : bool
+        If True generate verbose output.
+
+    http_headers : list of strings
+        HTTP headers to send with request. Ignored for GRPC
+        protocol. Each header must be specified as "Header:Value".
+
+    """
+    def __init__(self, url, protocol, verbose=False, http_headers=[]):
+        self._last_request_id = 0
+        self._ctx = c_void_p()
+
+        if http_headers is None:
+            http_headers = list()
+
+        http_headers_arr = (c_char_p * len(http_headers))()
+        http_headers_arr[:] = http_headers
+
+        _raise_if_error(
+            c_void_p(
+                _crequest_control_ctx_new(
+                    byref(self._ctx), url, int(protocol),
+                    http_headers_arr, len(http_headers), verbose)))
+
+    def __del__(self):
+        # when module is unloading may get called after
+        # _crequest_control_ctx_del has been released
+        if _crequest_control_ctx_del is not None:
+            self.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.close()
+
+    def close(self):
+        """Close the context. Any future calls to load() or unload() will
+        result in an Error.
+
+        """
+        _crequest_control_ctx_del(self._ctx)
+        self._ctx = None
+
+    def load(self, model_name):
+        """Request the inference server to load specified model.
+
+        Parameters
+        ----------
+        model_name : str
+            The name of the model to be loaded.
+
+        Raises
+        ------
+        InferenceServerException
+            If unable to load the model.
+
+        """
+        self._last_request_id = None
+        if self._ctx is None:
+            _raise_error("ControlContext is closed")
+
+        self._last_request_id = _raise_if_error(
+            c_void_p(_crequest_control_ctx_load(self._ctx, model_name)))
+        return
+
+    def unload(self, model_name):
+        """Request the inference server to unload specified model.
+
+        Parameters
+        ----------
+        model_name : str
+            The name of the model to be unloaded.
+
+        Raises
+        ------
+        InferenceServerException
+            If unable to unload the model.
+
+        """
+        self._last_request_id = None
+        if self._ctx is None:
+            _raise_error("ControlContext is closed")
+
+        self._last_request_id = _raise_if_error(
+            c_void_p(_crequest_control_ctx_unload(self._ctx, model_name)))
+        return
+
+    def get_last_request_id(self):
+        """Get the request ID of the most recent load() or unload()
+        request.
 
         Returns
         -------

--- a/src/clients/python/crequest.h
+++ b/src/clients/python/crequest.h
@@ -69,6 +69,18 @@ nic::Error* ServerStatusContextGetServerStatus(
     ServerStatusContextCtx* ctx, char** status, uint32_t* status_len);
 
 //==============================================================================
+// ControlContext
+typedef struct ControlContextCtx ControlContextCtx;
+nic::Error* ControlContextNew(
+    ControlContextCtx** ctx, const char* url, int protocol_int,
+    const char** headers, int num_headers, bool verbose);
+void ControlContextDelete(ControlContextCtx* ctx);
+nic::Error* ControlContextLoad(
+    ControlContextCtx* ctx, const char* model_name);
+nic::Error* ControlContextUnload(
+    ControlContextCtx* ctx, const char* model_name);
+
+//==============================================================================
 // InferContext
 typedef struct InferContextCtx InferContextCtx;
 nic::Error* InferContextNew(

--- a/src/core/constants.h
+++ b/src/core/constants.h
@@ -37,6 +37,7 @@ constexpr char kInferRESTEndpoint[] = "api/infer";
 constexpr char kStatusRESTEndpoint[] = "api/status";
 constexpr char kProfileRESTEndpoint[] = "api/profile";
 constexpr char kHealthRESTEndpoint[] = "api/health";
+constexpr char kControlRESTEndpoint[] = "api/control";
 
 #ifdef TRTIS_ENABLE_TENSORFLOW
 constexpr char kTensorFlowGraphDefPlatform[] = "tensorflow_graphdef";

--- a/src/core/model_repository_manager.cc
+++ b/src/core/model_repository_manager.cc
@@ -1020,12 +1020,9 @@ ModelRepositoryManager::LoadUnloadModel(
     std::lock_guard<std::mutex> lk(infos_mu_);
     if (type == ActionType::UNLOAD) {
       size_t erased_cnt = infos_.erase(model_name);
-      if (erased_cnt == 0) {
-        return Status(
-            RequestStatusCode::NOT_FOUND,
-            "model '" + model_name + "' is not loaded");
+      if (erased_cnt != 0) {
+        deleted.insert(model_name);
       }
-      deleted.insert(model_name);
     } else {
       const auto full_path = JoinPath({repository_path_, model_name});
 

--- a/src/core/trtserver.h
+++ b/src/core/trtserver.h
@@ -510,9 +510,9 @@ TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_ServerModelStatus(
     TRTSERVER_Server* server, const char* model_name,
     TRTSERVER_Protobuf** status);
 
-/// Load the requested model or reload the model if it has been
-/// loaded.  The function does not return until the model is loaded or
-/// fails to load.  Returned error indicates if model loaded
+/// Load the requested model or reload the model if it is already
+/// loaded. The function does not return until the model is loaded or
+/// fails to load. Returned error indicates if model loaded
 /// successfully or not.
 /// \param server The inference server object.
 /// \param model_name The name of the model.
@@ -520,9 +520,10 @@ TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_ServerModelStatus(
 TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_LoadModel(
     TRTSERVER_Server* server, const char* model_name);
 
-/// Unload the requested model.  The function does not return until the
-/// model is unloaded or fails to unload.  Returned error indicates if
-/// model unloaded successfully or not.
+/// Unload the requested model. Unloading a model that is not loaded
+/// on server has no affect and success code will be returned.
+/// The function does not return until the model is unloaded or fails to unload.
+/// Returned error indicates if model unloaded successfully or not.
 /// \param server The inference server object.
 /// \param model_name The name of the model.
 /// \return a TRTSERVER_Error indicating success or failure.


### PR DESCRIPTION
This change depends on #468 (implemented based on `grpc_service.proto` in that change)