### PR TITLE
Fix CustomGetOutputFn_t for non-required output

### DIFF
--- a/src/backends/custom/custom_backend.cc
+++ b/src/backends/custom/custom_backend.cc
@@ -468,7 +468,8 @@ CustomBackend::Context::GetOutput(
 
   // If there is no response provider return content == nullptr with
   // OK status as an indication that the output should not be written.
-  if (payload->response_provider_ != nullptr) {
+  if ((payload->response_provider_ != nullptr) &&
+        payload->response_provider_->RequiresOutput(std::string(cname))) {
     std::vector<int64_t> shape;
     if (shape_dim_cnt > 0) {
       shape.assign(shape_dims, shape_dims + shape_dim_cnt);


### PR DESCRIPTION
Should return true and set `content` to `nullptr` if the output is not required, to be consistent with the [description](https://github.com/NVIDIA/tensorrt-inference-server/blob/master/src/backends/custom/custom.h#L177)