### PR TITLE
Fix TRTIS_ENABLE_GPU=OFF builds

### DIFF
--- a/src/core/backend_context.cc
+++ b/src/core/backend_context.cc
@@ -103,13 +103,13 @@ BackendContext::SetInputBuffer(
                 RequestStatusCode::INTERNAL,
                 "failed to use CUDA copy for input '" + name +
                     "': " + std::string(cudaGetErrorString(err)));
+          }
 #else
           payload.status_ = Status(
               RequestStatusCode::INTERNAL,
               "try to use CUDA copy for input '" + name +
-                  "' while GPU is not supported"));
+                  "' while GPU is not supported");
 #endif  // TRTIS_ENABLE_GPU
-          }
         }
       }
       copied_byte_size += content_byte_size;


### PR DESCRIPTION
* fix #ifdef TRTIS_ENABLE_GPU logic in backend_context.cc

Discovered this while working on build automation. Very simple fix for the build.