### PR TITLE
Fix compiler warning

### DIFF
--- a/src/clients/c++/simple_sequence_client.cc
+++ b/src/clients/c++/simple_sequence_client.cc
@@ -160,7 +160,7 @@ AsyncSend(
   // Send inference request to the inference server.
   FAIL_IF_ERR(ctx->AsyncRun(&request), "unable to run model");
 
-  return std::move(request);
+  return request;
 }
 
 int32_t


### PR DESCRIPTION
/run/media/szheyu/data_1/tensorrt-inference-server/src/clients/c++/simple_s
equence_client.cc: 在函数‘std::shared_ptr<nvidia::inferenceserver::client::
InferContext::Request> {anonymous}::AsyncSend(const std::unique_ptr<nvidia:
:inferenceserver::client::InferContext>&, int32_t, bool, bool)’中:         
/run/media/szheyu/data_1/tensorrt-inference-server/src/clients/c++/simple_s
equence_client.cc:163:19: 错误：moving a local object in a return statement
 prevents copy elision [-Werror=pessimizing-move]
  163 |   return std::move(request);
      |          ~~~~~~~~~^~~~~~~~~  
/run/media/szheyu/data_1/tensorrt-inference-server/