### PR TITLE
Server side implementation for System Shared Memory

### DIFF
--- a/src/clients/c++/perf_client.cc
+++ b/src/clients/c++/perf_client.cc
@@ -2167,13 +2167,14 @@ main(int argc, char** argv)
           const auto& version = model_info.first.second;
           const auto name_ver = name + "_v" + std::to_string(version);
 
-          std::ofstream ofs(name_ver + "." +filename, std::ofstream::out);
+          std::ofstream ofs(name_ver + "." + filename, std::ofstream::out);
           ofs << "Concurrency,Inferences/Second,Client Send,"
-            << "Network+Server Send/Recv,Server Queue,"
-            << "Server Compute,Client Recv" << std::endl;
+              << "Network+Server Send/Recv,Server Queue,"
+              << "Server Compute,Client Recv" << std::endl;
 
           for (PerfStatus& status : summary) {
-            auto it = status.server_composing_model_stats.find(model_info.first);
+            auto it =
+                status.server_composing_model_stats.find(model_info.first);
             const auto& stats = it->second;
             uint64_t avg_queue_ns = stats.queue_time_ns / stats.request_count;
             uint64_t avg_compute_ns =
@@ -2185,12 +2186,12 @@ main(int argc, char** argv)
                     : 0;
             // infer / sec of the composing model is calculated using the
             // request count ratio between the composing model and the ensemble
-            double infer_ratio = 1.0 * stats.request_count / status.server_stats.request_count;
+            double infer_ratio =
+                1.0 * stats.request_count / status.server_stats.request_count;
             int infer_per_sec = infer_ratio * status.client_infer_per_sec;
             ofs << status.concurrency << "," << infer_per_sec << ",0,"
-                << (avg_overhead_ns / 1000) << ","
-                << (avg_queue_ns / 1000) << "," << (avg_compute_ns / 1000)
-                << ",0" << std::endl;
+                << (avg_overhead_ns / 1000) << "," << (avg_queue_ns / 1000)
+                << "," << (avg_compute_ns / 1000) << ",0" << std::endl;
           }
         }
       }

--- a/src/clients/c++/request.cc
+++ b/src/clients/c++/request.cc
@@ -36,6 +36,7 @@ ProfileContext::~ProfileContext() {}
 ServerHealthContext::~ServerHealthContext() {}
 ServerStatusContext::~ServerStatusContext() {}
 ModelControlContext::~ModelControlContext() {}
+SharedMemoryControlContext::~SharedMemoryControlContext() {}
 InferContext::Input::~Input() {}
 InferContext::Output::~Output() {}
 InferContext::Result::~Result() {}

--- a/src/clients/c++/request.h
+++ b/src/clients/c++/request.h
@@ -770,18 +770,25 @@ class SharedMemoryControlContext {
  public:
   virtual ~SharedMemoryControlContext() = 0;
 
-  /// Register a model on the inference server. If the shared memory is already
-  /// loaded, it will be reloaded to update the LRU policy. \param name The
-  /// name of the shared memory region to be registered. \return Error object
-  /// indicating success or failure.
+  /// Register a shared memory region on the inference server. If the shared
+  /// memory region is already registered, it will be unregistered and then
+  /// re-registered.
+  /// \param name The user-given name for the shared memory region to be
+  /// registered.
+  /// \param shm_key The unique name of the location in shared memory being
+  /// registered.
+  /// \param offset The offset into the shared memory region.
+  /// \param byte_size The size, in bytes of the tensor data.
+  /// \return Error object indicating success or failure.
   virtual Error RegisterSharedMemory(
       const std::string& name, const std::string& shm_key, size_t offset,
       size_t byte_size) = 0;
 
-  /// Unload a model from the inference server. unregistering a shared memory
-  /// region that is not registered on server has no affect and success code
-  /// will be returned. \param name The name of the shared memory region to
-  /// be unregistered. \return Error object indicating success or failure.
+  /// Unregister a registered shared memory region on the inference server. If
+  /// the shared memory region is not registered, do nothing and return failure.
+  /// \param name The user-given name for the shared memory region to be
+  /// unregistered.
+  /// \return Error object indicating success or failure.
   virtual Error UnregisterSharedMemory(const std::string& name) = 0;
 };
 

--- a/src/clients/c++/request.h
+++ b/src/clients/c++/request.h
@@ -771,8 +771,8 @@ class SharedMemoryControlContext {
   virtual ~SharedMemoryControlContext() = 0;
 
   /// Register a shared memory region on the inference server. If the shared
-  /// memory region is already registered, it will be unregistered and then
-  /// re-registered.
+  /// memory region is already registered, it will return an error message
+  /// with the error code 'TRTSERVER_ERROR_ALEADY_EXISTS'.
   /// \param name The user-given name for the shared memory region to be
   /// registered.
   /// \param shm_key The unique name of the location in shared memory being
@@ -785,7 +785,7 @@ class SharedMemoryControlContext {
       size_t byte_size) = 0;
 
   /// Unregister a registered shared memory region on the inference server. If
-  /// the shared memory region is not registered, do nothing and return failure.
+  /// the shared memory region is not registered, do nothing and return success.
   /// \param name The user-given name for the shared memory region to be
   /// unregistered.
   /// \return Error object indicating success or failure.

--- a/src/clients/c++/request.h
+++ b/src/clients/c++/request.h
@@ -747,8 +747,9 @@ class ModelControlContext {
 
 //==============================================================================
 /// A SharedMemoryControlContext object is used to control the registration /
-/// unregistration of shared memory regions on the inference server. Once
-/// created, a SharedMemoryControlContext object can be used repeatedly.
+/// unregistration and get the status of shared memory regions on the inference
+/// server. Once created, a SharedMemoryControlContext object can be used
+/// repeatedly.
 ///
 /// A SharedMemoryControlContext object can use either HTTP protocol or GRPC
 /// protocol depending on the Create function
@@ -763,6 +764,11 @@ class ModelControlContext {
 ///   ctx->RegisterSharedMemory(name, shm_key, 0, 104);
 ///   ...
 ///   ctx->UnregisterSharedMemory(name);
+///   ...
+///   ctx->UnregisterAllSharedMemory();
+///   ...
+///   std::vector<std::string> active_shm_regions;
+///   ctx->GetSharedMemoryStatus(active_shm_regions);
 ///   ...
 /// \endcode
 ///
@@ -790,6 +796,17 @@ class SharedMemoryControlContext {
   /// unregistered.
   /// \return Error object indicating success or failure.
   virtual Error UnregisterSharedMemory(const std::string& name) = 0;
+
+  /// Unregisters all registered shared memory regions on the inference server.
+  /// \return Error object indicating success or failure.
+  virtual Error UnregisterAllSharedMemory() = 0;
+
+  /// Get the list of names of all registered (active) shared memory regions on
+  /// the inference server. It is empty if there are none.
+  /// \param active_shm_regions The vector of names to be populated with the
+  /// list of active shared memory regions.
+  /// \return Error object indicating success or failure.
+  virtual Error GetSharedMemoryStatus() = 0;
 };
 
 //==============================================================================

--- a/src/clients/c++/request.h
+++ b/src/clients/c++/request.h
@@ -715,7 +715,7 @@ class ProfileContext {
 /// can be used repeatedly.
 ///
 /// A ModelControlContext object can use either HTTP protocol or GRPC protocol
-/// depending on the Create function (ControlHttpContext::Create or
+/// depending on the Create function (ModelControlHttpContext::Create or
 /// ModelControlGrpcContext::Create). For example:
 ///
 /// \code
@@ -743,6 +743,46 @@ class ModelControlContext {
   /// \param model_name The name of the model to be unloaded.
   /// \return Error object indicating success or failure.
   virtual Error Unload(const std::string& model_name) = 0;
+};
+
+//==============================================================================
+/// A SharedMemoryControlContext object is used to control the registration /
+/// unregistration of shared memory regions on the inference server. Once
+/// created, a SharedMemoryControlContext object can be used repeatedly.
+///
+/// A SharedMemoryControlContext object can use either HTTP protocol or GRPC
+/// protocol depending on the Create function
+/// (SharedMemoryControlHttpContext::Create or
+/// SharedMemoryControlGrpcContext::Create). For example:
+///
+/// \code
+///   std::unique_ptr<SharedMemoryControlContext> ctx;
+///   SharedMemoryControlGrpcContext::Create(&ctx, "localhost:8000");
+///   std::string name = "shared_memory";
+///   std::string shm_key = "/input";
+///   ctx->RegisterSharedMemory(name, shm_key, 0, 104);
+///   ...
+///   ctx->UnregisterSharedMemory(name);
+///   ...
+/// \endcode
+///
+class SharedMemoryControlContext {
+ public:
+  virtual ~SharedMemoryControlContext() = 0;
+
+  /// Register a model on the inference server. If the shared memory is already
+  /// loaded, it will be reloaded to update the LRU policy. \param name The
+  /// name of the shared memory region to be registered. \return Error object
+  /// indicating success or failure.
+  virtual Error RegisterSharedMemory(
+      const std::string& name, const std::string& shm_key, size_t offset,
+      size_t byte_size) = 0;
+
+  /// Unload a model from the inference server. unregistering a shared memory
+  /// region that is not registered on server has no affect and success code
+  /// will be returned. \param name The name of the shared memory region to
+  /// be unregistered. \return Error object indicating success or failure.
+  virtual Error UnregisterSharedMemory(const std::string& name) = 0;
 };
 
 //==============================================================================

--- a/src/clients/c++/request_grpc.cc
+++ b/src/clients/c++/request_grpc.cc
@@ -371,8 +371,8 @@ class SharedMemoryControlGrpcContextImpl : public SharedMemoryControlContext {
  public:
   SharedMemoryControlGrpcContextImpl(const std::string& url, bool verbose);
   Error RegisterSharedMemory(
-      const std::string& name, const std::string& shm_key,
-      const size_t offset, const size_t byte_size) override;
+      const std::string& name, const std::string& shm_key, const size_t offset,
+      const size_t byte_size) override;
   Error UnregisterSharedMemory(const std::string& name) override;
 
  private:
@@ -395,8 +395,8 @@ SharedMemoryControlGrpcContextImpl::SharedMemoryControlGrpcContextImpl(
 
 Error
 SharedMemoryControlGrpcContextImpl::RegisterSharedMemory(
-    const std::string& name, const std::string& shm_key,
-    const size_t offset, const size_t byte_size)
+    const std::string& name, const std::string& shm_key, const size_t offset,
+    const size_t byte_size)
 {
   return SendRequest(name, true, shm_key, offset, byte_size);
 }
@@ -410,8 +410,8 @@ SharedMemoryControlGrpcContextImpl::UnregisterSharedMemory(
 
 Error
 SharedMemoryControlGrpcContextImpl::SendRequest(
-    const std::string& name, const bool is_register,
-    const std::string& shm_key, const size_t offset, const size_t byte_size)
+    const std::string& name, const bool is_register, const std::string& shm_key,
+    const size_t offset, const size_t byte_size)
 {
   SharedMemoryControlRequest request;
   SharedMemoryControlResponse response;

--- a/src/clients/c++/request_grpc.h
+++ b/src/clients/c++/request_grpc.h
@@ -100,16 +100,34 @@ class ProfileGrpcContext {
 ////
 class ModelControlGrpcContext {
  public:
-  /// Create context that controls models to be loaded on a server and
-  /// to be unloaded from a server using GRPC.
+  /// Create context that controls models to be loaded on a server and to be
+  /// unloaded from a server using GRPC.
   /// \param ctx Returns the new ModelControlContext object.
   /// \param server_url The inference server name and port.
-  /// \param verbose If true generate verbose output when contacting
-  /// the inference server.
+  /// \param verbose If true generate verbose output when contacting the
+  /// inference server.
   /// \return Error object indicating success or failure.
   static Error Create(
       std::unique_ptr<ModelControlContext>* ctx, const std::string& server_url,
       bool verbose = false);
+};
+
+//==============================================================================
+//// SharedMemoryControlGrpcContext is the GRPC instantiation of
+//// SharedMemoryControlContext.
+////
+class SharedMemoryControlGrpcContext {
+ public:
+  /// Create context that controls registration / unregistration of shared
+  /// memory regions on the server using GRPC.
+  /// \param ctx Returns the new SharedMemoryControlContext object.
+  /// \param server_url The inference server name and port.
+  /// \param verbose If true generate verbose output when contacting the
+  /// inference server.
+  /// \return Error object indicating success or failure.
+  static Error Create(
+      std::unique_ptr<SharedMemoryControlContext>* ctx,
+      const std::string& server_url, bool verbose = false);
 };
 
 //==============================================================================

--- a/src/clients/c++/request_http.cc
+++ b/src/clients/c++/request_http.cc
@@ -745,8 +745,8 @@ class SharedMemoryControlHttpContextImpl : public SharedMemoryControlContext {
       const std::string& url, const std::map<std::string, std::string>& headers,
       bool verbose);
   Error RegisterSharedMemory(
-      const std::string& name, const std::string& shm_key,
-      const size_t offset, const size_t byte_size) override;
+      const std::string& name, const std::string& shm_key, const size_t offset,
+      const size_t byte_size) override;
   Error UnregisterSharedMemory(const std::string& name) override;
 
  private:
@@ -778,8 +778,8 @@ SharedMemoryControlHttpContextImpl::SharedMemoryControlHttpContextImpl(
 
 Error
 SharedMemoryControlHttpContextImpl::RegisterSharedMemory(
-    const std::string& name, const std::string& shm_key,
-    const size_t offset, const size_t byte_size)
+    const std::string& name, const std::string& shm_key, const size_t offset,
+    const size_t byte_size)
 {
   return SendRequest("register", name, shm_key, offset, byte_size);
 }

--- a/src/clients/c++/request_http.cc
+++ b/src/clients/c++/request_http.cc
@@ -739,6 +739,173 @@ ModelControlHttpContext::Create(
 
 //==============================================================================
 
+class SharedMemoryControlHttpContextImpl : public SharedMemoryControlContext {
+ public:
+  SharedMemoryControlHttpContextImpl(
+      const std::string& url, const std::map<std::string, std::string>& headers,
+      bool verbose);
+  Error RegisterSharedMemory(
+      const std::string& name, const std::string& shm_key,
+      const size_t offset, const size_t byte_size) override;
+  Error UnregisterSharedMemory(const std::string& name) override;
+
+ private:
+  static size_t ResponseHeaderHandler(void*, size_t, size_t, void*);
+  Error SendRequest(
+      const std::string& action_str, const std::string& name,
+      const std::string& shm_key, const size_t offset, const size_t byte_size);
+
+  // URL for control endpoint on inference server.
+  const std::string url_;
+
+  // Custom HTTP headers
+  const std::map<std::string, std::string> headers_;
+
+  // RequestStatus received in server response
+  RequestStatus request_status_;
+
+  // Enable verbose output
+  const bool verbose_;
+};
+
+SharedMemoryControlHttpContextImpl::SharedMemoryControlHttpContextImpl(
+    const std::string& url, const std::map<std::string, std::string>& headers,
+    bool verbose)
+    : url_(url + "/" + kSharedMemoryControlRESTEndpoint), headers_(headers),
+      verbose_(verbose)
+{
+}
+
+Error
+SharedMemoryControlHttpContextImpl::RegisterSharedMemory(
+    const std::string& name, const std::string& shm_key,
+    const size_t offset, const size_t byte_size)
+{
+  return SendRequest("register", name, shm_key, offset, byte_size);
+}
+
+Error
+SharedMemoryControlHttpContextImpl::UnregisterSharedMemory(
+    const std::string& name)
+{
+  return SendRequest("unregister", name, "", 0, 0);
+}
+
+Error
+SharedMemoryControlHttpContextImpl::SendRequest(
+    const std::string& action_str, const std::string& name,
+    const std::string& shm_key, const size_t offset, const size_t byte_size)
+{
+  request_status_.Clear();
+
+  if (!curl_global.Status().IsOk()) {
+    return curl_global.Status();
+  }
+
+  CURL* curl = curl_easy_init();
+  if (!curl) {
+    return Error(
+        RequestStatusCode::INTERNAL, "failed to initialize HTTP client");
+  }
+
+  // Want binary representation of the status.
+  std::string full_url = url_ + "/" + action_str + "/" + name;
+  if (action_str == "register") {
+    full_url += "/" + shm_key + "/" + std::to_string(offset) + "/" +
+                std::to_string(byte_size);
+  }
+
+  curl_easy_setopt(curl, CURLOPT_URL, full_url.c_str());
+  curl_easy_setopt(curl, CURLOPT_USERAGENT, "libcurl-agent/1.0");
+  // use POST method
+  curl_easy_setopt(curl, CURLOPT_POST, 1L);
+  if (verbose_) {
+    curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  }
+
+  // response headers handled by ResponseHeaderHandler()
+  curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, ResponseHeaderHandler);
+  curl_easy_setopt(curl, CURLOPT_HEADERDATA, this);
+
+  // Add custom headers...
+  struct curl_slist* header_list = nullptr;
+  for (const auto& pr : headers_) {
+    std::string hdr = pr.first + ": " + pr.second;
+    header_list = curl_slist_append(header_list, hdr.c_str());
+  }
+
+  if (header_list != nullptr) {
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, header_list);
+  }
+
+  CURLcode res = curl_easy_perform(curl);
+  if (res != CURLE_OK) {
+    curl_slist_free_all(header_list);
+    curl_easy_cleanup(curl);
+    return Error(
+        RequestStatusCode::INTERNAL,
+        "HTTP client failed: " + std::string(curl_easy_strerror(res)));
+  }
+
+  // Must use long with curl_easy_getinfo
+  long http_code;
+  curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+
+  curl_slist_free_all(header_list);
+  curl_easy_cleanup(curl);
+
+  // Should have a request status, if not then create an error status.
+  if (request_status_.code() == RequestStatusCode::INVALID) {
+    request_status_.Clear();
+    request_status_.set_code(RequestStatusCode::INTERNAL);
+    request_status_.set_msg("control request did not return status");
+  }
+
+  return Error(request_status_);
+}
+
+size_t
+SharedMemoryControlHttpContextImpl::ResponseHeaderHandler(
+    void* contents, size_t size, size_t nmemb, void* userp)
+{
+  SharedMemoryControlHttpContextImpl* ctx =
+      reinterpret_cast<SharedMemoryControlHttpContextImpl*>(userp);
+
+  char* buf = reinterpret_cast<char*>(contents);
+  size_t byte_size = size * nmemb;
+
+  size_t idx = strlen(kStatusHTTPHeader);
+  if ((idx < byte_size) && !strncasecmp(buf, kStatusHTTPHeader, idx)) {
+    while ((idx < byte_size) && (buf[idx] != ':')) {
+      ++idx;
+    }
+
+    if (idx < byte_size) {
+      std::string hdr(buf + idx + 1, byte_size - idx - 1);
+
+      if (!google::protobuf::TextFormat::ParseFromString(
+              hdr, &ctx->request_status_)) {
+        ctx->request_status_.Clear();
+      }
+    }
+  }
+
+  return byte_size;
+}
+
+Error
+SharedMemoryControlHttpContext::Create(
+    std::unique_ptr<SharedMemoryControlContext>* ctx,
+    const std::string& server_url,
+    const std::map<std::string, std::string>& headers, bool verbose)
+{
+  ctx->reset(static_cast<SharedMemoryControlContext*>(
+      new SharedMemoryControlHttpContextImpl(server_url, headers, verbose)));
+  return Error::Success;
+}
+
+//==============================================================================
+
 class HttpRequestImpl : public RequestImpl {
  public:
   HttpRequestImpl(

--- a/src/clients/c++/request_http.h
+++ b/src/clients/c++/request_http.h
@@ -144,18 +144,38 @@ class ProfileHttpContext {
 ///
 class ModelControlHttpContext {
  public:
-  /// Create context that controls models to be loaded on a server and
-  /// to be unloaded from a server using HTTP
-  /// protocol.
+  /// Create context that controls models to be loaded on a server and to be
+  /// unloaded from a server using HTTP protocol.
   /// \param ctx Returns the new ModelControlContext object.
   /// \param server_url The inference server name and port.
-  /// \param headers Map of HTTP headers to use with the control
-  /// request. The map key/value indicates the header name/value.
-  /// \param verbose If true generate verbose output when contacting
-  /// the inference server.
+  /// \param headers Map of HTTP headers to use with the control request.
+  /// The map key/value indicates the header name/value.
+  /// \param verbose If true generate verbose output when contacting the
+  /// inference server.
   /// \return Error object indicating success or failure.
   static Error Create(
       std::unique_ptr<ModelControlContext>* ctx, const std::string& server_url,
+      const std::map<std::string, std::string>& headers, bool verbose = false);
+};
+
+//==============================================================================
+//// SharedMemoryControlHttpContext is the HTTP instantiation of
+//// SharedMemoryControlContext.
+////
+class SharedMemoryControlHttpContext {
+ public:
+  /// Create context that controls registration / unregistration of shared
+  /// memory regions on the server using HTTP.
+  /// \param ctx Returns the new SharedMemoryControlContext object.
+  /// \param server_url The inference server name and port.
+  /// \param headers Map of HTTP headers to use with the control request.
+  /// The map key/value indicates the header name/value.
+  /// \param verbose If true generate verbose output when contacting the
+  /// inference server.
+  /// \return Error object indicating success or failure.
+  static Error Create(
+      std::unique_ptr<SharedMemoryControlContext>* ctx,
+      const std::string& server_url,
       const std::map<std::string, std::string>& headers, bool verbose = false);
 };
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -129,6 +129,7 @@ set(
   metrics.cc
   model_config_utils.cc
   model_repository_manager.cc
+  shared_memory_manager.cc
   profile.cc
   provider.cc
   provider_utils.cc
@@ -154,6 +155,7 @@ set(
   metrics.h
   model_config_utils.h
   model_repository_manager.h
+  shared_memory_manager.h
   profile.h
   provider.h
   provider_utils.h

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -129,13 +129,13 @@ set(
   metrics.cc
   model_config_utils.cc
   model_repository_manager.cc
-  shared_memory_manager.cc
   profile.cc
   provider.cc
   provider_utils.cc
   sequence_batch_scheduler.cc
   server.cc
   server_status.cc
+  shared_memory_manager.cc
   status.cc
   trtserver.cc
 )
@@ -155,7 +155,6 @@ set(
   metrics.h
   model_config_utils.h
   model_repository_manager.h
-  shared_memory_manager.h
   profile.h
   provider.h
   provider_utils.h
@@ -163,6 +162,7 @@ set(
   sequence_batch_scheduler.h
   server.h
   server_status.h
+  shared_memory_manager.h
   status.h
   trtserver.h
 )

--- a/src/core/constants.h
+++ b/src/core/constants.h
@@ -38,6 +38,7 @@ constexpr char kStatusRESTEndpoint[] = "api/status";
 constexpr char kProfileRESTEndpoint[] = "api/profile";
 constexpr char kHealthRESTEndpoint[] = "api/health";
 constexpr char kModelControlRESTEndpoint[] = "api/modelcontrol";
+constexpr char kSharedMemoryControlRESTEndpoint[] = "api/shmcontrol";
 
 #ifdef TRTIS_ENABLE_TENSORFLOW
 constexpr char kTensorFlowGraphDefPlatform[] = "tensorflow_graphdef";

--- a/src/core/constants.h
+++ b/src/core/constants.h
@@ -38,7 +38,7 @@ constexpr char kStatusRESTEndpoint[] = "api/status";
 constexpr char kProfileRESTEndpoint[] = "api/profile";
 constexpr char kHealthRESTEndpoint[] = "api/health";
 constexpr char kModelControlRESTEndpoint[] = "api/modelcontrol";
-constexpr char kSharedMemoryControlRESTEndpoint[] = "api/shmcontrol";
+constexpr char kSharedMemoryControlRESTEndpoint[] = "api/sharedmemorycontrol";
 
 #ifdef TRTIS_ENABLE_TENSORFLOW
 constexpr char kTensorFlowGraphDefPlatform[] = "tensorflow_graphdef";

--- a/src/core/grpc_service.proto
+++ b/src/core/grpc_service.proto
@@ -308,24 +308,37 @@ message SharedMemoryControlRequest
   //@@     Types of control operations for shared memory
   //@@
   enum Type {
-    //@@    .. cpp:enumerator:: Type::UNREGISTER = 0
-    //@@
-    //@@       To unregister the specified shared memory region.
-    //@@
-    UNREGISTER = 0;
-
-    //@@    .. cpp:enumerator:: Type::REGISTER = 1
+    //@@    .. cpp:enumerator:: Type::REGISTER = 0
     //@@
     //@@       To register the specified shared memory region.
     //@@
-    REGISTER = 1;
+    REGISTER = 0;
+
+    //@@    .. cpp:enumerator:: Type::UNREGISTER = 1
+    //@@
+    //@@       To unregister the specified shared memory region.
+    //@@
+    UNREGISTER = 1;
+
+    //@@    .. cpp:enumerator:: Type::UNREGISTER_ALL = 2
+    //@@
+    //@@       To unregister all active shared memory regions.
+    //@@
+    UNREGISTER_ALL = 2;
+
+    //@@    .. cpp:enumerator:: Type::GET_STATUS = 3
+    //@@
+    //@@       To get the list of all active shared memory regions.
+    //@@
+    GET_STATUS = 3;
   }
 
   //@@
   //@@  .. cpp:var:: Type type
   //@@
-  //@@     The control type that states whether to register or unregister the
-  //@@     specified shared memory region.
+  //@@     The control type that states whether to register/unregister the
+  //@@     specified shared memory region. Unregister all active shared memory
+  //@@     regions or get the list of active shared memory regions
   //@@
   Type type = 1;
 
@@ -334,6 +347,9 @@ message SharedMemoryControlRequest
   //@@     The shared memory region to register or unregister.
   //@@     All fields are needed to REGISTER the shared memory region.
   //@@     Only 'name' is needed to UNREGISTER the shared memory region.
+  //@@     No fields are needed to UNREGISTER_ALL the active shared memory
+  //@@     regions. No fields are needed to GET_STATUS of the active shared
+  //@@     memory regions.
   //@@
   InferSharedMemoryRegion shared_memory_region = 2;
 }
@@ -351,6 +367,13 @@ message SharedMemoryControlResponse
   //@@     The status of the request, indicating success or failure.
   //@@
   RequestStatus request_status = 1;
+
+  //@@
+  //@@  .. cpp:var:: RequestStatus request_status
+  //@@
+  //@@     The list of active shared memory regions. Empty if there are none.
+  //@@
+  repeated string active_shm_regions = 2;
 }
 
 //@@

--- a/src/core/provider.cc
+++ b/src/core/provider.cc
@@ -182,6 +182,7 @@ InferRequestProvider::GetNextInputContent(
       return Status(
           RequestStatusCode::INTERNAL, "unexpected input '" + name + "'");
     }
+    
     // If using shared memory return void* to address start for that input
     if (false) {
       // TODO create a shm_manager class that does

--- a/src/core/provider.cc
+++ b/src/core/provider.cc
@@ -182,12 +182,12 @@ InferRequestProvider::GetNextInputContent(
       return Status(
           RequestStatusCode::INTERNAL, "unexpected input '" + name + "'");
     }
-    
+
     // If using shared memory return void* to address start for that input
     if (false) {
-      // TODO create a shm_manager class that does
-      // shm_open and mmap for each new shared memory region and maintains
-      // list of current / registered shm regions
+      // auto it = shared_memory_map_.find(name);
+      // *content = it->second->mapped_addr_;
+      // *content_byte_size = it->second->byte_size_;
     } else {
       auto& input_content = pr->second;
 

--- a/src/core/provider.h
+++ b/src/core/provider.h
@@ -187,6 +187,8 @@ class InferRequestProvider {
   std::unordered_map<
       std::string, std::pair<std::shared_ptr<SystemMemory>, size_t>>
       input_buffer_;
+  std::unordered_map<std::string, std::tuple<std::string, size_t, size_t>>
+      io_shm_regions_;
 };
 
 //

--- a/src/core/server.cc
+++ b/src/core/server.cc
@@ -428,16 +428,15 @@ InferenceServer::GetSharedMemoryStatus(
 }
 
 Status
-InferenceServer::GetSharedMemoryInfo(
-    const std::string& name, void** shm_mapped_addr, size_t* shm_offset)
+InferenceServer::GetSharedMemoryAddress(
+    const std::string& name, void** shm_mapped_addr)
 {
   if (shared_memory_manager_ == nullptr) {
     LOG_INFO << "No shared memory manager is available. Exiting immediately.";
     return Status::Success;
   }
 
-  return shared_memory_manager_->GetSharedMemoryInfo(
-      name, shm_mapped_addr, shm_offset);
+  return shared_memory_manager_->GetSharedMemoryAddress(name, shm_mapped_addr);
 }
 
 uint64_t

--- a/src/core/server.cc
+++ b/src/core/server.cc
@@ -404,6 +404,18 @@ InferenceServer::UnregisterSharedMemory(const std::string& name)
 }
 
 Status
+InferenceServer::UnregisterAllSharedMemory()
+{
+  if (ready_state_ != ServerReadyState::SERVER_READY) {
+    return Status(RequestStatusCode::UNAVAILABLE, "Server not ready");
+  }
+
+  ScopedAtomicIncrement inflight(inflight_request_counter_);
+
+  return shared_memory_manager_->UnregisterAllSharedMemory();
+}
+
+Status
 InferenceServer::GetSharedMemoryStatus(
     std::vector<std::string>& active_shm_regions)
 {

--- a/src/core/server.cc
+++ b/src/core/server.cc
@@ -367,6 +367,36 @@ InferenceServer::UnloadModel(const std::string& model_name)
   return model_repository_manager_->LoadUnloadModel(model_name, action_type);
 }
 
+Status
+InferenceServer::RegisterSharedMemory(
+    const std::string& name, const std::string& shm_key, const size_t offset,
+    const size_t byte_size)
+{
+  if (ready_state_ != ServerReadyState::SERVER_READY) {
+    return Status(RequestStatusCode::UNAVAILABLE, "Server not ready");
+  }
+
+  ScopedAtomicIncrement inflight(inflight_request_counter_);
+
+  auto action_type = SharedMemoryManager::ActionType::REGISTER;
+  return shared_memory_manager_->RegisterUnregisterSharedMemory(
+      name, shm_key, offset, byte_size, action_type);
+}
+
+Status
+InferenceServer::UnregisterSharedMemory(const std::string& name)
+{
+  if (ready_state_ != ServerReadyState::SERVER_READY) {
+    return Status(RequestStatusCode::UNAVAILABLE, "Server not ready");
+  }
+
+  ScopedAtomicIncrement inflight(inflight_request_counter_);
+
+  auto action_type = SharedMemoryManager::ActionType::UNREGISTER;
+  return shared_memory_manager_->RegisterUnregisterSharedMemory(
+      name, "", 0, 0, action_type);
+}
+
 uint64_t
 InferenceServer::UptimeNs() const
 {

--- a/src/core/server.cc
+++ b/src/core/server.cc
@@ -423,9 +423,21 @@ InferenceServer::GetSharedMemoryStatus(
     LOG_INFO << "No shared memory manager is available. Exiting immediately.";
     return Status::Success;
   }
-  return shared_memory_manager_->GetSharedMemoryStatus(active_shm_regions);
 
-  return Status::Success;
+  return shared_memory_manager_->GetSharedMemoryStatus(active_shm_regions);
+}
+
+Status
+InferenceServer::GetSharedMemoryInfo(
+    const std::string& name, void** shm_mapped_addr, size_t* shm_offset)
+{
+  if (shared_memory_manager_ == nullptr) {
+    LOG_INFO << "No shared memory manager is available. Exiting immediately.";
+    return Status::Success;
+  }
+
+  return shared_memory_manager_->GetSharedMemoryInfo(
+      name, shm_mapped_addr, shm_offset);
 }
 
 uint64_t

--- a/src/core/server.h
+++ b/src/core/server.h
@@ -96,7 +96,10 @@ class InferenceServer {
   // Unregister the corresponding shared memory region.
   Status UnregisterSharedMemory(const std::string& name);
 
-  // Get the list of live shared memory regions.
+  // Unregister all active shared memory regions.
+  Status UnregisterAllSharedMemory();
+
+  // Get the list of active shared memory regions.
   Status GetSharedMemoryStatus(std::vector<std::string>& active_shm_regions);
 
   // Return the ready state for the server.

--- a/src/core/server.h
+++ b/src/core/server.h
@@ -96,6 +96,9 @@ class InferenceServer {
   // Unregister the corresponding shared memory region.
   Status UnregisterSharedMemory(const std::string& name);
 
+  // Get the list of live shared memory regions.
+  Status GetLiveSharedMemory(std::vector<std::string>& active_shm_regions);
+
   // Return the ready state for the server.
   ServerReadyState ReadyState() const { return ready_state_; }
 

--- a/src/core/server.h
+++ b/src/core/server.h
@@ -38,6 +38,7 @@
 #include "src/core/provider.h"
 #include "src/core/server_status.h"
 #include "src/core/server_status.pb.h"
+#include "src/core/shared_memory_manager.h"
 #include "src/core/status.h"
 
 namespace nvidia { namespace inferenceserver {
@@ -85,6 +86,15 @@ class InferenceServer {
 
   // Unload the corresponding model.
   Status UnloadModel(const std::string& model_name);
+
+  // Register the corresponding shared memory region. Re-register the shared
+  // memory region has been registered.
+  Status RegisterSharedMemory(
+      const std::string& name, const std::string& shm_key, const size_t offset,
+      const size_t byte_size);
+
+  // Unregister the corresponding shared memory region.
+  Status UnregisterSharedMemory(const std::string& name);
 
   // Return the ready state for the server.
   ServerReadyState ReadyState() const { return ready_state_; }
@@ -191,6 +201,7 @@ class InferenceServer {
 
   std::shared_ptr<ServerStatusManager> status_manager_;
   std::unique_ptr<ModelRepositoryManager> model_repository_manager_;
+  std::unique_ptr<SharedMemoryManager> shared_memory_manager_;
 };
 
 }}  // namespace nvidia::inferenceserver

--- a/src/core/server.h
+++ b/src/core/server.h
@@ -102,9 +102,9 @@ class InferenceServer {
   // Get the list of active shared memory regions.
   Status GetSharedMemoryStatus(std::vector<std::string>& active_shm_regions);
 
-  // Get the base address and offset for the specific shared memory region
-  Status GetSharedMemoryInfo(
-      const std::string& name, void** shm_mapped_addr, size_t* shm_offset);
+  // Get the base address + offset for the specific shared memory region
+  Status GetSharedMemoryAddress(
+      const std::string& name, void** shm_mapped_addr);
 
   // Return the ready state for the server.
   ServerReadyState ReadyState() const { return ready_state_; }

--- a/src/core/server.h
+++ b/src/core/server.h
@@ -102,6 +102,10 @@ class InferenceServer {
   // Get the list of active shared memory regions.
   Status GetSharedMemoryStatus(std::vector<std::string>& active_shm_regions);
 
+  // Get the base address and offset for the specific shared memory region
+  Status GetSharedMemoryInfo(
+      const std::string& name, void** shm_mapped_addr, size_t* shm_offset);
+
   // Return the ready state for the server.
   ServerReadyState ReadyState() const { return ready_state_; }
 

--- a/src/core/server.h
+++ b/src/core/server.h
@@ -97,7 +97,7 @@ class InferenceServer {
   Status UnregisterSharedMemory(const std::string& name);
 
   // Get the list of live shared memory regions.
-  Status GetLiveSharedMemory(std::vector<std::string>& active_shm_regions);
+  Status GetSharedMemoryStatus(std::vector<std::string>& active_shm_regions);
 
   // Return the ready state for the server.
   ServerReadyState ReadyState() const { return ready_state_; }

--- a/src/core/server_status.cc
+++ b/src/core/server_status.cc
@@ -190,9 +190,17 @@ ServerStatusManager::UpdateServerStat(
       break;
     }
 
-    case ServerStatTimerScoped::Kind::CONTROL: {
+    case ServerStatTimerScoped::Kind::MODELCONTROL: {
       StatDuration* d =
           server_status_.mutable_model_control_stats()->mutable_success();
+      d->set_count(d->count() + 1);
+      d->set_total_time_ns(d->total_time_ns() + duration);
+      break;
+    }
+
+    case ServerStatTimerScoped::Kind::SHMCONTROL: {
+      StatDuration* d =
+          server_status_.mutable_shm_control_stats()->mutable_success();
       d->set_count(d->count() + 1);
       d->set_total_time_ns(d->total_time_ns() + duration);
       break;

--- a/src/core/server_status.cc
+++ b/src/core/server_status.cc
@@ -190,7 +190,7 @@ ServerStatusManager::UpdateServerStat(
       break;
     }
 
-    case ServerStatTimerScoped::Kind::MODELCONTROL: {
+    case ServerStatTimerScoped::Kind::MODEL_CONTROL: {
       StatDuration* d =
           server_status_.mutable_model_control_stats()->mutable_success();
       d->set_count(d->count() + 1);
@@ -198,7 +198,7 @@ ServerStatusManager::UpdateServerStat(
       break;
     }
 
-    case ServerStatTimerScoped::Kind::SHMCONTROL: {
+    case ServerStatTimerScoped::Kind::SHARED_MEMORY_CONTROL: {
       StatDuration* d =
           server_status_.mutable_shm_control_stats()->mutable_success();
       d->set_count(d->count() + 1);

--- a/src/core/server_status.h
+++ b/src/core/server_status.h
@@ -48,10 +48,10 @@ class ServerStatTimerScoped {
     // Stat for health request. Duration from request to response.
     HEALTH,
     // Stat for model control request. Duration from request to response.
-    MODELCONTROL,
+    MODEL_CONTROL,
     // Stat for shared memory control request. Duration from request to
     // response.
-    SHMCONTROL
+    SHARED_MEMORY_CONTROL
   };
 
   // Start server timer for a given status 'kind'.

--- a/src/core/server_status.h
+++ b/src/core/server_status.h
@@ -47,8 +47,11 @@ class ServerStatTimerScoped {
     PROFILE,
     // Stat for health request. Duration from request to response.
     HEALTH,
-    // Stat for control request. Duration from request to response.
-    CONTROL
+    // Stat for model control request. Duration from request to response.
+    MODELCONTROL,
+    // Stat for shared memory control request. Duration from request to
+    // response.
+    SHMCONTROL
   };
 
   // Start server timer for a given status 'kind'.

--- a/src/core/server_status.proto
+++ b/src/core/server_status.proto
@@ -113,6 +113,21 @@ message ModelControlRequestStats
 }
 
 //@@
+//@@.. cpp:var:: message SharedMemoryControlRequestStats
+//@@
+//@@   Statistics collected for SharedMemoryControl requests.
+//@@
+message SharedMemoryControlRequestStats
+{
+  //@@  .. cpp:var:: StatDuration success
+  //@@
+  //@@     Total time required to handle successful SharedMemoryControl
+  //@@     requests, not including HTTP or gRPC endpoint termination time.
+  //@@
+  StatDuration success = 1;
+}
+
+//@@
 //@@.. cpp:var:: message InferRequestStats
 //@@
 //@@   Statistics collected for Infer requests.
@@ -355,4 +370,10 @@ message ServerStatus
   //@@     Statistics for ModelControl requests.
   //@@
   ModelControlRequestStats model_control_stats = 9;
+
+  //@@  .. cpp:var:: SharedMemoryControlRequestStats shm_control_stats
+  //@@
+  //@@     Statistics for SharedMemoryControl requests.
+  //@@
+  SharedMemoryControlRequestStats shm_control_stats = 10;
 }

--- a/src/core/shared_memory_manager.cc
+++ b/src/core/shared_memory_manager.cc
@@ -244,4 +244,20 @@ SharedMemoryManager::GetSharedMemoryStatus(
   return Status::Success;
 }
 
+Status
+SharedMemoryManager::GetSharedMemoryInfo(
+    const std::string& name, void** shm_mapped_addr, size_t* shm_offset)
+{
+  auto it = shared_memory_map_.find(name);
+  if (it == shared_memory_map_.end()) {
+    return Status(
+        RequestStatusCode::INTERNAL,
+        "Unable to find shared memory region: '" + name + "'");
+  }
+
+  *shm_mapped_addr = it->second->mapped_addr_;
+  *shm_offset = it->second->offset_;
+  return Status::Success;
+}
+
 }}  // namespace nvidia::inferenceserver

--- a/src/core/shared_memory_manager.cc
+++ b/src/core/shared_memory_manager.cc
@@ -1,0 +1,233 @@
+// Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#include "src/core/shared_memory_manager.h"
+
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <algorithm>
+#include <deque>
+#include <exception>
+#include <future>
+#include "src/core/constants.h"
+#include "src/core/logging.h"
+#include "src/core/server_status.h"
+
+namespace nvidia { namespace inferenceserver {
+
+Status
+open_shm_region(const std::string& shm_key, int* shm_fd)
+{
+  // get shared memory region descriptor
+  *shm_fd = shm_open(shm_key.c_str(), O_RDONLY, S_IRUSR | S_IWUSR);
+  if (*shm_fd == -1) {
+    return Status(
+        RequestStatusCode::INTERNAL, "Unable to get shared memory descriptor");
+  }
+
+  return Status::Success;
+}
+
+Status
+get_shm_addr(
+    const int shm_fd, const size_t offset, const size_t byte_size,
+    void** shm_addr)
+{
+  // map shared memory to process address space
+  *shm_addr = mmap(NULL, byte_size, PROT_WRITE, MAP_SHARED, shm_fd, offset);
+  if (*shm_addr == MAP_FAILED) {
+    return Status(
+        RequestStatusCode::INTERNAL, "Unable to process address space");
+  }
+
+  return Status::Success;
+}
+
+Status
+shm_close(int shm_fd)
+{
+  int tmp = close(shm_fd);
+  if (tmp == -1) {
+    return Status(
+        RequestStatusCode::INTERNAL, "Unable to close shared memory region");
+  }
+
+  return Status::Success;
+}
+
+Status
+mmap_cleanup(void* shm_addr, size_t byte_size)
+{
+  int tmp_fd = munmap(shm_addr, byte_size);
+  if (tmp_fd == -1) {
+    return Status(
+        RequestStatusCode::INTERNAL, "Unable to munmap shared memory region");
+  }
+
+  return Status::Success;
+}
+
+Status
+SharedMemoryManager::RegisterSharedMemory(
+    const std::string& name, const std::string& shm_key, const size_t offset,
+    const size_t byte_size)
+{
+  LOG_VERBOSE(1) << "Register() shared memory region: '" << name << "'";
+  Status status = Status::Success;
+
+  // check if key is in shared_memory_map_ then remove
+  if (shared_memory_map_.find(name) != shared_memory_map_.end()) {
+    UnregisterSharedMemory(name);
+  }
+
+  // register (or re-register)
+  try {
+    void* tmp_addr;
+    int shm_fd;
+
+    // don't re-open if shared memory is alreay open
+    for (auto itr = shared_memory_map_.begin(); itr != shared_memory_map_.end();
+         ++itr) {
+      if (itr->second->shm_key_ == shm_key)
+        shm_fd = itr->second->shm_fd_;
+      else {
+        RETURN_IF_ERROR(open_shm_region(shm_key, &shm_fd));
+      }
+    }
+
+    RETURN_IF_ERROR(get_shm_addr(shm_fd, offset, byte_size, &tmp_addr));
+    std::unique_ptr<SharedMemoryInfo> shm_info(new SharedMemoryInfo(
+        name, shm_key, offset, byte_size, shm_fd, tmp_addr));
+    shared_memory_map_.insert(std::make_pair(
+        name, std::unique_ptr<SharedMemoryInfo>(new SharedMemoryInfo(
+                  name, shm_key, offset, byte_size, shm_fd, tmp_addr))));
+  }
+  catch (std::exception& ex) {
+    return Status(
+        RequestStatusCode::INVALID_ARG,
+        "Unable to register shared memory region successfully.");
+  }
+
+  return Status::Success;
+}
+
+Status
+SharedMemoryManager::UnregisterSharedMemory(const std::string& name)
+{
+  LOG_VERBOSE(1) << "Unregister() '" << name << "'";
+
+  auto it = shared_memory_map_.find(name);
+  if (it != shared_memory_map_.end()) {
+    void* tmp_addr;
+    RETURN_IF_ERROR(get_shm_addr(
+        it->second->shm_fd_, it->second->offset_, it->second->byte_size_,
+        &tmp_addr));
+    RETURN_IF_ERROR(mmap_cleanup(tmp_addr, it->second->byte_size_));
+
+    // if no other region with same shm_key then close
+    bool last_one = true;
+    for (auto itr = shared_memory_map_.begin(); itr != shared_memory_map_.end();
+         ++itr) {
+      if (itr->second->shm_key_ == it->second->shm_key_)
+        last_one = false;
+    }
+    if (last_one) {
+      RETURN_IF_ERROR(shm_close(it->second->shm_fd_));
+    }
+
+    // remove region info from shared_memory_map_
+    shared_memory_map_.erase(it);
+  } else {
+    return Status(
+        RequestStatusCode::INVALID_ARG,
+        "Cannot unregister shared memory region that has not been registered.");
+  }
+
+  return Status::Success;
+}
+
+SharedMemoryManager::SharedMemoryManager(
+    const std::shared_ptr<ServerStatusManager>& status_manager)
+    : status_manager_(status_manager)
+{
+}
+
+SharedMemoryManager::~SharedMemoryManager()
+{
+  UnregisterAllSharedMemory();
+}
+
+void
+SharedMemoryManager::Create(
+    const std::shared_ptr<ServerStatusManager>& status_manager,
+    std::unique_ptr<SharedMemoryManager>* shared_memory_manager)
+{
+  // Not setting the smart pointer directly to simplify clean up
+  std::unique_ptr<SharedMemoryManager> tmp_manager(
+      new SharedMemoryManager(status_manager));
+  *shared_memory_manager = std::move(tmp_manager);
+}
+
+Status
+SharedMemoryManager::RegisterUnregisterSharedMemory(
+    const std::string& name, const std::string& shm_key, const size_t offset,
+    const size_t byte_size, ActionType type)
+{
+  // Serialize all operations that change model state
+  std::lock_guard<std::mutex> lock(register_mu_);
+
+  // Update SharedMemoryInfo related to file system accordingly
+  std::set<std::string> added, deleted, modified;
+  {
+    std::lock_guard<std::mutex> lk(shm_info_mu_);
+    if (type == ActionType::UNREGISTER) {
+      UnregisterSharedMemory(name);
+    } else {
+      RegisterSharedMemory(name, shm_key, offset, byte_size);
+    }
+  }
+
+  return Status::Success;
+}
+
+Status
+SharedMemoryManager::UnregisterAllSharedMemory()
+{
+  for (const auto& shm_info : shared_memory_map_) {
+    Status unregister_status = UnregisterSharedMemory(shm_info.first);
+    if (!unregister_status.IsOk()) {
+      return Status(
+          RequestStatusCode::INTERNAL,
+          "Failed to gracefully unregister all shared memory regions: " +
+              unregister_status.Message());
+    }
+  }
+  return Status::Success;
+}
+
+}}  // namespace nvidia::inferenceserver

--- a/src/core/shared_memory_manager.cc
+++ b/src/core/shared_memory_manager.cc
@@ -49,7 +49,8 @@ OpenSharedMemoryRegion(const std::string& shm_key, int* shm_fd)
   *shm_fd = shm_open(shm_key.c_str(), O_RDONLY, S_IRUSR | S_IWUSR);
   if (*shm_fd == -1) {
     return Status(
-        RequestStatusCode::INTERNAL, "Unable to open shared memory region: '" + shm_key + "'");
+        RequestStatusCode::INTERNAL,
+        "Unable to open shared memory region: '" + shm_key + "'");
   }
 
   return Status::Success;
@@ -132,7 +133,7 @@ SharedMemoryManager::RegisterSharedMemory(
     RETURN_IF_ERROR(OpenSharedMemoryRegion(shm_key, &shm_fd));
   }
 
-  Status status = MapSharedMemory(shm_fd, offset, byte_size, &mapped_addr));
+  Status status = MapSharedMemory(shm_fd, offset, byte_size, &mapped_addr);
   if (!status.IsOk()) {
     return Status(
         RequestStatusCode::INVALID_ARG,
@@ -156,7 +157,8 @@ SharedMemoryManager::UnregisterSharedMemory(const std::string& name)
 
   auto it = shared_memory_map_.find(name);
   if (it != shared_memory_map_.end()) {
-    RETURN_IF_ERROR(UnmapSharedMemory(it->second->mapped_addr_, it->second->byte_size_));
+    RETURN_IF_ERROR(
+        UnmapSharedMemory(it->second->mapped_addr_, it->second->byte_size_));
 
     // remove region info from shared_memory_map_
     shared_memory_map_.erase(it);

--- a/src/core/shared_memory_manager.cc
+++ b/src/core/shared_memory_manager.cc
@@ -245,8 +245,8 @@ SharedMemoryManager::GetSharedMemoryStatus(
 }
 
 Status
-SharedMemoryManager::GetSharedMemoryInfo(
-    const std::string& name, void** shm_mapped_addr, size_t* shm_offset)
+SharedMemoryManager::GetSharedMemoryAddress(
+    const std::string& name, void** shm_mapped_addr)
 {
   auto it = shared_memory_map_.find(name);
   if (it == shared_memory_map_.end()) {
@@ -255,8 +255,8 @@ SharedMemoryManager::GetSharedMemoryInfo(
         "Unable to find shared memory region: '" + name + "'");
   }
 
-  *shm_mapped_addr = it->second->mapped_addr_;
-  *shm_offset = it->second->offset_;
+  *shm_mapped_addr =
+      (void*)((uint8_t*)it->second->mapped_addr_ + it->second->offset_);
   return Status::Success;
 }
 

--- a/src/core/shared_memory_manager.h
+++ b/src/core/shared_memory_manager.h
@@ -1,0 +1,115 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+#pragma once
+
+#include <mutex>
+#include "src/core/grpc_service.pb.h"
+#include "src/core/model_config.h"
+#include "src/core/model_config.pb.h"
+#include "src/core/status.h"
+
+namespace nvidia { namespace inferenceserver {
+
+class InferenceServer;
+class InferenceBackend;
+class ServerStatusManager;
+
+/// An object to manage the registered shared memory regions in the server.
+class SharedMemoryManager {
+ public:
+  /// A struct that records the shared memory regions registered by the shared
+  /// memory manager.
+  struct SharedMemoryInfo {
+    SharedMemoryInfo(
+        const std::string& name, const std::string& shm_key,
+        const size_t offset, const size_t byte_size, int shm_fd, void* shm_addr)
+        : name_(name), shm_key_(shm_key), offset_(offset),
+          byte_size_(byte_size), shm_fd_(shm_fd), shm_addr_(shm_addr)
+    {
+    }
+
+    std::string name_;
+    std::string shm_key_;
+    size_t offset_;
+    size_t byte_size_;
+    int shm_fd_;
+    void* shm_addr_;
+  };
+
+  using SharedMemoryStateMap =
+      std::map<std::string, std::unique_ptr<SharedMemoryInfo>>;
+
+  enum ActionType { NO_ACTION, REGISTER, UNREGISTER };
+
+  ~SharedMemoryManager();
+
+  /// Register or Unregister a specified shared memory region.
+  /// \param name The user-given name for the shared memory region to be
+  /// registered.
+  /// \param shm_key The unique name of the location in shared memory being
+  /// registered.
+  /// \param offset The offset into the shared memory region.
+  /// \param byte_size The size, in bytes of the tensor data.
+  /// \parm type The type action to be performed. If the action is REGISTER and
+  /// the shared memory region has been registered, the shared memory region
+  /// will be re-registered.
+  /// \return error status. Return "NOT_FOUND" if it tries to unregister a
+  /// shared memory region that hasn't been registered.
+  Status RegisterUnregisterSharedMemory(
+      const std::string& name, const std::string& shm_key, const size_t offset,
+      const size_t byte_size, ActionType type);
+
+  /// Helper function that (Re)registers shared memory region if valid
+  Status RegisterSharedMemory(
+      const std::string& name, const std::string& shm_key, const size_t offset,
+      const size_t byte_size);
+
+  /// Helper function that Unregisters shared memory region if it is registered
+  Status UnregisterSharedMemory(const std::string& name);
+
+  /// Unregisters all shared memory regions. This function can be called by the
+  /// user. It should be called before shutting down the shared memory manager.
+  Status UnregisterAllSharedMemory();
+
+  /// \return the list of all registered shared memory regions.
+  const SharedMemoryStateMap GetLiveBackendStates();
+
+ private:
+  void Create(
+      const std::shared_ptr<ServerStatusManager>& status_manager,
+      std::unique_ptr<SharedMemoryManager>* shared_memory_manager);
+  SharedMemoryManager(
+      const std::shared_ptr<ServerStatusManager>& status_manager);
+
+  std::mutex shm_info_mu_;
+  std::mutex register_mu_;
+
+  std::shared_ptr<ServerStatusManager> status_manager_;
+  SharedMemoryStateMap shared_memory_map_;
+};
+
+}}  // namespace nvidia::inferenceserver

--- a/src/core/shared_memory_manager.h
+++ b/src/core/shared_memory_manager.h
@@ -98,10 +98,10 @@ class SharedMemoryManager {
   /// the inference server. It is empty if there are none.
   Status GetSharedMemoryStatus(std::vector<std::string>& active_shm_regions);
 
-  // Get the base address and offset for the specific shared memory region. If
+  // Get the base address + offset for the specific shared memory region. If
   // the shared memory region is not valid return an error message
-  Status GetSharedMemoryInfo(
-      const std::string& name, void** shm_mapped_addr, size_t* shm_offset);
+  Status GetSharedMemoryAddress(
+      const std::string& name, void** shm_mapped_addr);
 
   /// Creates a SharedMemoryManager object that uses the given status_manager
   static Status Create(

--- a/src/core/shared_memory_manager.h
+++ b/src/core/shared_memory_manager.h
@@ -95,13 +95,15 @@ class SharedMemoryManager {
   /// user. It should be called before shutting down the shared memory manager.
   Status UnregisterAllSharedMemory();
 
-  /// \return the list of all registered shared memory regions.
-  const SharedMemoryStateMap GetLiveBackendStates();
+  /// updates the list of all registered shared memory regions.
+  Status GetLiveSharedMemory(std::vector<std::string>& active_shm_regions);
 
- private:
-  void Create(
+  /// Creates a SharedMemoryManager object that uses the given status_manager
+  static Status Create(
       const std::shared_ptr<ServerStatusManager>& status_manager,
       std::unique_ptr<SharedMemoryManager>* shared_memory_manager);
+
+ private:
   SharedMemoryManager(
       const std::shared_ptr<ServerStatusManager>& status_manager);
 

--- a/src/core/shared_memory_manager.h
+++ b/src/core/shared_memory_manager.h
@@ -46,7 +46,8 @@ class SharedMemoryManager {
   struct SharedMemoryInfo {
     SharedMemoryInfo(
         const std::string& name, const std::string& shm_key,
-        const size_t offset, const size_t byte_size, int shm_fd, void* mapped_addr)
+        const size_t offset, const size_t byte_size, int shm_fd,
+        void* mapped_addr)
         : name_(name), shm_key_(shm_key), offset_(offset),
           byte_size_(byte_size), shm_fd_(shm_fd), mapped_addr_(mapped_addr)
     {
@@ -93,7 +94,8 @@ class SharedMemoryManager {
   /// automatically when destroying the shared memory manager.
   Status UnregisterAllSharedMemory();
 
-  /// updates the list of all registered shared memory regions.
+  /// Get the list of names of all registered (active) shared memory regions on
+  /// the inference server. It is empty if there are none.
   Status GetSharedMemoryStatus(std::vector<std::string>& active_shm_regions);
 
   /// Creates a SharedMemoryManager object that uses the given status_manager

--- a/src/core/shared_memory_manager.h
+++ b/src/core/shared_memory_manager.h
@@ -98,6 +98,11 @@ class SharedMemoryManager {
   /// the inference server. It is empty if there are none.
   Status GetSharedMemoryStatus(std::vector<std::string>& active_shm_regions);
 
+  // Get the base address and offset for the specific shared memory region. If
+  // the shared memory region is not valid return an error message
+  Status GetSharedMemoryInfo(
+      const std::string& name, void** shm_mapped_addr, size_t* shm_offset);
+
   /// Creates a SharedMemoryManager object that uses the given status_manager
   static Status Create(
       const std::shared_ptr<ServerStatusManager>& status_manager,

--- a/src/core/trtserver.cc
+++ b/src/core/trtserver.cc
@@ -612,6 +612,35 @@ TRTSERVER_InferenceRequestProviderSetInputData(
   return nullptr;  // Success
 }
 
+TRTSERVER_Error*
+TRTSERVER_InferenceRequestProviderSetSharedMemoryInputData(
+    TRTSERVER_Server* server,
+    TRTSERVER_InferenceRequestProvider* request_provider,
+    const char* input_name, const char* shm_name, size_t offset,
+    size_t byte_size)
+{
+  TrtServerRequestProvider* lprovider =
+      reinterpret_cast<TrtServerRequestProvider*>(request_provider);
+
+  void* shm_mapped_addr;
+  size_t shm_offset;
+  TRTSERVER_Error* err = TRTSERVER_ServerGetSharedMemoryInfo(
+      server, shm_name, &shm_mapped_addr, &shm_offset);
+  if (err != nullptr) {
+    return TRTSERVER_ErrorNew(
+        TRTSERVER_ERROR_INVALID_ARG,
+        std::string(
+            "shared memory region '" + std::string(shm_name) + "' is not valid")
+            .c_str());
+  }
+
+  // modify base by adding current offset as well are shared region offset
+  lprovider->SetInputData(
+      input_name, (void*)((char*)shm_mapped_addr + offset + shm_offset),
+      byte_size);
+  return nullptr;  // Success
+}
+
 //
 // TRTSERVER_InferenceResponse
 //
@@ -1083,6 +1112,23 @@ TRTSERVER_ServerGetSharedMemoryStatus(
       ni::ServerStatTimerScoped::Kind::SHARED_MEMORY_CONTROL);
 
   RETURN_IF_STATUS_ERROR(lserver->GetSharedMemoryStatus(active_shm_regions));
+
+  return nullptr;  // success
+}
+
+TRTSERVER_Error*
+TRTSERVER_ServerGetSharedMemoryInfo(
+    TRTSERVER_Server* server, const char* name, void** shm_mapped_addr,
+    size_t* shm_offset)
+{
+  ni::InferenceServer* lserver = reinterpret_cast<ni::InferenceServer*>(server);
+
+  ni::ServerStatTimerScoped timer(
+      lserver->StatusManager(),
+      ni::ServerStatTimerScoped::Kind::SHARED_MEMORY_CONTROL);
+
+  RETURN_IF_STATUS_ERROR(lserver->GetSharedMemoryInfo(
+      std::string(name), shm_mapped_addr, shm_offset));
 
   return nullptr;  // success
 }

--- a/src/core/trtserver.cc
+++ b/src/core/trtserver.cc
@@ -623,9 +623,8 @@ TRTSERVER_InferenceRequestProviderSetSharedMemoryInputData(
       reinterpret_cast<TrtServerRequestProvider*>(request_provider);
 
   void* shm_mapped_addr;
-  size_t shm_offset;
-  TRTSERVER_Error* err = TRTSERVER_ServerGetSharedMemoryInfo(
-      server, shm_name, &shm_mapped_addr, &shm_offset);
+  TRTSERVER_Error* err = TRTSERVER_ServerGetSharedMemoryAddress(
+      server, shm_name, &shm_mapped_addr);
   if (err != nullptr) {
     return TRTSERVER_ErrorNew(
         TRTSERVER_ERROR_INVALID_ARG,
@@ -634,10 +633,9 @@ TRTSERVER_InferenceRequestProviderSetSharedMemoryInputData(
             .c_str());
   }
 
-  // modify base by adding current offset as well are shared region offset
+  // modify mapped appress by adding current offset
   lprovider->SetInputData(
-      input_name, (void*)((char*)shm_mapped_addr + offset + shm_offset),
-      byte_size);
+      input_name, (void*)((char*)shm_mapped_addr + offset), byte_size);
   return nullptr;  // Success
 }
 
@@ -1117,9 +1115,8 @@ TRTSERVER_ServerGetSharedMemoryStatus(
 }
 
 TRTSERVER_Error*
-TRTSERVER_ServerGetSharedMemoryInfo(
-    TRTSERVER_Server* server, const char* name, void** shm_mapped_addr,
-    size_t* shm_offset)
+TRTSERVER_ServerGetSharedMemoryAddress(
+    TRTSERVER_Server* server, const char* name, void** shm_mapped_addr)
 {
   ni::InferenceServer* lserver = reinterpret_cast<ni::InferenceServer*>(server);
 
@@ -1127,8 +1124,8 @@ TRTSERVER_ServerGetSharedMemoryInfo(
       lserver->StatusManager(),
       ni::ServerStatTimerScoped::Kind::SHARED_MEMORY_CONTROL);
 
-  RETURN_IF_STATUS_ERROR(lserver->GetSharedMemoryInfo(
-      std::string(name), shm_mapped_addr, shm_offset));
+  RETURN_IF_STATUS_ERROR(
+      lserver->GetSharedMemoryAddress(std::string(name), shm_mapped_addr));
 
   return nullptr;  // success
 }

--- a/src/core/trtserver.cc
+++ b/src/core/trtserver.cc
@@ -26,6 +26,8 @@
 
 #include "src/core/trtserver.h"
 
+#include <string>
+#include <vector>
 #include "src/core/backend.h"
 #include "src/core/logging.h"
 #include "src/core/metrics.h"
@@ -1052,6 +1054,35 @@ TRTSERVER_ServerUnregisterSharedMemory(
       ni::ServerStatTimerScoped::Kind::SHARED_MEMORY_CONTROL);
 
   RETURN_IF_STATUS_ERROR(lserver->UnregisterSharedMemory(std::string(name)));
+
+  return nullptr;  // success
+}
+
+TRTSERVER_Error*
+TRTSERVER_ServerUnregisterAllSharedMemory(TRTSERVER_Server* server)
+{
+  ni::InferenceServer* lserver = reinterpret_cast<ni::InferenceServer*>(server);
+
+  ni::ServerStatTimerScoped timer(
+      lserver->StatusManager(),
+      ni::ServerStatTimerScoped::Kind::SHARED_MEMORY_CONTROL);
+
+  RETURN_IF_STATUS_ERROR(lserver->UnregisterAllSharedMemory());
+
+  return nullptr;  // success
+}
+
+TRTSERVER_Error*
+TRTSERVER_ServerGetSharedMemoryStatus(
+    TRTSERVER_Server* server, std::vector<std::string>& active_shm_regions)
+{
+  ni::InferenceServer* lserver = reinterpret_cast<ni::InferenceServer*>(server);
+
+  ni::ServerStatTimerScoped timer(
+      lserver->StatusManager(),
+      ni::ServerStatTimerScoped::Kind::SHARED_MEMORY_CONTROL);
+
+  RETURN_IF_STATUS_ERROR(lserver->GetSharedMemoryStatus(active_shm_regions));
 
   return nullptr;  // success
 }

--- a/src/core/trtserver.cc
+++ b/src/core/trtserver.cc
@@ -1004,7 +1004,7 @@ TRTSERVER_ServerLoadModel(TRTSERVER_Server* server, const char* model_name)
   ni::InferenceServer* lserver = reinterpret_cast<ni::InferenceServer*>(server);
 
   ni::ServerStatTimerScoped timer(
-      lserver->StatusManager(), ni::ServerStatTimerScoped::Kind::CONTROL);
+      lserver->StatusManager(), ni::ServerStatTimerScoped::Kind::MODELCONTROL);
 
   RETURN_IF_STATUS_ERROR(lserver->LoadModel(std::string(model_name)));
 
@@ -1017,9 +1017,38 @@ TRTSERVER_ServerUnloadModel(TRTSERVER_Server* server, const char* model_name)
   ni::InferenceServer* lserver = reinterpret_cast<ni::InferenceServer*>(server);
 
   ni::ServerStatTimerScoped timer(
-      lserver->StatusManager(), ni::ServerStatTimerScoped::Kind::CONTROL);
+      lserver->StatusManager(), ni::ServerStatTimerScoped::Kind::MODELCONTROL);
 
   RETURN_IF_STATUS_ERROR(lserver->UnloadModel(std::string(model_name)));
+
+  return nullptr;  // success
+}
+
+TRTSERVER_Error*
+TRTSERVER_RegisterSharedMemory(
+    TRTSERVER_Server* server, const char* name, const char* shm_key,
+    const size_t offset, const size_t byte_size)
+{
+  ni::InferenceServer* lserver = reinterpret_cast<ni::InferenceServer*>(server);
+
+  ni::ServerStatTimerScoped timer(
+      lserver->StatusManager(), ni::ServerStatTimerScoped::Kind::SHMCONTROL);
+
+  RETURN_IF_STATUS_ERROR(lserver->RegisterSharedMemory(
+      std::string(name), std::string(shm_key), offset, byte_size));
+
+  return nullptr;  // success
+}
+
+TRTSERVER_Error*
+TRTSERVER_UnregisterSharedMemory(TRTSERVER_Server* server, const char* name)
+{
+  ni::InferenceServer* lserver = reinterpret_cast<ni::InferenceServer*>(server);
+
+  ni::ServerStatTimerScoped timer(
+      lserver->StatusManager(), ni::ServerStatTimerScoped::Kind::SHMCONTROL);
+
+  RETURN_IF_STATUS_ERROR(lserver->UnregisterSharedMemory(std::string(name)));
 
   return nullptr;  // success
 }

--- a/src/core/trtserver.cc
+++ b/src/core/trtserver.cc
@@ -1004,7 +1004,7 @@ TRTSERVER_ServerLoadModel(TRTSERVER_Server* server, const char* model_name)
   ni::InferenceServer* lserver = reinterpret_cast<ni::InferenceServer*>(server);
 
   ni::ServerStatTimerScoped timer(
-      lserver->StatusManager(), ni::ServerStatTimerScoped::Kind::MODELCONTROL);
+      lserver->StatusManager(), ni::ServerStatTimerScoped::Kind::MODEL_CONTROL);
 
   RETURN_IF_STATUS_ERROR(lserver->LoadModel(std::string(model_name)));
 
@@ -1017,7 +1017,7 @@ TRTSERVER_ServerUnloadModel(TRTSERVER_Server* server, const char* model_name)
   ni::InferenceServer* lserver = reinterpret_cast<ni::InferenceServer*>(server);
 
   ni::ServerStatTimerScoped timer(
-      lserver->StatusManager(), ni::ServerStatTimerScoped::Kind::MODELCONTROL);
+      lserver->StatusManager(), ni::ServerStatTimerScoped::Kind::MODEL_CONTROL);
 
   RETURN_IF_STATUS_ERROR(lserver->UnloadModel(std::string(model_name)));
 
@@ -1025,14 +1025,15 @@ TRTSERVER_ServerUnloadModel(TRTSERVER_Server* server, const char* model_name)
 }
 
 TRTSERVER_Error*
-TRTSERVER_RegisterSharedMemory(
+TRTSERVER_ServerRegisterSharedMemory(
     TRTSERVER_Server* server, const char* name, const char* shm_key,
     const size_t offset, const size_t byte_size)
 {
   ni::InferenceServer* lserver = reinterpret_cast<ni::InferenceServer*>(server);
 
   ni::ServerStatTimerScoped timer(
-      lserver->StatusManager(), ni::ServerStatTimerScoped::Kind::SHMCONTROL);
+      lserver->StatusManager(),
+      ni::ServerStatTimerScoped::Kind::SHARED_MEMORY_CONTROL);
 
   RETURN_IF_STATUS_ERROR(lserver->RegisterSharedMemory(
       std::string(name), std::string(shm_key), offset, byte_size));
@@ -1041,12 +1042,14 @@ TRTSERVER_RegisterSharedMemory(
 }
 
 TRTSERVER_Error*
-TRTSERVER_UnregisterSharedMemory(TRTSERVER_Server* server, const char* name)
+TRTSERVER_ServerUnregisterSharedMemory(
+    TRTSERVER_Server* server, const char* name)
 {
   ni::InferenceServer* lserver = reinterpret_cast<ni::InferenceServer*>(server);
 
   ni::ServerStatTimerScoped timer(
-      lserver->StatusManager(), ni::ServerStatTimerScoped::Kind::SHMCONTROL);
+      lserver->StatusManager(),
+      ni::ServerStatTimerScoped::Kind::SHARED_MEMORY_CONTROL);
 
   RETURN_IF_STATUS_ERROR(lserver->UnregisterSharedMemory(std::string(name)));
 

--- a/src/core/trtserver.h
+++ b/src/core/trtserver.h
@@ -715,12 +715,10 @@ TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_ServerGetSharedMemoryStatus(
 /// an error message.
 /// \param server The inference server object.
 /// \param shm_name The user-given name for the shared memory region.
-/// \param shm_mapped_addr The start address of the shared memory region.
-/// \param offset The offset into the shared memory region to be read.
+/// \param shm_mapped_addr The offseted address of the shared memory region.
 /// \return a TRTSERVER_Error indicating success or failure.
-TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_ServerGetSharedMemoryInfo(
-    TRTSERVER_Server* server, const char* shm_name, void** shm_mapped_addr,
-    size_t* shm_offset);
+TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_ServerGetSharedMemoryAddress(
+    TRTSERVER_Server* server, const char* shm_name, void** shm_mapped_addr);
 
 /// Get the current metrics for the server. The caller takes ownership
 /// of the metrics object and must call TRTSERVER_MetricsDelete to

--- a/src/core/trtserver.h
+++ b/src/core/trtserver.h
@@ -647,9 +647,9 @@ TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_ServerUnloadModel(
     TRTSERVER_Server* server, const char* model_name);
 
 /// Register a shared memory region on the inference server. If the shared
-/// memory region is already registered, it will be unregistered and then
-/// re-registered. Returned error indicates if shared memory region was
-/// registered successfully or not.
+/// memory region is already registered, it will return an error message.
+/// Returned error indicates if shared memory region is registered successfully
+/// or not.
 /// \param server The inference server object.
 /// \param name The user-given name for the shared memory region to be
 /// registered.
@@ -658,19 +658,18 @@ TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_ServerUnloadModel(
 /// \param offset The offset into the shared memory region.
 /// \param byte_size The size, in bytes of the tensor data.
 /// \return a TRTSERVER_Error indicating success or failure.
-TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_RegisterSharedMemory(
+TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_ServerRegisterSharedMemory(
     TRTSERVER_Server* server, const char* name, const char* shm_key,
     const size_t offset, const size_t byte_size);
 
 /// Unregister a registered shared memory region on the inference server. If
-/// the shared memory region is not registered, do nothing and return failure.
-/// Returned error indicates if the shared memory region was unregistered
-/// successfully or not.
+/// the shared memory region is not registered, do nothing. Returned error
+/// indicates if the shared memory region was unregistered successfully or not.
 /// \param server The inference server object.
 /// \param name The user-given name for the shared memory region to be
 /// registered.
 /// \return a TRTSERVER_Error indicating success or failure.
-TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_UnregisterSharedMemory(
+TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_ServerUnregisterSharedMemory(
     TRTSERVER_Server* server, const char* name);
 
 /// Get the current metrics for the server. The caller takes ownership

--- a/src/core/trtserver.h
+++ b/src/core/trtserver.h
@@ -322,6 +322,26 @@ TRTSERVER_InferenceRequestProviderSetInputData(
     TRTSERVER_InferenceRequestProvider* request_provider, const char* name,
     const void* base, size_t byte_size);
 
+/// Assign a buffer of data to an input by pointing to that location in shared
+/// memory. The 'request_provider' takes ownership of the buffer in the shared
+/// memory region and so the caller should not modify or free the shared memory
+/// region until that ownership is released when 'request_provider' is deleted.
+/// The total size of data that is provided for an input must equal the
+/// batch_byte_size for that input.
+/// \param server The inference server object.
+/// \param request_provider The request provider object.
+/// \param input_name The name of the input.
+/// \param input_name The name of the registered shared memory region to use.
+/// \param offset The offset from the start address of the registered shared
+/// memory region. \param byte_size The size, in bytes, of the input data.
+/// \return a TRTSERVER_Error indicating success or failure.
+TRTSERVER_EXPORT TRTSERVER_Error*
+TRTSERVER_InferenceRequestProviderSetSharedMemoryInputData(
+    TRTSERVER_Server* server,
+    TRTSERVER_InferenceRequestProvider* request_provider,
+    const char* input_name, const char* shm_name, size_t offset,
+    size_t byte_size);
+
 /// TRTSERVER_InferenceResponse
 ///
 /// Object representing the response for an inference request. The
@@ -689,6 +709,18 @@ TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_ServerUnregisterAllSharedMemory(
 /// \return a TRTSERVER_Error indicating success or failure.
 TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_ServerGetSharedMemoryStatus(
     TRTSERVER_Server* server, std::vector<std::string>& active_shm_regions);
+
+/// Lookup information about a shared memory region on the inference server. If
+/// the shared memory region is no longer registered or valid, it will return
+/// an error message.
+/// \param server The inference server object.
+/// \param shm_name The user-given name for the shared memory region.
+/// \param shm_mapped_addr The start address of the shared memory region.
+/// \param offset The offset into the shared memory region to be read.
+/// \return a TRTSERVER_Error indicating success or failure.
+TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_ServerGetSharedMemoryInfo(
+    TRTSERVER_Server* server, const char* shm_name, void** shm_mapped_addr,
+    size_t* shm_offset);
 
 /// Get the current metrics for the server. The caller takes ownership
 /// of the metrics object and must call TRTSERVER_MetricsDelete to

--- a/src/core/trtserver.h
+++ b/src/core/trtserver.h
@@ -312,35 +312,24 @@ TRTSERVER_InferenceRequestProviderInputBatchByteSize(
 /// 'request_provider' is deleted. The total size of data that is
 /// provided for an input must equal the value returned by
 /// TRTSERVER_InferenceRequestProviderInputBatchByteSize().
+/// \param server The inference server object. Not needed if not using
+/// shared memory.
 /// \param request_provider The request provider object.
-/// \param name The name of the input.
-/// \param base The base address of the input data.
+/// \param input_name The name of the input.
+/// \param shm_name The name of the registered shared memory region to use. Set
+/// to nullptr if not using shared memory.
+/// \param base The base address of the input data. Set to nullptr if using
+/// shared memory.
 /// \param byte_size The size, in bytes, of the input data.
+/// \param offset The offset from the start address of the registered shared.
+/// Set to 0 if using shared memory.
 /// \return a TRTSERVER_Error indicating success or failure.
 TRTSERVER_EXPORT TRTSERVER_Error*
 TRTSERVER_InferenceRequestProviderSetInputData(
-    TRTSERVER_InferenceRequestProvider* request_provider, const char* name,
-    const void* base, size_t byte_size);
-
-/// Assign a buffer of data to an input by pointing to that location in shared
-/// memory. The 'request_provider' takes ownership of the buffer in the shared
-/// memory region and so the caller should not modify or free the shared memory
-/// region until that ownership is released when 'request_provider' is deleted.
-/// The total size of data that is provided for an input must equal the
-/// batch_byte_size for that input.
-/// \param server The inference server object.
-/// \param request_provider The request provider object.
-/// \param input_name The name of the input.
-/// \param input_name The name of the registered shared memory region to use.
-/// \param offset The offset from the start address of the registered shared
-/// memory region. \param byte_size The size, in bytes, of the input data.
-/// \return a TRTSERVER_Error indicating success or failure.
-TRTSERVER_EXPORT TRTSERVER_Error*
-TRTSERVER_InferenceRequestProviderSetSharedMemoryInputData(
     TRTSERVER_Server* server,
     TRTSERVER_InferenceRequestProvider* request_provider,
-    const char* input_name, const char* shm_name, size_t offset,
-    size_t byte_size);
+    const char* input_name, const char* shm_name, const void* base,
+    size_t byte_size, size_t offset);
 
 /// TRTSERVER_InferenceResponse
 ///

--- a/src/core/trtserver.h
+++ b/src/core/trtserver.h
@@ -646,6 +646,33 @@ TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_ServerLoadModel(
 TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_ServerUnloadModel(
     TRTSERVER_Server* server, const char* model_name);
 
+/// Register a shared memory region on the inference server. If the shared
+/// memory region is already registered, it will be unregistered and then
+/// re-registered. Returned error indicates if shared memory region was
+/// registered successfully or not.
+/// \param server The inference server object.
+/// \param name The user-given name for the shared memory region to be
+/// registered.
+/// \param shm_key The unique name of the location in shared memory being
+/// registered.
+/// \param offset The offset into the shared memory region.
+/// \param byte_size The size, in bytes of the tensor data.
+/// \return a TRTSERVER_Error indicating success or failure.
+TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_RegisterSharedMemory(
+    TRTSERVER_Server* server, const char* name, const char* shm_key,
+    const size_t offset, const size_t byte_size);
+
+/// Unregister a registered shared memory region on the inference server. If
+/// the shared memory region is not registered, do nothing and return failure.
+/// Returned error indicates if the shared memory region was unregistered
+/// successfully or not.
+/// \param server The inference server object.
+/// \param name The user-given name for the shared memory region to be
+/// registered.
+/// \return a TRTSERVER_Error indicating success or failure.
+TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_UnregisterSharedMemory(
+    TRTSERVER_Server* server, const char* name);
+
 /// Get the current metrics for the server. The caller takes ownership
 /// of the metrics object and must call TRTSERVER_MetricsDelete to
 /// release the object.

--- a/src/core/trtserver.h
+++ b/src/core/trtserver.h
@@ -30,6 +30,8 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <string>
+#include <vector>
 
 #ifdef __cplusplus
 extern "C" {
@@ -671,6 +673,22 @@ TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_ServerRegisterSharedMemory(
 /// \return a TRTSERVER_Error indicating success or failure.
 TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_ServerUnregisterSharedMemory(
     TRTSERVER_Server* server, const char* name);
+
+/// Unregister all active shared memory regions on the inference server.
+/// Returned error indicates if the shared memory regions were unregistered
+/// successfully or not.
+/// \param server The inference server object.
+/// \return a TRTSERVER_Error indicating success or failure.
+TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_ServerUnregisterAllSharedMemory(
+    TRTSERVER_Server* server);
+
+/// Get the list of names of all active shared memory region on the inference
+/// server. If there are none then the list is empty. Returned error indicates
+/// if it was able to successfully get all active shared memory regions or not.
+/// \param server The inference server object.
+/// \return a TRTSERVER_Error indicating success or failure.
+TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_ServerGetSharedMemoryStatus(
+    TRTSERVER_Server* server, std::vector<std::string>& active_shm_regions);
 
 /// Get the current metrics for the server. The caller takes ownership
 /// of the metrics object and must call TRTSERVER_MetricsDelete to

--- a/src/servers/grpc_server.cc
+++ b/src/servers/grpc_server.cc
@@ -467,6 +467,11 @@ GRPCServer::Create(
       inferenceService->RegisterRPC<ModelControlContext>(
           &GRPCService::AsyncService::RequestModelControl);
 
+  LOG_VERBOSE(1) << "Register SharedMemoryControl RPC";
+  (*grpc_server)->rpcSharedMemoryControl_ =
+      inferenceService->RegisterRPC<SharedMemoryControlContext>(
+          &GRPCService::AsyncService::RequestSharedMemoryControl);
+
   LOG_VERBOSE(1) << "Register Profile RPC";
   (*grpc_server)->rpcProfile_ = inferenceService->RegisterRPC<ProfileContext>(
       &GRPCService::AsyncService::RequestProfile);
@@ -493,6 +498,7 @@ GRPCServer::Start()
         rpcStreamInfer_, g_Resources, stream_infer_thread_cnt_);
     executor->RegisterContexts(rpcStatus_, g_Resources, 1);
     executor->RegisterContexts(rpcModelControl_, g_Resources, 1);
+    executor->RegisterContexts(rpcSharedMemoryControl_, g_Resources, 1);
     executor->RegisterContexts(rpcHealth_, g_Resources, 1);
     executor->RegisterContexts(rpcProfile_, g_Resources, 1);
 

--- a/src/servers/grpc_server.cc
+++ b/src/servers/grpc_server.cc
@@ -304,7 +304,7 @@ class InferBaseContext : public BaseContext<LifeCycle, AsyncResources> {
     // the provided raw tensor data.
     size_t idx = 0;
     for (const auto& io : request_header.input()) {
-      if (io.shared_memory().name() == "") {
+      if (io.shared_memory().name() != "") {
         idx++;
         continue;
       }
@@ -341,7 +341,7 @@ class InferBaseContext : public BaseContext<LifeCycle, AsyncResources> {
     // the provided raw tensor data.
     size_t idx = 0;
     for (const auto& io : request_header.input()) {
-      if (io.shared_memory().name() != "") {
+      if (io.shared_memory().name() == "") {
         idx++;
         continue;
       }

--- a/src/servers/grpc_server.cc
+++ b/src/servers/grpc_server.cc
@@ -318,11 +318,10 @@ class InferBaseContext : public BaseContext<LifeCycle, AsyncResources> {
                   .c_str());
         }
 
-        RETURN_IF_ERR(
-            TRTSERVER_InferenceRequestProviderSetSharedMemoryInputData(
-                server, request_provider, io.name().c_str(),
-                io.shared_memory().name().c_str(), io.shared_memory().offset(),
-                io.shared_memory().byte_size()));
+        RETURN_IF_ERR(TRTSERVER_InferenceRequestProviderSetInputData(
+            server, request_provider, io.name().c_str(),
+            io.shared_memory().name().c_str(), nullptr,
+            io.shared_memory().byte_size(), io.shared_memory().offset()));
 
         idx++;
       } else {
@@ -344,7 +343,8 @@ class InferBaseContext : public BaseContext<LifeCycle, AsyncResources> {
 
         const std::string& raw = request.raw_input(idx++);
         RETURN_IF_ERR(TRTSERVER_InferenceRequestProviderSetInputData(
-            request_provider, io.name().c_str(), raw.c_str(), raw.size()));
+            server, request_provider, io.name().c_str(), nullptr, raw.c_str(),
+            raw.size(), 0));
       }
     }
 

--- a/src/servers/grpc_server.cc
+++ b/src/servers/grpc_server.cc
@@ -177,9 +177,15 @@ class SharedMemoryControlContext final
             request.shared_memory_region().shm_key().c_str(),
             request.shared_memory_region().offset(),
             request.shared_memory_region().byte_size());
-      } else {
+      } else if (request.type() == SharedMemoryControlRequest::UNREGISTER) {
         err = TRTSERVER_ServerUnregisterSharedMemory(
             server, request.shared_memory_region().name().c_str());
+      } else if (request.type() == SharedMemoryControlRequest::UNREGISTER_ALL) {
+        err = TRTSERVER_ServerUnregisterAllSharedMemory(server);
+      } else {
+        std::vector<std::string> active_shm_regions;
+        err = TRTSERVER_ServerGetSharedMemoryStatus(server, active_shm_regions);
+        // TODO Write to response
       }
 
       RequestStatusUtil::Create(

--- a/src/servers/grpc_server.cc
+++ b/src/servers/grpc_server.cc
@@ -304,6 +304,10 @@ class InferBaseContext : public BaseContext<LifeCycle, AsyncResources> {
     // the provided raw tensor data.
     size_t idx = 0;
     for (const auto& io : request_header.input()) {
+      if (io.shared_memory().name() == "") {
+        idx++;
+        continue;
+      }
       uint64_t byte_size = 0;
       RETURN_IF_ERR(TRTSERVER_InferenceRequestProviderInputBatchByteSize(
           request_provider, io.name().c_str(), &byte_size));
@@ -323,6 +327,41 @@ class InferBaseContext : public BaseContext<LifeCycle, AsyncResources> {
       const std::string& raw = request.raw_input(idx++);
       RETURN_IF_ERR(TRTSERVER_InferenceRequestProviderSetInputData(
           request_provider, io.name().c_str(), raw.c_str(), raw.size()));
+    }
+
+    return nullptr;  // success
+  }
+
+  TRTSERVER_Error* GRPCSharedMemoryInput(
+      TRTSERVER_Server* server, const InferRequestHeader& request_header,
+      const InferRequest& request,
+      TRTSERVER_InferenceRequestProvider* request_provider)
+  {
+    // Verify that the batch-byte-size of each input matches the size of
+    // the provided raw tensor data.
+    size_t idx = 0;
+    for (const auto& io : request_header.input()) {
+      if (io.shared_memory().name() != "") {
+        idx++;
+        continue;
+      }
+
+      if (io.batch_byte_size() != io.shared_memory().byte_size()) {
+        return TRTSERVER_ErrorNew(
+            TRTSERVER_ERROR_INVALID_ARG,
+            std::string(
+                "unexpected size " +
+                std::to_string(io.shared_memory().byte_size()) +
+                " for input '" + io.name() + "', expecting " +
+                std::to_string(io.batch_byte_size()) + " for model '" +
+                request.model_name() + "'")
+                .c_str());
+      }
+
+      RETURN_IF_ERR(TRTSERVER_InferenceRequestProviderSetSharedMemoryInputData(
+          server, request_provider, io.name().c_str(),
+          io.shared_memory().name().c_str(), io.shared_memory().offset(),
+          io.shared_memory().byte_size()));
     }
 
     return nullptr;  // success
@@ -352,24 +391,28 @@ class InferBaseContext : public BaseContext<LifeCycle, AsyncResources> {
       if (err == nullptr) {
         err = GRPCToInput(request.meta_data(), request, request_provider);
         if (err == nullptr) {
-          GRPCInferRequest* grpc_infer_request = new GRPCInferRequest(
-              this, execution_context, response, request.meta_data().id(),
-              server_id, unique_id);
+          err = GRPCSharedMemoryInput(
+              server, request.meta_data(), request, request_provider);
+          if (err == nullptr) {
+            GRPCInferRequest* grpc_infer_request = new GRPCInferRequest(
+                this, execution_context, response, request.meta_data().id(),
+                server_id, unique_id);
 
-          err = TRTSERVER_ServerInferAsync(
-              server, request_provider,
-              nullptr /* http_response_provider_hack */,
-              &response /* grpc_response_provider_hack */, nullptr, nullptr,
-              GRPCInferRequest::InferComplete,
-              reinterpret_cast<void*>(grpc_infer_request));
-          if (err != nullptr) {
-            delete grpc_infer_request;
-            grpc_infer_request = nullptr;
+            err = TRTSERVER_ServerInferAsync(
+                server, request_provider,
+                nullptr /* http_response_provider_hack */,
+                &response /* grpc_response_provider_hack */, nullptr, nullptr,
+                GRPCInferRequest::InferComplete,
+                reinterpret_cast<void*>(grpc_infer_request));
+            if (err != nullptr) {
+              delete grpc_infer_request;
+              grpc_infer_request = nullptr;
+            }
+
+            // The request provider can be deleted immediately after the
+            // ServerInferAsync call returns.
+            TRTSERVER_InferenceRequestProviderDelete(request_provider);
           }
-
-          // The request provider can be deleted immediately after the
-          // ServerInferAsync call returns.
-          TRTSERVER_InferenceRequestProviderDelete(request_provider);
         }
       }
     }

--- a/src/servers/grpc_server.cc
+++ b/src/servers/grpc_server.cc
@@ -172,13 +172,13 @@ class SharedMemoryControlContext final
 
       TRTSERVER_Error* err = nullptr;
       if (request.type() == SharedMemoryControlRequest::REGISTER) {
-        err = TRTSERVER_RegisterSharedMemory(
+        err = TRTSERVER_ServerRegisterSharedMemory(
             server, request.shared_memory_region().name().c_str(),
             request.shared_memory_region().shm_key().c_str(),
             request.shared_memory_region().offset(),
             request.shared_memory_region().byte_size());
       } else {
-        err = TRTSERVER_UnregisterSharedMemory(
+        err = TRTSERVER_ServerUnregisterSharedMemory(
             server, request.shared_memory_region().name().c_str());
       }
 

--- a/src/servers/grpc_server.h
+++ b/src/servers/grpc_server.h
@@ -55,6 +55,7 @@ class GRPCServer : private nvrpc::Server {
   nvrpc::IRPC* rpcStreamInfer_;
   nvrpc::IRPC* rpcStatus_;
   nvrpc::IRPC* rpcModelControl_;
+  nvrpc::IRPC* rpcSharedMemoryControl_;
   nvrpc::IRPC* rpcProfile_;
   nvrpc::IRPC* rpcHealth_;
   int infer_thread_cnt_;

--- a/src/servers/http_server.cc
+++ b/src/servers/http_server.cc
@@ -248,6 +248,11 @@ class HTTPAPIServer : public HTTPServerImpl {
       const std::string& model_name, const InferRequestHeader& request_header,
       evbuffer* input_buffer,
       TRTSERVER_InferenceRequestProvider* request_provider);
+  TRTSERVER_Error*
+  SharedMemoryToInput(
+      TRTSERVER_Server* server, const std::string& model_name, const InferRequestHeader& request_header,
+      evbuffer* input_buffer,
+      TRTSERVER_InferenceRequestProvider* request_provider);
 
   static void OKReplyCallback(evthr_t* thr, void* arg, void* shared);
   static void BADReplyCallback(evthr_t* thr, void* arg, void* shared);
@@ -616,6 +621,10 @@ HTTPAPIServer::EVBufferToInput(
   // Get the byte-size for each input and from that get the blocks
   // holding the data for that input
   for (const auto& io : request_header.input()) {
+    if (io.shared_memory().name() != "") {
+      v_idx++;
+      continue;
+    }
     uint64_t byte_size = 0;
     RETURN_IF_ERR(TRTSERVER_InferenceRequestProviderInputBatchByteSize(
         request_provider, io.name().c_str(), &byte_size));
@@ -663,6 +672,52 @@ HTTPAPIServer::EVBufferToInput(
         std::string(
             "unexpected additional input data for model '" + model_name + "'")
             .c_str());
+  }
+
+  return nullptr;  // success
+}
+
+TRTSERVER_Error*
+HTTPAPIServer::SharedMemoryToInput(
+    TRTSERVER_Server* server, const std::string& model_name, const InferRequestHeader& request_header,
+    evbuffer* input_buffer,
+    TRTSERVER_InferenceRequestProvider* request_provider)
+{
+  // Extracts input data from the shared memory region and registers in
+  // 'request_provider' using the provided offset and byte_size
+  //
+  // Get the base address and offset into the shared memory region for the
+  // input data from the registered shared memory region.
+
+
+  // Get the byte-size for each input and from that get the blocks
+  // holding the data for that input
+  for (const auto& io : request_header.input()) {
+    if (io.shared_memory().name() == "") {
+      continue;
+    }
+    // If 'byte_size' is zero then need to add an empty input data
+    // block... the provider expects at least one data block for every
+    // input.
+    if (io.shared_memory().byte_size() == 0) {
+      RETURN_IF_ERR(TRTSERVER_InferenceRequestProviderSetSharedMemoryInputData(
+          server, request_provider, io.name().c_str(), "", 0, 0));
+    } else {
+      RETURN_IF_ERR(TRTSERVER_InferenceRequestProviderSetSharedMemoryInputData(
+          server, request_provider, io.name().c_str(), io.shared_memory().name().c_str(), io.shared_memory().offset(), io.shared_memory().byte_size()));
+    }
+
+    if (io.batch_byte_size() != io.shared_memory().byte_size()) {
+      return TRTSERVER_ErrorNew(
+        TRTSERVER_ERROR_INVALID_ARG,
+        std::string(
+            "unexpected size " +
+            std::to_string(io.shared_memory().byte_size()) +
+            " bytes for input '" + io.name() + "', expecting " +
+            std::to_string(io.batch_byte_size()) + " bytes for model '" +
+            model_name + "'")
+            .c_str());
+    }
   }
 
   return nullptr;  // success
@@ -717,22 +772,26 @@ HTTPAPIServer::HandleInfer(evhtp_request_t* req, const std::string& infer_uri)
     err = EVBufferToInput(
         model_name, request_header, req->buffer_in, request_provider);
     if (err == nullptr) {
-      InferRequest* infer_request =
-          new InferRequest(req, request_header.id(), server_id_, unique_id);
+      err = SharedMemoryToInput(
+          server_.get(), model_name, request_header, req->buffer_in, request_provider);
+      if (err == nullptr) {
+        InferRequest* infer_request =
+            new InferRequest(req, request_header.id(), server_id_, unique_id);
 
-      err = TRTSERVER_ServerInferAsync(
-          server_.get(), request_provider,
-          req->buffer_out /* http_response_provider_hack */,
-          nullptr /* grpc_response_provider_hack */, nullptr, nullptr,
-          InferRequest::InferComplete, reinterpret_cast<void*>(infer_request));
-      if (err != nullptr) {
-        delete infer_request;
-        infer_request = nullptr;
+        err = TRTSERVER_ServerInferAsync(
+            server_.get(), request_provider,
+            req->buffer_out /* http_response_provider_hack */,
+            nullptr /* grpc_response_provider_hack */, nullptr, nullptr,
+            InferRequest::InferComplete, reinterpret_cast<void*>(infer_request));
+        if (err != nullptr) {
+          delete infer_request;
+          infer_request = nullptr;
+        }
+
+        // The request provider can be deleted immediately after the
+        // ServerInferAsync call returns.
+        TRTSERVER_InferenceRequestProviderDelete(request_provider);
       }
-
-      // The request provider can be deleted immediately after the
-      // ServerInferAsync call returns.
-      TRTSERVER_InferenceRequestProviderDelete(request_provider);
     }
   }
 

--- a/src/servers/http_server.cc
+++ b/src/servers/http_server.cc
@@ -245,10 +245,6 @@ class HTTPAPIServer : public HTTPServerImpl {
       evhtp_request_t* req, const std::string& sharedmemorycontrol_uri);
 
   TRTSERVER_Error* EVBufferToInput(
-      const std::string& model_name, const InferRequestHeader& request_header,
-      evbuffer* input_buffer,
-      TRTSERVER_InferenceRequestProvider* request_provider);
-  TRTSERVER_Error* SharedMemoryToInput(
       TRTSERVER_Server* server, const std::string& model_name,
       const InferRequestHeader& request_header, evbuffer* input_buffer,
       TRTSERVER_InferenceRequestProvider* request_provider);
@@ -593,8 +589,8 @@ HTTPAPIServer::HandleSharedMemoryControl(
 
 TRTSERVER_Error*
 HTTPAPIServer::EVBufferToInput(
-    const std::string& model_name, const InferRequestHeader& request_header,
-    evbuffer* input_buffer,
+    TRTSERVER_Server* server, const std::string& model_name,
+    const InferRequestHeader& request_header, evbuffer* input_buffer,
     TRTSERVER_InferenceRequestProvider* request_provider)
 {
   // Extract individual input data from HTTP body and register in
@@ -621,47 +617,70 @@ HTTPAPIServer::EVBufferToInput(
   // holding the data for that input
   for (const auto& io : request_header.input()) {
     if (io.shared_memory().name() != "") {
-      v_idx++;
-      continue;
-    }
-    uint64_t byte_size = 0;
-    RETURN_IF_ERR(TRTSERVER_InferenceRequestProviderInputBatchByteSize(
-        request_provider, io.name().c_str(), &byte_size));
-
-    // If 'byte_size' is zero then need to add an empty input data
-    // block... the provider expects at least one data block for every
-    // input.
-    if (byte_size == 0) {
-      RETURN_IF_ERR(TRTSERVER_InferenceRequestProviderSetInputData(
-          request_provider, io.name().c_str(), nullptr, 0 /* byte_size */));
-    } else {
-      while ((byte_size > 0) && (v_idx < n)) {
-        char* base = static_cast<char*>(v[v_idx].iov_base);
-        size_t base_size;
-        if (v[v_idx].iov_len > byte_size) {
-          base_size = byte_size;
-          v[v_idx].iov_base = static_cast<void*>(base + byte_size);
-          v[v_idx].iov_len -= byte_size;
-          byte_size = 0;
-        } else {
-          base_size = v[v_idx].iov_len;
-          byte_size -= v[v_idx].iov_len;
-          v_idx++;
-        }
-
+      if (io.shared_memory().byte_size() == 0) {
         RETURN_IF_ERR(TRTSERVER_InferenceRequestProviderSetInputData(
-            request_provider, io.name().c_str(), base, base_size));
+            server, request_provider, io.name().c_str(), "", nullptr, 0, 0));
+      } else {
+        RETURN_IF_ERR(TRTSERVER_InferenceRequestProviderSetInputData(
+            server, request_provider, io.name().c_str(),
+            io.shared_memory().name().c_str(), nullptr,
+            io.shared_memory().byte_size(), io.shared_memory().offset()));
       }
-    }
 
-    if (byte_size != 0) {
-      return TRTSERVER_ErrorNew(
-          TRTSERVER_ERROR_INVALID_ARG,
-          std::string(
-              "unexpected size for input '" + io.name() + "', expecting " +
-              std::to_string(byte_size) + " bytes for model '" + model_name +
-              "'")
-              .c_str());
+      if (io.batch_byte_size() != io.shared_memory().byte_size()) {
+        return TRTSERVER_ErrorNew(
+            TRTSERVER_ERROR_INVALID_ARG,
+            std::string(
+                "unexpected size " +
+                std::to_string(io.shared_memory().byte_size()) +
+                " bytes for input '" + io.name() + "', expecting " +
+                std::to_string(io.batch_byte_size()) + " bytes for model '" +
+                model_name + "'")
+                .c_str());
+      }
+      v_idx++;
+    } else {
+      uint64_t byte_size = 0;
+      RETURN_IF_ERR(TRTSERVER_InferenceRequestProviderInputBatchByteSize(
+          request_provider, io.name().c_str(), &byte_size));
+
+      // If 'byte_size' is zero then need to add an empty input data
+      // block... the provider expects at least one data block for every
+      // input.
+      if (byte_size == 0) {
+        RETURN_IF_ERR(TRTSERVER_InferenceRequestProviderSetInputData(
+            server, request_provider, io.name().c_str(), nullptr, nullptr, 0,
+            0));
+      } else {
+        while ((byte_size > 0) && (v_idx < n)) {
+          char* base = static_cast<char*>(v[v_idx].iov_base);
+          size_t base_size;
+          if (v[v_idx].iov_len > byte_size) {
+            base_size = byte_size;
+            v[v_idx].iov_base = static_cast<void*>(base + byte_size);
+            v[v_idx].iov_len -= byte_size;
+            byte_size = 0;
+          } else {
+            base_size = v[v_idx].iov_len;
+            byte_size -= v[v_idx].iov_len;
+            v_idx++;
+          }
+
+          RETURN_IF_ERR(TRTSERVER_InferenceRequestProviderSetInputData(
+              server, request_provider, io.name().c_str(), nullptr, base,
+              base_size, 0));
+        }
+      }
+
+      if (byte_size != 0) {
+        return TRTSERVER_ErrorNew(
+            TRTSERVER_ERROR_INVALID_ARG,
+            std::string(
+                "unexpected size for input '" + io.name() + "', expecting " +
+                std::to_string(byte_size) + " bytes for model '" + model_name +
+                "'")
+                .c_str());
+      }
     }
   }
 
@@ -671,54 +690,6 @@ HTTPAPIServer::EVBufferToInput(
         std::string(
             "unexpected additional input data for model '" + model_name + "'")
             .c_str());
-  }
-
-  return nullptr;  // success
-}
-
-TRTSERVER_Error*
-HTTPAPIServer::SharedMemoryToInput(
-    TRTSERVER_Server* server, const std::string& model_name,
-    const InferRequestHeader& request_header, evbuffer* input_buffer,
-    TRTSERVER_InferenceRequestProvider* request_provider)
-{
-  // Extracts input data from the shared memory region and registers in
-  // 'request_provider' using the provided offset and byte_size
-  //
-  // Get the base address and offset into the shared memory region for the
-  // input data from the registered shared memory region.
-
-
-  // Get the byte-size for each input and from that get the blocks
-  // holding the data for that input
-  for (const auto& io : request_header.input()) {
-    if (io.shared_memory().name() == "") {
-      continue;
-    }
-    // If 'byte_size' is zero then need to add an empty input data
-    // block... the provider expects at least one data block for every
-    // input.
-    if (io.shared_memory().byte_size() == 0) {
-      RETURN_IF_ERR(TRTSERVER_InferenceRequestProviderSetSharedMemoryInputData(
-          server, request_provider, io.name().c_str(), "", 0, 0));
-    } else {
-      RETURN_IF_ERR(TRTSERVER_InferenceRequestProviderSetSharedMemoryInputData(
-          server, request_provider, io.name().c_str(),
-          io.shared_memory().name().c_str(), io.shared_memory().offset(),
-          io.shared_memory().byte_size()));
-    }
-
-    if (io.batch_byte_size() != io.shared_memory().byte_size()) {
-      return TRTSERVER_ErrorNew(
-          TRTSERVER_ERROR_INVALID_ARG,
-          std::string(
-              "unexpected size " +
-              std::to_string(io.shared_memory().byte_size()) +
-              " bytes for input '" + io.name() + "', expecting " +
-              std::to_string(io.batch_byte_size()) + " bytes for model '" +
-              model_name + "'")
-              .c_str());
-    }
   }
 
   return nullptr;  // success
@@ -771,30 +742,25 @@ HTTPAPIServer::HandleInfer(evhtp_request_t* req, const std::string& infer_uri)
       request_header_serialized.c_str(), request_header_serialized.size());
   if (err == nullptr) {
     err = EVBufferToInput(
-        model_name, request_header, req->buffer_in, request_provider);
+        server_.get(), model_name, request_header, req->buffer_in,
+        request_provider);
     if (err == nullptr) {
-      err = SharedMemoryToInput(
-          server_.get(), model_name, request_header, req->buffer_in,
-          request_provider);
-      if (err == nullptr) {
-        InferRequest* infer_request =
-            new InferRequest(req, request_header.id(), server_id_, unique_id);
+      InferRequest* infer_request =
+          new InferRequest(req, request_header.id(), server_id_, unique_id);
 
-        err = TRTSERVER_ServerInferAsync(
-            server_.get(), request_provider,
-            req->buffer_out /* http_response_provider_hack */,
-            nullptr /* grpc_response_provider_hack */, nullptr, nullptr,
-            InferRequest::InferComplete,
-            reinterpret_cast<void*>(infer_request));
-        if (err != nullptr) {
-          delete infer_request;
-          infer_request = nullptr;
-        }
-
-        // The request provider can be deleted immediately after the
-        // ServerInferAsync call returns.
-        TRTSERVER_InferenceRequestProviderDelete(request_provider);
+      err = TRTSERVER_ServerInferAsync(
+          server_.get(), request_provider,
+          req->buffer_out /* http_response_provider_hack */,
+          nullptr /* grpc_response_provider_hack */, nullptr, nullptr,
+          InferRequest::InferComplete, reinterpret_cast<void*>(infer_request));
+      if (err != nullptr) {
+        delete infer_request;
+        infer_request = nullptr;
       }
+
+      // The request provider can be deleted immediately after the
+      // ServerInferAsync call returns.
+      TRTSERVER_InferenceRequestProviderDelete(request_provider);
     }
   }
 

--- a/src/servers/http_server.cc
+++ b/src/servers/http_server.cc
@@ -198,7 +198,7 @@ class HTTPAPIServer : public HTTPServerImpl {
         infer_regex_(R"(/([^/]+)(?:/(\d+))?)"), status_regex_(R"(/(.*))"),
         modelcontrol_regex_(R"(/(load|unload)/([^/]+))"),
         sharedmemorycontrol_regex_(
-            R"(/(register|unregister)/([^/]+)/([\d]+)/([\d]+))")
+            R"(/(register|unregister|unregisterall|status)/([^/]+)/([\d]+)/([\d]+))")
   {
     TRTSERVER_Error* err = TRTSERVER_ServerId(server_.get(), &server_id_);
     if (err != nullptr) {
@@ -550,21 +550,19 @@ HTTPAPIServer::HandleSharedMemoryControl(
     return;
   }
 
-  // try {
-  //
-  // }
-  // catch () {
-  //   err = TRTSERVER_ErrorNew(
-  //       TRTSERVER_ERROR_UNKNOWN,
-  //       std::string("unknown action type '" + action_type_str +
-  //       "'").c_str());
-  // }
   TRTSERVER_Error* err = nullptr;
   if (action_type_str == "register") {
     err = TRTSERVER_ServerRegisterSharedMemory(
         server_.get(), name.c_str(), name.c_str(), offset, byte_size);
   } else if (action_type_str == "unregister") {
     err = TRTSERVER_ServerUnregisterSharedMemory(server_.get(), name.c_str());
+  } else if (action_type_str == "unregisterall") {
+    err = TRTSERVER_ServerUnregisterAllSharedMemory(server_.get());
+  } else if (action_type_str == "status") {
+    std::vector<std::string> active_shm_regions;
+    err = TRTSERVER_ServerGetSharedMemoryStatus(
+        server_.get(), active_shm_regions);
+    // TODO Write to response
   } else {
     err = TRTSERVER_ErrorNew(
         TRTSERVER_ERROR_UNKNOWN,

--- a/src/servers/main.cc
+++ b/src/servers/main.cc
@@ -802,8 +802,8 @@ Parse(TRTSERVER_ServerOptions* server_options, int argc, char** argv)
 #ifdef TRTIS_ENABLE_HTTP
   http_port_ = http_port;
   http_health_port_ = http_health_port;
-  http_ports_ = {http_port_, http_health_port_, http_port_, http_port_,
-                 http_port_};
+  http_ports_ = {http_port_, http_health_port_, http_port_,
+                 http_port_, http_port_,        http_port_};
   http_thread_cnt_ = http_thread_cnt;
 #endif  // TRTIS_ENABLE_HTTP
 

--- a/src/servers/main.cc
+++ b/src/servers/main.cc
@@ -80,8 +80,8 @@ bool allow_http_ = true;
 int32_t http_port_ = 8000;
 int32_t http_health_port_ = -1;
 std::vector<int32_t> http_ports_;
-std::vector<std::string> endpoint_names = {"status", "health", "profile",
-                                           "infer", "modelcontrol"};
+std::vector<std::string> endpoint_names = {
+    "status", "health", "profile", "infer", "modelcontrol", "shmcontrol"};
 #endif  // TRTIS_ENABLE_HTTP
 
 #ifdef TRTIS_ENABLE_GRPC

--- a/src/servers/main.cc
+++ b/src/servers/main.cc
@@ -81,7 +81,8 @@ int32_t http_port_ = 8000;
 int32_t http_health_port_ = -1;
 std::vector<int32_t> http_ports_;
 std::vector<std::string> endpoint_names = {
-    "status", "health", "profile", "infer", "modelcontrol", "shmcontrol"};
+    "status", "health",       "profile",
+    "infer",  "modelcontrol", "sharedmemorycontrol"};
 #endif  // TRTIS_ENABLE_HTTP
 
 #ifdef TRTIS_ENABLE_GRPC

--- a/src/servers/simple.cc
+++ b/src/servers/simple.cc
@@ -292,13 +292,13 @@ main(int argc, char** argv)
 
   FAIL_IF_ERR(
       TRTSERVER_InferenceRequestProviderSetInputData(
-          request_provider, input0->name().c_str(), &input0_data[0],
-          input0_data.size() * sizeof(int32_t)),
+          server.get(), request_provider, input0->name().c_str(), nullptr,
+          &input0_data[0], input0_data.size() * sizeof(int32_t), 0),
       "assigning INPUT0 data");
   FAIL_IF_ERR(
       TRTSERVER_InferenceRequestProviderSetInputData(
-          request_provider, input1->name().c_str(), &input1_data[0],
-          input1_data.size() * sizeof(int32_t)),
+          server.get(), request_provider, input1->name().c_str(), nullptr,
+          &input1_data[0], input1_data.size() * sizeof(int32_t), 0),
       "assigning INPUT1 data");
 
   // Perform inference...


### PR DESCRIPTION
- **Unregister/RegisterSharedMemory**: register shared memory (shm_opens and mmaps when needed/registered. close and munmap when not needed/unregistered).
- **UnregisterAllSharedMemory**: unregister _all_ shared memory regions. 
- **GetLiveSharedMemory**: get list (names) of  all shared memory regions that are currently registered.