### PR TITLE
Adding an option to let Graphdef dictate the model placement on devices

### DIFF
--- a/src/backends/tensorflow/base_backend.cc
+++ b/src/backends/tensorflow/base_backend.cc
@@ -83,6 +83,11 @@ BaseBackend::CreateExecutionContexts(
         RETURN_IF_ERROR(CreateExecutionContext(
             instance_name, Context::NO_GPU_DEVICE, backend_config, paths));
         total_context_cnt++;
+      } else if (group.kind() == ModelInstanceGroup::KIND_MODEL) {
+        const std::string instance_name =
+            group.name() + "_" + std::to_string(c) + "_model_device";
+        RETURN_IF_ERROR(CreateExecutionContext(
+            instance_name, Context::MODEL_DEVICE, backend_config, paths));
       } else {
         for (int gpu_device : group.gpus()) {
           const std::string instance_name = group.name() + "_" +
@@ -128,6 +133,11 @@ BaseBackend::CreateExecutionContext(
 
     LOG_INFO << "Creating instance " << instance_name << " on CPU using "
              << cc_model_filename;
+  } else if (gpu_device == Context::MODEL_DEVICE) {
+    cc_model_filename = Config().default_model_filename();
+
+    LOG_INFO << "Creating instance " << instance_name
+             << " on devices as specified in " << cc_model_filename;
   } else {
 #ifdef TRTIS_ENABLE_GPU
     cudaDeviceProp cuprops;

--- a/src/backends/tensorflow/base_backend.h
+++ b/src/backends/tensorflow/base_backend.h
@@ -71,6 +71,10 @@ class BaseBackend : public InferenceBackend {
     // context.
     static constexpr int NO_GPU_DEVICE = -1;
 
+    // GPU device number that indicates model will be loaded on GPUs
+    // as specified in model graph
+    static constexpr int MODEL_DEVICE = -2;
+
     // Max batch size value that indicates batching is not supported.
     static constexpr int NO_BATCHING = 0;
 

--- a/src/backends/tensorflow/tensorflow_backend_tf.h
+++ b/src/backends/tensorflow/tensorflow_backend_tf.h
@@ -50,6 +50,10 @@ extern "C" {
 // GPU device number that indicates that no gpu is available.
 #define TRTISTF_NO_GPU_DEVICE -1
 
+// GPU device number that indicates TRTIS should do nothing to control
+// the device alloaction for the network and let Tensorflow handle it.
+#define TRTISTF_MODEL_DEVICE -2
+
 // Max batch size value that indicates batching is not supported.
 #define TRTISTF_NO_BATCHING 0
 

--- a/src/core/model_config.proto
+++ b/src/core/model_config.proto
@@ -109,6 +109,16 @@ message ModelInstanceGroup
     //@@       CPU.
     //@@
     KIND_CPU = 2;
+
+    //@@    .. cpp:enumerator:: Kind::KIND_MODEL = 3
+    //@@
+    //@@       This instance group represents instances that should run on the
+    //@@       CPU and/or GPU(s) as specified by the model or backend itself.
+    //@@       The inference server will not override the model/backend
+    //@@       settings.
+    //@@       Currently, this option is supported only for Tensorflow models.
+    //@@
+    KIND_MODEL = 3;
   }
 
   //@@  .. cpp:var:: string name
@@ -124,8 +134,8 @@ message ModelInstanceGroup
   //@@
   //@@     The kind of this instance group. Default is KIND_AUTO. If
   //@@     KIND_AUTO or KIND_GPU then both 'count' and 'gpu' are valid and
-  //@@     may be specified. If KIND_CPU only 'count' is valid and 'gpu'
-  //@@     cannot be specified.
+  //@@     may be specified. If KIND_CPU or KIND_MODEL only 'count' is valid
+  //@@     and 'gpu' cannot be specified.
   //@@
   Kind kind = 4;
 

--- a/tools/patch/tensorflow/cc/saved_model/loader.cc
+++ b/tools/patch/tensorflow/cc/saved_model/loader.cc
@@ -11,15 +11,13 @@ index 85d3dd01fa..b385f8b857 100644
  #include "tensorflow/core/lib/io/path.h"
  #include "tensorflow/core/lib/monitoring/counter.h"
  #include "tensorflow/core/lib/strings/str_util.h"
-@@ -244,9 +245,30 @@ Status LoadSavedModelInternal(const SessionOptions& session_options,
+@@ -244,9 +245,28 @@ Status LoadSavedModelInternal(const SessionOptions& session_options,
                                SavedModelBundle* const bundle) {
    TF_RETURN_IF_ERROR(ReadMetaGraphDefFromSavedModel(export_dir, tags,
                                                      &bundle->meta_graph_def));
 +  
 +  // If allocator starts with a '/' then it is being used to
-+  // communicate the CPU/GPU that the graph runs on. This isn't
-+  // foolproof since individual operations in the graph could specify
-+  // a specific run location. [DLIS-43]
++  // communicate the CPU/GPU that the graph runs on.
 +  SessionOptions lsession_options = session_options;
 +  const std::string& alloc_type =
 +    lsession_options.config.gpu_options().allocator_type();


### PR DESCRIPTION
The tensorflow model configuration can now specify kind KIND_MODEL, in which case TRTIS relinquishes control of model placements on devices, letting the model instances being placed as specified in graphdef.