### PR TITLE
Fix PyTorch Backend for 19.08

### DIFF
--- a/src/backends/pytorch/libtorch_backend.cc
+++ b/src/backends/pytorch/libtorch_backend.cc
@@ -240,7 +240,8 @@ LibTorchBackend::CreateExecutionContext(
   try {
     // lp_itr->second is the torch model serialized to string
     std::istringstream model_stream(lp_itr->second);
-    context->torch_model_ = std::make_shared<torch::jit::script::Module>(torch::jit::load(model_stream, context->device_));
+    context->torch_model_ = std::make_shared<torch::jit::script::Module>(
+        torch::jit::load(model_stream, context->device_));
   }
   catch (const std::exception& ex) {
     return Status(

--- a/src/backends/pytorch/libtorch_backend.cc
+++ b/src/backends/pytorch/libtorch_backend.cc
@@ -240,7 +240,7 @@ LibTorchBackend::CreateExecutionContext(
   try {
     // lp_itr->second is the torch model serialized to string
     std::istringstream model_stream(lp_itr->second);
-    context->torch_model_ = torch::jit::load(model_stream, context->device_);
+    context->torch_model_ = std::make_shared<torch::jit::script::Module>(torch::jit::load(model_stream, context->device_));
   }
   catch (const std::exception& ex) {
     return Status(


### PR DESCRIPTION
PyTorch image for 19.08 uses 1.20 where the load api no longer returns a shared pointer

@deadeyegoodwin should I modify this PR for r19.08 instead of master?