### PR TITLE
dynamic shape support for tensorrt backend

### DIFF
--- a/src/backends/tensorrt/plan_backend.cc
+++ b/src/backends/tensorrt/plan_backend.cc
@@ -41,10 +41,12 @@
 namespace nvidia { namespace inferenceserver {
 
 PlanBackend::Context::Context(
-    const std::string& name, const int gpu_device, const int max_batch_size)
+    const std::string& name, const int gpu_device, const int max_batch_size,
+    const int profile_index)
     : BackendContext(name, gpu_device, max_batch_size), runtime_(nullptr),
-      engine_(nullptr), context_(nullptr), byte_sizes_(nullptr),
-      buffers_(nullptr)
+      engine_(nullptr), context_(nullptr), profile_index_(profile_index),
+      is_dynamic_(false), byte_sizes_(nullptr), buffers_(nullptr),
+      max_elements_cnt_(nullptr)
 {
   stream_ = nullptr;
 }
@@ -57,8 +59,14 @@ PlanBackend::Context::~Context()
     delete[] byte_sizes_;
     byte_sizes_ = nullptr;
   }
+
+  if (max_elements_cnt_ != nullptr) {
+    delete[] max_elements_cnt_;
+    max_elements_cnt_ = nullptr;
+  }
+
   if (buffers_ != nullptr) {
-    for (int i = 0; i < engine_->getNbBindings(); ++i) {
+    for (int i = 0; i < num_expected_bindings_; ++i) {
       if (buffers_[i] != nullptr) {
         cudaError_t err = cudaFree(buffers_[i]);
         if (err != cudaSuccess) {
@@ -152,8 +160,9 @@ PlanBackend::CreateExecutionContexts(
         const std::string instance_name = group.name() + "_" +
                                           std::to_string(c) + "_gpu" +
                                           std::to_string(gpu_device);
-        RETURN_IF_ERROR(
-            CreateExecutionContext(instance_name, gpu_device, models));
+        const int profile_index = group.optimization_profile_index();
+        RETURN_IF_ERROR(CreateExecutionContext(
+            instance_name, gpu_device, models, profile_index));
         total_context_cnt++;
       }
     }
@@ -175,10 +184,23 @@ PlanBackend::CreateExecutionContexts(
   return Status::Success;
 }
 
+void
+PlanBackend::Context::InitProfile()
+{
+  const int total_profiles = engine_->getNbOptimizationProfiles();
+  if (total_profiles == 0) {
+    num_expected_bindings_ = engine_->getNbBindings();
+  } else {
+    num_expected_bindings_ = engine_->getNbBindings() / total_profiles;
+  }
+  binding_offset_ = profile_index_ * num_expected_bindings_;
+}
+
 Status
 PlanBackend::CreateExecutionContext(
     const std::string& instance_name, const int gpu_device,
-    const std::unordered_map<std::string, std::vector<char>>& models)
+    const std::unordered_map<std::string, std::vector<char>>& models,
+    const int profile_index)
 {
   cudaError_t cuerr;
 
@@ -214,7 +236,8 @@ PlanBackend::CreateExecutionContext(
   const int mbs = (Config().max_batch_size() <= 0) ? Context::NO_BATCHING
                                                    : Config().max_batch_size();
 
-  contexts_.emplace_back(new Context(instance_name, gpu_device, mbs));
+  contexts_.emplace_back(
+      new Context(instance_name, gpu_device, mbs, profile_index));
   const std::unique_ptr<Context>& context = contexts_.back();
 
   // Set the device before generating engine and context.
@@ -228,21 +251,53 @@ PlanBackend::CreateExecutionContext(
   RETURN_IF_ERROR(
       LoadPlan(mn_itr->second, &context->runtime_, &context->engine_));
 
-  if (context->max_batch_size_ > context->engine_->getMaxBatchSize()) {
+  /* Batch Size will be specified explicitly in dimensions
+   if (context->max_batch_size_ > context->engine_->getMaxBatchSize()) {
+     return Status(
+         RequestStatusCode::INVALID_ARG,
+         "unexpected configuration maximum batch size " +
+             std::to_string(Config().max_batch_size()) + " for '" + Name() +
+             "', model maximum is " +
+             std::to_string(context->engine_->getMaxBatchSize()));
+   }
+   */
+
+  // Now the TRT execution context
+  context->context_ = context->engine_->createExecutionContext();
+  if (context->context_ == nullptr) {
     return Status(
-        RequestStatusCode::INVALID_ARG,
-        "unexpected configuration maximum batch size " +
-            std::to_string(Config().max_batch_size()) + " for '" + Name() +
-            "', model maximum is " +
-            std::to_string(context->engine_->getMaxBatchSize()));
+        RequestStatusCode::INTERNAL, "unable to create TensorRT context");
   }
 
-  const int num_expected_bindings = context->engine_->getNbBindings();
+  // TRT sets the optimization profile to be 0 implicitly with the first
+  // context creation. As currently TRTIS supports one context per engine,
+  // in order to set the specified profile_index, another context is created
+  // and the previous context is destroyed.
+  if (profile_index != 0) {
+    auto first_context = context->context_;
+    context->context_ = context->engine_->createExecutionContext();
+    if (context->context_ == nullptr) {
+      return Status(
+          RequestStatusCode::INTERNAL, "unable to create TensorRT context");
+    }
+    if (!context->context_->setOptimizationProfile(profile_index)) {
+      return Status(
+          RequestStatusCode::INVALID_ARG,
+          "Can not set the specified optimization profile " +
+              std::to_string(profile_index) + " for " + Name() +
+              ". Expected optimization profile index range 0-" +
+              std::to_string(
+                  context->engine_->getNbOptimizationProfiles() - 1));
+    }
+    first_context->destroy();
+  }
+
+  context->InitProfile();
 
   // Collect all the expected input and allowed output tensor names
   // and validate that the model configuration specifies only those.
   std::set<std::string> allowed_inputs, allowed_outputs;
-  for (int i = 0; i < num_expected_bindings; ++i) {
+  for (int i = 0; i < context->num_expected_bindings_; ++i) {
     if (context->engine_->bindingIsInput(i)) {
       allowed_inputs.emplace(context->engine_->getBindingName(i));
     } else {
@@ -263,15 +318,22 @@ PlanBackend::CreateExecutionContext(
   // Initialize the inputs and outputs. Make sure the model matches
   // what is in the configuration. Allocate memory for the maximum
   // possible batch size: min(engine maximum, config maximum)
-  context->byte_sizes_ = new uint64_t[num_expected_bindings];
-  context->buffers_ = new void*[num_expected_bindings]();  // init to nullptr
+  context->byte_sizes_ = new uint64_t[context->num_expected_bindings_];
+  context->buffers_ =
+      new void*[context->num_expected_bindings_]();  // init to nullptr
+  context->max_elements_cnt_ = new uint64_t[context->num_expected_bindings_];
 
   RETURN_IF_ERROR(context->InitializeConfigInputBindings(Config().input()));
   RETURN_IF_ERROR(context->InitializeSequenceControlInputBindings(Config()));
+  if (!context->context_->allInputDimensionsSpecified()) {
+    return Status(
+        RequestStatusCode::INTERNAL,
+        "failed to specify the dimensions of all input bindings");
+  }
   RETURN_IF_ERROR(context->InitializeConfigOutputBindings(Config().output()));
 
   // Make sure every index is initialized.
-  for (int i = 0; i < num_expected_bindings; ++i) {
+  for (int i = 0; i < context->num_expected_bindings_; ++i) {
     if (context->buffers_[i] == nullptr) {
       return Status(
           RequestStatusCode::INVALID_ARG,
@@ -280,13 +342,6 @@ PlanBackend::CreateExecutionContext(
                   (context->engine_->bindingIsInput(i) ? "input" : "output")) +
               " '" + context->engine_->getBindingName(i) + "' for " + Name());
     }
-  }
-
-  // Now the TRT execution context
-  context->context_ = context->engine_->createExecutionContext();
-  if (context->context_ == nullptr) {
-    return Status(
-        RequestStatusCode::INTERNAL, "unable to create TensorRT context");
   }
 
   // Create CUDA stream associated with the execution context
@@ -318,7 +373,8 @@ PlanBackend::CreateExecutionContext(
   }
 
   LOG_INFO << "Created instance " << instance_name << " on GPU " << gpu_device
-           << " (" << cc << ") with stream priority " << cuda_stream_priority;
+           << " (" << cc << ") with stream priority " << cuda_stream_priority
+           << " and optimization profile " << profile_index;
 
   return Status::Success;
 }
@@ -357,18 +413,45 @@ PlanBackend::Context::ValidateOutputs(
 }
 
 Status
+PlanBackend::Context::NormalizeDims(
+    const nvinfer1::Dims& max_dims, const DimsList& dims,
+    std::vector<int64_t>* normalized_dims)
+{
+  if (max_dims.nbDims != dims.size()) {
+    return Status(
+        RequestStatusCode::INVALID_ARG,
+        "can not normalize dimension " + DimsListToString(dims) + " to " +
+            DimsDebugString(max_dims) + " due to  incompatibility.");
+  }
+
+  for (int i = 0; i < dims.size(); ++i) {
+    if (dims[i] == WILDCARD_DIM) {
+      normalized_dims->emplace_back(max_dims.d[i]);
+    } else if (dims[i] <= max_dims.d[i]) {
+      normalized_dims->emplace_back(dims[i]);
+    } else {
+      return Status(
+          RequestStatusCode::INVALID_ARG,
+          "can not normalize dimension " + DimsListToString(dims) + " to " +
+              DimsDebugString(max_dims) + " due to  incompatibility.");
+    }
+  }
+  return Status::Success;
+}
+
+Status
 PlanBackend::Context::InitializeInputBinding(
     const std::string& input_name, const DataType input_datatype,
     const DimsList& model_config_dims)
 {
-  int index = engine_->getBindingIndex(input_name.c_str());
+  int index = binding_offset_ + engine_->getBindingIndex(input_name.c_str());
   if (index < 0) {
     return Status(
         RequestStatusCode::NOT_FOUND,
         "input '" + input_name + "' not found for " + name_);
   }
 
-  if (buffers_[index] != nullptr) {
+  if (buffers_[index - binding_offset_] != nullptr) {
     return Status(
         RequestStatusCode::INVALID_ARG, "input '" + input_name +
                                             "' has already appeared as an " +
@@ -392,7 +475,7 @@ PlanBackend::Context::InitializeInputBinding(
   }
 
   nvinfer1::Dims engine_dims = engine_->getBindingDimensions(index);
-  if (!CompareDims(engine_dims, model_config_dims)) {
+  if (!CompareDimsWithWildcard(engine_dims, model_config_dims)) {
     return Status(
         RequestStatusCode::INVALID_ARG,
         "unexpected shape for input '" + input_name +
@@ -401,7 +484,25 @@ PlanBackend::Context::InitializeInputBinding(
             DimsDebugString(engine_dims) + " for " + name_);
   }
 
-  const int64_t byte_size = GetByteSize(max_batch_size_, dt, model_config_dims);
+  // Detect whether dynamic or not
+  if (ContainsWildcard(engine_dims)) {
+    is_dynamic_ = true;
+  }
+
+  int64_t byte_size;
+  std::vector<int64_t> normalized_dims;
+  if (!ContainsWildcard(model_config_dims)) {
+    byte_size = GetByteSize(max_batch_size_, dt, model_config_dims);
+    max_elements_cnt_[index - binding_offset_] =
+        CountElements(model_config_dims);
+  } else {
+    nvinfer1::Dims max_possible_dims = engine_->getProfileDimensions(
+        index, profile_index_, nvinfer1::OptProfileSelector::kMAX);
+    RETURN_IF_ERROR(
+        NormalizeDims(max_possible_dims, model_config_dims, &normalized_dims));
+    byte_size = GetByteSize(max_batch_size_, dt, normalized_dims);
+    max_elements_cnt_[index - binding_offset_] = CountElements(normalized_dims);
+  }
   if (byte_size == -1) {
     return Status(
         RequestStatusCode::INTERNAL,
@@ -420,8 +521,27 @@ PlanBackend::Context::InitializeInputBinding(
                                          cudaGetErrorString(err));
   }
 
-  byte_sizes_[index] = byte_size;
-  buffers_[index] = buffer;
+  byte_sizes_[index - binding_offset_] = byte_size;
+  buffers_[index - binding_offset_] = buffer;
+
+
+  if (ContainsWildcard(model_config_dims)) {
+    nvinfer1::Dims* input_dim = new nvinfer1::Dims();
+    if (!DimVecToDims(normalized_dims, input_dim)) {
+      return Status(
+          RequestStatusCode::INTERNAL, "failed to create dims object for " +
+                                           DimsDebugString(normalized_dims) +
+                                           " for input '" + input_name +
+                                           "' for " + name_ + ".");
+    }
+    if (!context_->setBindingDimensions(index, *input_dim)) {
+      return Status(
+          RequestStatusCode::INTERNAL,
+          "failed to set binding dimension to " + DimsDebugString(*input_dim) +
+              " for input '" + input_name + "' for " + name_ + ".");
+    }
+    delete input_dim;
+  }
 
   return Status::Success;
 }
@@ -476,14 +596,14 @@ PlanBackend::Context::InitializeConfigOutputBindings(
     const ::google::protobuf::RepeatedPtrField<ModelOutput>& ios)
 {
   for (const auto& io : ios) {
-    int index = engine_->getBindingIndex(io.name().c_str());
+    int index = binding_offset_ + engine_->getBindingIndex(io.name().c_str());
     if (index < 0) {
       return Status(
           RequestStatusCode::NOT_FOUND,
           "output '" + io.name() + "' not found for " + name_);
     }
 
-    if (buffers_[index] != nullptr) {
+    if (buffers_[index - binding_offset_] != nullptr) {
       return Status(
           RequestStatusCode::INVALID_ARG, "output '" + io.name() +
                                               "' has already appeared as an " +
@@ -510,7 +630,7 @@ PlanBackend::Context::InitializeConfigOutputBindings(
         (io.has_reshape()) ? io.reshape().shape() : io.dims();
 
     nvinfer1::Dims engine_dims = engine_->getBindingDimensions(index);
-    if (!CompareDims(engine_dims, model_config_dims)) {
+    if (!CompareDimsWithWildcard(engine_dims, model_config_dims)) {
       return Status(
           RequestStatusCode::INVALID_ARG,
           "unexpected shape for output '" + io.name() +
@@ -519,12 +639,20 @@ PlanBackend::Context::InitializeConfigOutputBindings(
               DimsDebugString(engine_dims) + " for " + name_);
     }
 
-    const int64_t byte_size =
-        GetByteSize(max_batch_size_, dt, model_config_dims);
-    if (byte_size == -1) {
-      return Status(
-          RequestStatusCode::INTERNAL, "unable to calculate size for output '" +
-                                           io.name() + " for " + name_);
+    int64_t byte_size;
+    if (!ContainsWildcard(model_config_dims)) {
+      byte_size = GetByteSize(max_batch_size_, dt, model_config_dims);
+      if (byte_size == -1) {
+        return Status(
+            RequestStatusCode::INTERNAL,
+            "unable to calculate size for output '" + io.name() + " for " +
+                name_);
+      }
+    } else {
+      const nvinfer1::Dims output_dim = context_->getBindingDimensions(index);
+      std::vector<int64_t> dim_vec;
+      DimsToVec(output_dim, &dim_vec);
+      byte_size = GetByteSize(max_batch_size_, dt, dim_vec);
     }
 
     // Allocate CUDA memory. We rely on buffers_ being non-nullptr to
@@ -539,8 +667,8 @@ PlanBackend::Context::InitializeConfigOutputBindings(
               name_ + ": " + std::string(cudaGetErrorString(err)));
     }
 
-    byte_sizes_[index] = byte_size;
-    buffers_[index] = buffer;
+    byte_sizes_[index - binding_offset_] = byte_size;
+    buffers_[index - binding_offset_] = buffer;
   }
 
   return Status::Success;
@@ -631,6 +759,8 @@ PlanBackend::Context::Run(std::vector<Scheduler::Payload>* payloads)
 
   cudaSetDevice(gpu_device_);
 
+  std::shared_ptr<InferRequestProvider> input_request_provider;
+
   // For each request in 'payloads' collect the total batch size for
   // this inference execution. The batch-size, number of inputs, and
   // size of each input has already been checked by each payloads
@@ -645,6 +775,10 @@ PlanBackend::Context::Run(std::vector<Scheduler::Payload>* payloads)
     }
 
     total_batch_size += payload.request_provider_->RequestHeader().batch_size();
+
+    // All payloads must have equally-sized input tensors so use any
+    // payload as the representative for the input tensors.
+    input_request_provider = payload.request_provider_;
   }
 
   // If there are no valid payloads then no need to run the
@@ -665,15 +799,37 @@ PlanBackend::Context::Run(std::vector<Scheduler::Payload>* payloads)
 
   // For each input, concatenate input values from each payload into
   // the corresponding binding.
-  for (int bindex = 0; bindex < engine_->getNbBindings(); ++bindex) {
-    if (!engine_->bindingIsInput(bindex)) {
+  for (int bindex = 0; bindex < num_expected_bindings_; ++bindex) {
+    if (!engine_->bindingIsInput(binding_offset_ + bindex)) {
       continue;
     }
 
-    const std::string& name = engine_->getBindingName(bindex);
-    const size_t batch1_byte_size =
-        byte_sizes_[bindex] / std::max(1, max_batch_size_);
+    // Get the shape of the input. The provider has already checked
+    // that the request shape is valid so don't need to do it here.
+    std::vector<int64_t> shape;
 
+    // The first element of the vector will be the batch size
+    shape.push_back(total_batch_size);
+
+    const std::string& name = engine_->getBindingName(bindex);
+
+    // Can be further optimized
+    size_t batch1_element_cnt = 1;
+    LOG_INFO << input_request_provider->RequestHeader().DebugString();
+    for (const auto& input : input_request_provider->RequestHeader().input()) {
+      const std::string& this_name = input.name();
+      if (this_name.compare(name) == 0) {
+        for (auto dim : input.dims()) {
+          shape.push_back(dim);
+          batch1_element_cnt *= dim;
+        }
+      }
+    }
+
+    const size_t batch1_byte_size =
+        (byte_sizes_[bindex] /
+         (max_elements_cnt_[bindex] * std::max(1, max_batch_size_))) *
+        batch1_element_cnt;
     // Visit the payloads in order and copy the input tensors to
     // GPU. Skip payloads that had errors since they are not included
     // in the dynamic batch.
@@ -688,6 +844,25 @@ PlanBackend::Context::Run(std::vector<Scheduler::Payload>* payloads)
     SetInputBuffer(
         name, expected_byte_sizes, payloads, TRTSERVER_MEMORY_GPU,
         static_cast<char*>(buffers_[bindex]));
+
+    // Set the binding dimension so that output dimensions can be obtained
+    if (is_dynamic_) {
+      nvinfer1::Dims* this_dim = new nvinfer1::Dims();
+      if (!DimVecToDims(shape, this_dim)) {
+        return Status(
+            RequestStatusCode::INTERNAL,
+            "failed to create dims object for " + DimsDebugString(shape) +
+                " for input '" + name + "' for " + name_ + ".");
+      }
+      if (!context_->setBindingDimensions(bindex, *this_dim)) {
+        return Status(
+            RequestStatusCode::INTERNAL,
+            "failed to set binding dimension to " + DimsDebugString(*this_dim) +
+                " for input '" + name + "' for " + name_ +
+                ". The dimension is beyond the limits of optimization profile");
+      }
+      delete this_dim;
+    }
   }
 
   // Async execute the inference using a CUDA graph if available for
@@ -703,11 +878,25 @@ PlanBackend::Context::Run(std::vector<Scheduler::Payload>* payloads)
               cudaGetErrorString(err));
     }
   } else {
-    if (!context_->enqueue(total_batch_size, buffers_, stream_, nullptr)) {
-      cudaStreamSynchronize(stream_);
-      return Status(
-          RequestStatusCode::INTERNAL,
-          "unable to enqueue for inference " + name_);
+    if (is_dynamic_) {
+      if (!context_->allInputDimensionsSpecified()) {
+        return Status(
+            RequestStatusCode::INTERNAL,
+            "failed to specify the dimensions of all input bindings");
+      }
+      if (!context_->enqueueV2(buffers_, stream_, nullptr)) {
+        cudaStreamSynchronize(stream_);
+        return Status(
+            RequestStatusCode::INTERNAL,
+            "unable to enqueue for inference " + name_);
+      }
+    } else {
+      if (!context_->enqueue(total_batch_size, buffers_, stream_, nullptr)) {
+        cudaStreamSynchronize(stream_);
+        return Status(
+            RequestStatusCode::INTERNAL,
+            "unable to enqueue for inference " + name_);
+      }
     }
   }
 

--- a/src/backends/tensorrt/plan_utils.cc
+++ b/src/backends/tensorrt/plan_utils.cc
@@ -84,6 +84,59 @@ CompareDims(const nvinfer1::Dims& model_dims, const DimsList& dims)
   return true;
 }
 
+bool
+CompareDimsWithWildcard(const nvinfer1::Dims& model_dims, const DimsList& dims)
+{
+  if (model_dims.nbDims != dims.size()) {
+    std::cout << "size" << std::endl;
+    return false;
+  }
+
+  for (int i = 0; i < model_dims.nbDims; ++i) {
+    if ((model_dims.d[i] != WILDCARD_DIM) && (dims[i] != WILDCARD_DIM) &&
+        (model_dims.d[i] != dims[i])) {
+      std::cout << "elem" << std::endl;
+      return false;
+    }
+  }
+
+  return true;
+}
+
+void
+DimsToVec(const nvinfer1::Dims& model_dims, std::vector<int64_t>* dims)
+{
+  dims->clear();
+  for (int i = 0; i < model_dims.nbDims; ++i) {
+    dims->emplace_back(model_dims.d[i]);
+  }
+}
+
+bool
+DimVecToDims(const std::vector<int64_t>& dim_vec, nvinfer1::Dims* dims)
+{
+  if (dim_vec.size() > dims->MAX_DIMS) {
+    return false;
+  } else {
+    dims->nbDims = dim_vec.size();
+    for (int i = 0; i < dims->nbDims; ++i) {
+      dims->d[i] = (int)dim_vec[i];
+    }
+  }
+  return true;
+}
+
+bool
+ContainsWildcard(const nvinfer1::Dims& dims)
+{
+  for (int i = 0; i < dims.nbDims; ++i) {
+    if (dims.d[i] == WILDCARD_DIM) {
+      return true;
+    }
+  }
+  return false;
+}
+
 const std::string
 DimsDebugString(const nvinfer1::Dims& dims)
 {
@@ -99,6 +152,51 @@ DimsDebugString(const nvinfer1::Dims& dims)
   }
   str.append("]");
   return str;
+}
+
+const std::string
+DimsDebugString(const std::vector<int64_t>& dims)
+{
+  bool first = true;
+  std::string str;
+  str.append("[");
+  for (uint32_t i = 0; i < dims.size(); ++i) {
+    if (!first) {
+      str.append(",");
+    }
+    str.append(std::to_string(dims[i]));
+    first = false;
+  }
+  str.append("]");
+  return str;
+}
+
+int
+CountElements(const std::vector<int64_t>& dims)
+{
+  if (dims.size() == 0) {
+    return 0;
+  } else {
+    size_t count = 1;
+    for (uint32_t i = 0; i < dims.size(); ++i) {
+      count *= dims[i];
+    }
+    return count;
+  }
+}
+
+int
+CountElements(const DimsList& dims)
+{
+  if (dims.size() == 0) {
+    return 0;
+  } else {
+    size_t count = 1;
+    for (int i = 0; i < dims.size(); ++i) {
+      count *= dims[i];
+    }
+    return count;
+  }
 }
 
 }}  // namespace nvidia::inferenceserver

--- a/src/backends/tensorrt/plan_utils.h
+++ b/src/backends/tensorrt/plan_utils.h
@@ -38,6 +38,21 @@ std::pair<bool, nvinfer1::DataType> ConvertDataTypeToTrtType(
 
 bool CompareDims(const nvinfer1::Dims& model_dims, const DimsList& dims);
 
+bool CompareDimsWithWildcard(
+    const nvinfer1::Dims& model_dims, const DimsList& dims);
+
+void DimsToVec(const nvinfer1::Dims& model_dims, std::vector<int64_t>* dims);
+
+bool DimVecToDims(const std::vector<int64_t>& dim_vec, nvinfer1::Dims* dims);
+
+bool ContainsWildcard(const nvinfer1::Dims& dims);
+
 const std::string DimsDebugString(const nvinfer1::Dims& dims);
+
+const std::string DimsDebugString(const std::vector<int64_t>& dims);
+
+int CountElements(const DimsList& dims);
+
+int CountElements(const std::vector<int64_t>& dims);
 
 }}  // namespace nvidia::inferenceserver

--- a/src/core/model_config.cc
+++ b/src/core/model_config.cc
@@ -290,6 +290,17 @@ CompareDims(const DimsList& dims0, const DimsList& dims1)
 }
 
 bool
+ContainsWildcard(const DimsList& dims)
+{
+  for (int i = 0; i < dims.size(); ++i) {
+    if (dims[i] == WILDCARD_DIM) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool
 CompareDimsWithWildcard(const DimsList& dims0, const DimsList& dims1)
 {
   if (dims0.size() != dims1.size()) {

--- a/src/core/model_config.h
+++ b/src/core/model_config.h
@@ -196,6 +196,12 @@ int GetCpuNiceLevel(const ModelConfig& config);
 /// \return True if the shapes are equal, false if not equal.
 bool CompareDims(const DimsList& dims0, const DimsList& dims1);
 
+/// Returns true if the specified dimensions contain the wildcard
+/// \param dims The target dimensions
+/// \return Whether or not the specified dimension contains the
+/// wildcard.
+bool ContainsWildcard(const DimsList& dims);
+
 /// Compare two model configuration shapes for equality. Wildcard
 /// dimensions (that is, dimensions with size WILDCARD_DIM) are
 /// allowed to match with any value. So, a dimension in one shape

--- a/src/core/model_config.proto
+++ b/src/core/model_config.proto
@@ -154,6 +154,16 @@ message ModelInstanceGroup
   //@@     available GPUs.
   //@@
   repeated int32 gpus = 3;
+
+  //@@  .. cpp:var:: int32 optimization_profile_index
+  //@@
+  //@@     For TensorRT Plan models, using inputs with dynamic shape, this
+  //@@     parameter specifies the index of an optimization profile to be set
+  //@@     for this instance group. This index should lie between 0 and
+  //@@     <TotalNumberOfOptimizationProfilesInPlanModel> - 1. This parameter
+  //@@     is ignored for other backends and TensorRT not using dynamic shapes.
+  //@@
+  int32 optimization_profile_index = 5;
 }
 
 //@@


### PR DESCRIPTION
The changes are not yet tested for the inference part. However, with the changes backend successfully load the plan with the specified optimization profile and dynamic inputs. The dimensions inferred were also successfully verified.
```

# trtserver --model-store=/opt/tensorrtserver/qa/L0_perflab_trt_resnet/dynamic_model/t
I0820 19:46:04.490879 3040 metrics.cc:160] found 2 GPUs supporting NVML metrics
I0820 19:46:04.497003 3040 metrics.cc:169]   GPU 0: GeForce GT 710
I0820 19:46:04.503369 3040 metrics.cc:169]   GPU 1: TITAN RTX
I0820 19:46:04.503564 3040 server.cc:111] Initializing TensorRT Inference Server
I0820 19:46:04.524753 3040 server_status.cc:83] New status tracking for model 'dynamic_reshape_plan'
I0820 19:46:04.524826 3040 model_repository_manager.cc:668] loading: dynamic_reshape_plan:1
I0820 19:46:04.528435 3040 plan_backend.cc:232] Creating instance dynamic_reshape_plan_0_0_gpu0 on GPU 0 (7.5) using model.plan
W0820 19:46:08.280734 3040 logging.cc:46] Could not set default profile 0 for execution context. Profile index must be set explicitly.
I0820 19:46:08.281076 3040 plan_backend.cc:375] Created instance dynamic_reshape_plan_0_0_gpu0 on GPU 0 (7.5) with stream priority 0 and optimization profile 2
I0820 19:46:08.281293 3040 plan_backend.cc:232] Creating instance dynamic_reshape_plan_0_1_gpu0 on GPU 0 (7.5) using model.plan
W0820 19:46:08.284828 3040 logging.cc:46] Could not set default profile 0 for execution context. Profile index must be set explicitly.
I0820 19:46:08.285107 3040 plan_backend.cc:375] Created instance dynamic_reshape_plan_0_1_gpu0 on GPU 0 (7.5) with stream priority 0 and optimization profile 2
I0820 19:46:08.285420 3040 model_repository_manager.cc:811] successfully loaded 'dynamic_reshape_plan' version 1
```

The model.plan is a simple TensorRT IResizeLayer that takes in dynamic shaped input and produce output of a fixed size. Below is the model configuration used:

```
name: "dynamic_reshape_plan"
platform: "tensorrt_plan"
max_batch_size: 4
input [
  {
    name: "input"
    data_type: TYPE_FP32
    dims: [ 1, -1, -1 ]
  }
]
output [
  {
    name: "out"
    data_type: TYPE_FP32
    dims: [ 1, -1, -1 ]
  }
]
instance_group [
  {
    count: 2
    optimization_profile_index : 2
  }
]

dynamic_batching { preferred_batch_size: [ 4 ] }
```


 