### PR TITLE
server will populate the compute and queue times for ensemble models

### DIFF
--- a/src/clients/c++/inference_profiler.cc
+++ b/src/clients/c++/inference_profiler.cc
@@ -484,23 +484,10 @@ InferenceProfiler::SummarizeServerModelStats(
           end_itr->second.success().count() - start_cnt;
       server_stats->cumm_time_ns =
           end_itr->second.success().total_time_ns() - start_cumm_time_ns;
-      if (server_stats->composing_models_stat.empty()) {
-        server_stats->queue_time_ns =
-            end_itr->second.queue().total_time_ns() - start_queue_time_ns;
-        server_stats->compute_time_ns =
-            end_itr->second.compute().total_time_ns() - start_compute_time_ns;
-      } else {
-        server_stats->queue_time_ns = 0;
-        server_stats->compute_time_ns = 0;
-        // The compute and queue times are calculated as a total of the
-        // composing models.
-        for (auto& composing_model_stat : server_stats->composing_models_stat) {
-          server_stats->queue_time_ns +=
-              composing_model_stat.second.queue_time_ns;
-          server_stats->compute_time_ns +=
-              composing_model_stat.second.compute_time_ns;
-        }
-      }
+      server_stats->queue_time_ns =
+          end_itr->second.queue().total_time_ns() - start_queue_time_ns;
+      server_stats->compute_time_ns =
+          end_itr->second.compute().total_time_ns() - start_compute_time_ns;
     }
   }
 
@@ -513,6 +500,10 @@ InferenceProfiler::SummarizeServerStats(
     const std::map<std::string, ni::ModelStatus>& end_status,
     ServerSideStats* server_stats)
 {
+  RETURN_IF_ERROR(SummarizeServerModelStats(
+      model_name_, model_version_, start_status.find(model_name_)->second,
+      end_status.find(model_name_)->second, server_stats));
+
   // Summarize the composing models, if any.
   for (const auto& model_info : composing_models_) {
     auto it = server_stats->composing_models_stat
@@ -523,10 +514,6 @@ InferenceProfiler::SummarizeServerStats(
         start_status.find(model_info.first)->second,
         end_status.find(model_info.first)->second, &(it->second)));
   }
-
-  RETURN_IF_ERROR(SummarizeServerModelStats(
-      model_name_, model_version_, start_status.find(model_name_)->second,
-      end_status.find(model_name_)->second, server_stats));
 
   return nic::Error::Success;
 }

--- a/src/clients/c++/inference_profiler.cc
+++ b/src/clients/c++/inference_profiler.cc
@@ -50,16 +50,45 @@ InferenceProfiler::Create(
       std::move(profile_ctx), std::move(status_ctx), std::move(manager)));
 
   if (local_profiler->scheduler_type_ == ContextFactory::ENSEMBLE) {
-    std::map<std::string, ni::ModelStatus> model_status;
-    RETURN_IF_ERROR(local_profiler->GetServerSideStatus(&model_status));
-    const auto& it = model_status.find(local_profiler->model_name_);
-    for (const auto& step : it->second.config().ensemble_scheduling().step()) {
-      local_profiler->composing_models_.emplace(
-          step.model_name(), step.model_version());
-    }
+    ni::ServerStatus server_status;
+    RETURN_IF_ERROR(
+        local_profiler->status_ctx_->GetServerStatus(&server_status));
+    RETURN_IF_ERROR(local_profiler->BuildComposingModelMap(server_status));
   }
 
   *profiler = std::move(local_profiler);
+  return nic::Error::Success;
+}
+
+nic::Error
+InferenceProfiler::BuildComposingModelMap(const ni::ServerStatus& server_status)
+{
+  RETURN_IF_ERROR(
+      BuildComposingModelMap(model_name_, model_version_, server_status));
+  return nic::Error::Success;
+}
+
+nic::Error
+InferenceProfiler::BuildComposingModelMap(
+    const std::string& model_name, const int64_t& model_version,
+    const ni::ServerStatus& server_status)
+{
+  const auto& itr = server_status.model_status().find(model_name);
+  if (itr == server_status.model_status().end()) {
+    return nic::Error(
+        ni::RequestStatusCode::INTERNAL,
+        "unable to find status for model" + model_name);
+  } else {
+    if (itr->second.config().platform() == "ensemble") {
+      for (const auto& step :
+           itr->second.config().ensemble_scheduling().step()) {
+        this->composing_models_map_[std::make_pair(model_name, model_version)]
+            .emplace(step.model_name(), step.model_version());
+        this->BuildComposingModelMap(
+            step.model_name(), step.model_version(), server_status);
+      }
+    }
+  }
   return nic::Error::Success;
 }
 
@@ -181,27 +210,45 @@ InferenceProfiler::GetServerSideStatus(
 
   ni::ServerStatus server_status;
   RETURN_IF_ERROR(status_ctx_->GetServerStatus(&server_status));
-  const auto& itr = server_status.model_status().find(model_name_);
+  RETURN_IF_ERROR(GetServerSideStatus(
+      server_status, std::make_pair(model_name_, model_version_),
+      model_status));
+  return nic::Error::Success;
+}
+
+nic::Error
+InferenceProfiler::GetServerSideStatus(
+    ni::ServerStatus& server_status, const ModelInfo model_info,
+    std::map<std::string, ni::ModelStatus>* model_status)
+{
+  const auto& itr = server_status.model_status().find(model_info.first);
   if (itr == server_status.model_status().end()) {
     return nic::Error(
         ni::RequestStatusCode::INTERNAL,
-        "unable to find status for model" + model_name_);
+        "unable to find status for model" + model_info.first);
   } else {
-    model_status->emplace(model_name_, itr->second);
+    model_status->emplace(model_info.first, itr->second);
   }
 
   // Also get status for composing models if any
-  for (const auto& model_info : composing_models_) {
-    const auto& itr = server_status.model_status().find(model_info.first);
-    if (itr == server_status.model_status().end()) {
-      return nic::Error(
-          ni::RequestStatusCode::INTERNAL,
-          "unable to find status for composing model" + model_info.first);
+  for (const auto& composing_model_info : composing_models_map_[model_info]) {
+    if (composing_models_map_.find(composing_model_info) !=
+        composing_models_map_.end()) {
+      RETURN_IF_ERROR(GetServerSideStatus(
+          server_status, composing_model_info, model_status));
     } else {
-      model_status->emplace(model_info.first, itr->second);
+      const auto& itr =
+          server_status.model_status().find(composing_model_info.first);
+      if (itr == server_status.model_status().end()) {
+        return nic::Error(
+            ni::RequestStatusCode::INTERNAL,
+            "unable to find status for composing model" +
+                composing_model_info.first);
+      } else {
+        model_status->emplace(composing_model_info.first, itr->second);
+      }
     }
   }
-
   return nic::Error::Success;
 }
 
@@ -496,25 +543,45 @@ InferenceProfiler::SummarizeServerModelStats(
 
 nic::Error
 InferenceProfiler::SummarizeServerStats(
+    const ModelInfo model_info,
     const std::map<std::string, ni::ModelStatus>& start_status,
     const std::map<std::string, ni::ModelStatus>& end_status,
     ServerSideStats* server_stats)
 {
   RETURN_IF_ERROR(SummarizeServerModelStats(
-      model_name_, model_version_, start_status.find(model_name_)->second,
-      end_status.find(model_name_)->second, server_stats));
+      model_info.first, model_info.second,
+      start_status.find(model_info.first)->second,
+      end_status.find(model_info.first)->second, server_stats));
 
   // Summarize the composing models, if any.
-  for (const auto& model_info : composing_models_) {
+  for (const auto& composing_model_info : composing_models_map_[model_info]) {
     auto it = server_stats->composing_models_stat
-                  .emplace(model_info, ServerSideStats())
+                  .emplace(composing_model_info, ServerSideStats())
                   .first;
-    RETURN_IF_ERROR(SummarizeServerModelStats(
-        model_info.first, model_info.second,
-        start_status.find(model_info.first)->second,
-        end_status.find(model_info.first)->second, &(it->second)));
+    if (composing_models_map_.find(composing_model_info) !=
+        composing_models_map_.end()) {
+      RETURN_IF_ERROR(SummarizeServerStats(
+          composing_model_info, start_status, end_status, &(it->second)));
+    } else {
+      RETURN_IF_ERROR(SummarizeServerModelStats(
+          composing_model_info.first, composing_model_info.second,
+          start_status.find(composing_model_info.first)->second,
+          end_status.find(composing_model_info.first)->second, &(it->second)));
+    }
   }
 
+  return nic::Error::Success;
+}
+
+nic::Error
+InferenceProfiler::SummarizeServerStats(
+    const std::map<std::string, ni::ModelStatus>& start_status,
+    const std::map<std::string, ni::ModelStatus>& end_status,
+    ServerSideStats* server_stats)
+{
+  RETURN_IF_ERROR(SummarizeServerStats(
+      std::make_pair(model_name_, model_version_), start_status, end_status,
+      server_stats));
   return nic::Error::Success;
 }
 

--- a/src/clients/c++/inference_profiler.h
+++ b/src/clients/c++/inference_profiler.h
@@ -63,6 +63,9 @@ struct ServerSideStats {
   uint64_t cumm_time_ns;
   uint64_t queue_time_ns;
   uint64_t compute_time_ns;
+
+  std::map<std::pair<std::string, int64_t>, ServerSideStats>
+      composing_models_stat;
 };
 
 struct PerfStatus {
@@ -70,8 +73,6 @@ struct PerfStatus {
   size_t batch_size;
   // Request count and elapsed time measured by server
   ServerSideStats server_stats;
-  std::map<std::pair<std::string, int64_t>, ServerSideStats>
-      server_composing_model_stats;
 
   // Request count and elapsed time measured by client
   uint64_t client_request_count;
@@ -238,6 +239,12 @@ class InferenceProfiler {
       const size_t valid_request_count, const size_t valid_sequence_count,
       PerfStatus& summary);
 
+  nic::Error SummarizeServerStats(
+      const std::map<std::string, ni::ModelStatus>& start_status,
+      const std::map<std::string, ni::ModelStatus>& end_status,
+      ServerSideStats* server_stats);
+
+
   /// \param model_name The name of the model to summarize the server side stats
   /// \param model_version The version of the model
   /// \param start_status The model status at the start of the measurement.
@@ -245,7 +252,7 @@ class InferenceProfiler {
   /// \param server_stats Returns the summary that the fileds recorded by server
   /// are set.
   /// \return Error object indicating success or failure.
-  nic::Error SummarizeServerStats(
+  nic::Error SummarizeServerModelStats(
       const std::string& model_name, const int64_t model_version,
       const ni::ModelStatus& start_status, const ni::ModelStatus& end_status,
       ServerSideStats* server_stats);

--- a/src/clients/c++/inference_profiler.h
+++ b/src/clients/c++/inference_profiler.h
@@ -239,22 +239,26 @@ class InferenceProfiler {
       const size_t valid_request_count, const size_t valid_sequence_count,
       PerfStatus& summary);
 
-  nic::Error SummarizeServerStats(
-      const std::map<std::string, ni::ModelStatus>& start_status,
-      const std::map<std::string, ni::ModelStatus>& end_status,
-      ServerSideStats* server_stats);
-
-
   /// \param model_name The name of the model to summarize the server side stats
   /// \param model_version The version of the model
   /// \param start_status The model status at the start of the measurement.
   /// \param end_status The model status at the end of the measurement.
-  /// \param server_stats Returns the summary that the fileds recorded by server
+  /// \param server_stats Returns the summary that the fields recorded by server
   /// are set.
   /// \return Error object indicating success or failure.
   nic::Error SummarizeServerModelStats(
       const std::string& model_name, const int64_t model_version,
       const ni::ModelStatus& start_status, const ni::ModelStatus& end_status,
+      ServerSideStats* server_stats);
+
+  /// \param start_status The model status at the start of the measurement.
+  /// \param end_status The model status at the end of the measurement.
+  /// \param server_stats Returns the summary that the fields recorded by server
+  /// are set.
+  /// \return Error object indicating success or failure.
+  nic::Error SummarizeServerStats(
+      const std::map<std::string, ni::ModelStatus>& start_status,
+      const std::map<std::string, ni::ModelStatus>& end_status,
       ServerSideStats* server_stats);
 
   bool verbose_;

--- a/src/clients/c++/inference_profiler.h
+++ b/src/clients/c++/inference_profiler.h
@@ -31,6 +31,8 @@
 
 
 namespace perfclient {
+using ModelInfo = std::pair<std::string, int64_t>;
+using ComposingModelMap = std::map<ModelInfo, std::set<ModelInfo>>;
 
 /// Constant parameters that determine the whether stopping criteria has met
 /// for the current phase of testing
@@ -64,8 +66,7 @@ struct ServerSideStats {
   uint64_t queue_time_ns;
   uint64_t compute_time_ns;
 
-  std::map<std::pair<std::string, int64_t>, ServerSideStats>
-      composing_models_stat;
+  std::map<ModelInfo, ServerSideStats> composing_models_stat;
 };
 
 struct PerfStatus {
@@ -168,6 +169,20 @@ class InferenceProfiler {
       std::unique_ptr<nic::ServerStatusContext> status_ctx,
       std::unique_ptr<LoadManager> manager);
 
+  /// A helper function to construct the map of ensemble models to its composing
+  /// models \param model_name The ensemble model to be added into the map
+  /// \param model_version The version of the model to be added
+  /// \server_status The server status response from TRTIS.
+  /// \return Error object indicating success or failure
+  nic::Error BuildComposingModelMap(
+      const std::string& model_name, const int64_t& model_version,
+      const ni::ServerStatus& server_status);
+
+  /// Constructs the composing_model_map_ which includes the details of ensemble
+  /// \param The server status response from TRTIS
+  /// \return Error object indicating success or failure
+  nic::Error BuildComposingModelMap(const ni::ServerStatus& server_status);
+
   nic::Error StartProfile() { return profile_ctx_->StartProfile(); }
 
   nic::Error StopProfile() { return profile_ctx_->StopProfile(); }
@@ -183,6 +198,12 @@ class InferenceProfiler {
   /// models will also be returned.
   /// \return Error object indicating success or failure.
   nic::Error GetServerSideStatus(
+      std::map<std::string, ni::ModelStatus>* model_status);
+
+  // A helper fuction for obtaining the status of the models provided by the
+  // server.
+  nic::Error GetServerSideStatus(
+      ni::ServerStatus& server_status, const ModelInfo model_info,
       std::map<std::string, ni::ModelStatus>* model_status);
 
   /// Sumarize the measurement with the provided statistics.
@@ -257,6 +278,18 @@ class InferenceProfiler {
   /// are set.
   /// \return Error object indicating success or failure.
   nic::Error SummarizeServerStats(
+      const ModelInfo model_info,
+      const std::map<std::string, ni::ModelStatus>& start_status,
+      const std::map<std::string, ni::ModelStatus>& end_status,
+      ServerSideStats* server_stats);
+
+
+  /// \param start_status The model status at the start of the measurement.
+  /// \param end_status The model status at the end of the measurement.
+  /// \param server_stats Returns the summary that the fields recorded by server
+  /// are set.
+  /// \return Error object indicating success or failure.
+  nic::Error SummarizeServerStats(
       const std::map<std::string, ni::ModelStatus>& start_status,
       const std::map<std::string, ni::ModelStatus>& end_status,
       ServerSideStats* server_stats);
@@ -271,7 +304,7 @@ class InferenceProfiler {
   ContextFactory::ModelSchedulerType scheduler_type_;
   std::string model_name_;
   int64_t model_version_;
-  std::set<std::pair<std::string, int64_t>> composing_models_;
+  ComposingModelMap composing_models_map_;
 
   std::unique_ptr<nic::ProfileContext> profile_ctx_;
   std::unique_ptr<nic::ServerStatusContext> status_ctx_;

--- a/src/clients/c++/perf_client.cc
+++ b/src/clients/c++/perf_client.cc
@@ -127,9 +127,14 @@ SignalHandler(int signum)
 //
 
 nic::Error
-ReportServerSideStats(const ServerSideStats& stats)
+ReportServerSideStats(const ServerSideStats& stats, const int iteration)
 {
+  const std::string ident = std::string(2 * iteration, ' ');
   const uint64_t cnt = stats.request_count;
+  if (cnt == 0) {
+    std::cout << ident << "  Request count: " << cnt << std::endl;
+    return nic::Error(ni::RequestStatusCode::SUCCESS);
+  }
 
   const uint64_t cumm_time_us = stats.cumm_time_ns / 1000;
   const uint64_t cumm_avg_us = cumm_time_us / cnt;
@@ -143,8 +148,8 @@ ReportServerSideStats(const ServerSideStats& stats)
   const uint64_t overhead = (cumm_avg_us > queue_avg_us + compute_avg_us)
                                 ? (cumm_avg_us - queue_avg_us - compute_avg_us)
                                 : 0;
-  std::cout << "    Request count: " << cnt << std::endl
-            << "    Avg request latency: " << cumm_avg_us << " usec";
+  std::cout << ident << "  Request count: " << cnt << std::endl
+            << ident << "  Avg request latency: " << cumm_avg_us << " usec";
   if (stats.composing_models_stat.empty()) {
     std::cout << " (overhead " << overhead << " usec + "
               << "queue " << queue_avg_us << " usec + "
@@ -152,13 +157,20 @@ ReportServerSideStats(const ServerSideStats& stats)
               << std::endl;
   } else {
     std::cout << std::endl;
-    std::cout << "    Total avg compute time : " << compute_avg_us << " usec"
-              << std::endl;
-    std::cout << "    Total avg queue time : " << queue_avg_us << " usec"
+    std::cout << ident << "  Total avg compute time : " << compute_avg_us
+              << " usec" << std::endl;
+    std::cout << ident << "  Total avg queue time : " << queue_avg_us << " usec"
               << std::endl
               << std::endl;
-  }
 
+    std::cout << ident << "Composing models: " << std::endl;
+    for (const auto& model_stats : stats.composing_models_stat) {
+      const auto& model_info = model_stats.first;
+      std::cout << ident << model_info.first
+                << ", version: " << model_info.second << std::endl;
+      ReportServerSideStats(model_stats.second, iteration + 1);
+    }
+  }
 
   return nic::Error(ni::RequestStatusCode::SUCCESS);
 }
@@ -236,17 +248,7 @@ Report(
   std::cout << client_library_detail << std::endl;
 
   std::cout << "  Server: " << std::endl;
-  ReportServerSideStats(summary.server_stats);
-
-  if (!summary.server_stats.composing_models_stat.empty()) {
-    std::cout << "  Composing models: " << std::endl;
-    for (const auto& model_stats : summary.server_stats.composing_models_stat) {
-      const auto& model_info = model_stats.first;
-      std::cout << "  " << model_info.first
-                << ", version: " << model_info.second << std::endl;
-      ReportServerSideStats(model_stats.second);
-    }
-  }
+  ReportServerSideStats(summary.server_stats, 1);
 
   return nic::Error(ni::RequestStatusCode::SUCCESS);
 }

--- a/src/core/ensemble_scheduler.cc
+++ b/src/core/ensemble_scheduler.cc
@@ -650,6 +650,12 @@ EnsembleContext::ScheduleSteps(
           }
 
           timer.reset();
+          // Accumulate the queue and compute durations from this composing
+          // model
+          context->stats_->IncrementQueueDuration(
+              infer_stats->GetQueueDuration());
+          context->stats_->IncrementComputeDuration(
+              infer_stats->GetComputeDuration());
           infer_stats.reset();
           step->infer_status_ = status;
           Proceed(context, step);

--- a/src/core/server_status.cc
+++ b/src/core/server_status.cc
@@ -418,6 +418,19 @@ ModelInferStats::~ModelInferStats()
   }
 }
 
+
+void
+ModelInferStats::IncrementQueueDuration(const uint64_t increment_value)
+{
+  queue_duration_ns_ += increment_value;
+}
+
+void
+ModelInferStats::IncrementComputeDuration(const uint64_t increment_value)
+{
+  compute_duration_ns_ += increment_value;
+}
+
 struct timespec
 ModelInferStats::StartRequestTimer(ScopedTimer* timer) const
 {

--- a/src/core/server_status.h
+++ b/src/core/server_status.h
@@ -137,11 +137,22 @@ class ModelInferStats {
   // Set CUDA GPU device index where inference was performed.
   void SetGPUDevice(int idx) { gpu_device_ = idx; }
 
+  // Increments the queue_duration by specified value
+  void IncrementQueueDuration(const uint64_t increment_value);
+  // Increments the compute duration by specified value
+  void IncrementComputeDuration(const uint64_t increment_value);
+
   // Set the number of model executions that were performed for this
   // inference request. Can be zero if this request was dynamically
   // batched with another request (in dynamic batch case only one of
   // the batched requests will count the execution).
   void SetModelExecutionCount(uint32_t count) { execution_count_ = count; }
+
+  // Returns the current queue_duration in nanoseconds
+  uint64_t GetQueueDuration() const { return queue_duration_ns_; }
+
+  // Returns the current compute_duration in nanoseconds
+  uint64_t GetComputeDuration() const { return compute_duration_ns_; }
 
   // Get a ScopedTimer that measures entire inference request-response
   // duration. The lifetime of 'timer' must not exceed the


### PR DESCRIPTION
Instead of just printing 0 for compute and queue times for ubrella ensemble, server will set them to the total sum of the compute and queue times of the composing models.