### PR TITLE
Fix alloc_fn in grpc/http frontend to match trtserver.h description...

### DIFF
--- a/src/servers/grpc_server.cc
+++ b/src/servers/grpc_server.cc
@@ -138,8 +138,9 @@ AsyncResources::ResponseAlloc(
   *buffer = nullptr;
   *buffer_userp = nullptr;
 
-  // Can't allocate for any memory type other than CPU.
-  if (memory_type != TRTSERVER_MEMORY_CPU) {
+  // Can't allocate for any memory type other than CPU. If byte size is 0,
+  // proceed regardless of memory type as no allocation is required.
+  if ((memory_type != TRTSERVER_MEMORY_CPU) && (byte_size != 0)) {
     LOG_VERBOSE(1) << "GRPC allocation failed for type " << memory_type
                    << " for " << tensor_name;
     return nullptr;  // Success

--- a/src/servers/http_server.cc
+++ b/src/servers/http_server.cc
@@ -301,15 +301,15 @@ HTTPAPIServer::ResponseAlloc(
   *buffer = nullptr;
   *buffer_userp = nullptr;
 
-  // Can't allocate for any memory type other than CPU.
-  if (memory_type != TRTSERVER_MEMORY_CPU) {
-    LOG_VERBOSE(1) << "HTTP allocation failed for type " << memory_type
-                   << " for " << tensor_name;
-    return nullptr;  // Success
-  }
-
   // Don't need to do anything if no memory was requested.
   if (byte_size > 0) {
+    // Can't allocate for any memory type other than CPU.
+    if (memory_type != TRTSERVER_MEMORY_CPU) {
+      LOG_VERBOSE(1) << "HTTP allocation failed for type " << memory_type
+                    << " for " << tensor_name;
+      return nullptr;  // Success
+    }
+    
     // Reserve requested space in evbuffer...
     struct evbuffer_iovec output_iovec;
     if (evbuffer_reserve_space(evhttp_buffer, byte_size, &output_iovec, 1) !=


### PR DESCRIPTION
Check memory type and expect repeated call only if byte size is non-zero