### PR TITLE
[Jetson] Native compile on Jetson Xavier

### DIFF
--- a/build/trtis/CMakeLists.txt
+++ b/build/trtis/CMakeLists.txt
@@ -110,6 +110,12 @@ if(${TRTIS_ENABLE_GPU})
   find_package(CUDA REQUIRED)
   message(STATUS "Using CUDA ${CUDA_VERSION}")
   set(CUDA_NVCC_FLAGS -std=c++11)
+
+  if(CUDA_VERSION VERSION_GREATER_EQUAL "10.1")
+    add_definitions(-DTRTIS_ENABLE_CUDA_GRAPH=1)
+  else()
+    message(WARNING "CUDA ${CUDA_VERSION} does not support CUDA graphs.")
+  endif()
 endif() # TRTIS_ENABLE_GPU
 
 #


### PR DESCRIPTION
(note: this pull request is a clean-up version of #414 )

### Setup configuration:
1. Jetson Xavier with Jetpack 4.2.1
2. CUDA 10.0
3. TensorRT 5.1.6

### Code changes:
1. Add CUDA version check in CMake.
2. Disable CUDA graph if CUDA version < 10.1.

### Compilation steps:
1. Please follow the official [instructions](https://docs.nvidia.com/deeplearning/sdk/tensorrt-inference-server-guide/docs/build.html#building-the-server-with-cmake) for building server with CMake.
2. CUDA 10.0 and TensorRT 5.1.6 are installed by Jetpack sdkmanager during flashing.
3. Install all other packages listed in [Dockerfile](https://github.com/NVIDIA/tensorrt-inference-server/blob/master/Dockerfile#L159).
4. Native compile on Jetson.
```
mkdir builddir
cd builddir
cmake -DCMAKE_BUILD_TYPE=Release \
      -DTRTIS_ENABLE_METRICS=ON \
      -DTRTIS_ENABLE_CUSTOM=ON \
      -DTRTIS_ENABLE_GPU=ON \
      -DTRTIS_ENABLE_TENSORRT=ON \
      ../build
make -j trtis
make -j trtis-clients
make -j trtis-custom-backends
```
5. Launch server.
```
cd /path/to/tensorrt-inference-server/builddir/trtis/install/bin
LD_PRELOAD=/usr/local/cuda/lib64/stubs/libnvidia-ml.so \ 
  LD_LIBRARY_PATH=$LD_LIBRARY_PATH:../lib \ 
  ./trtserver --model-store=/your/model/store
```
6. Create Jetson docker image with [instruction](https://github.com/NVIDIA/nvidia-docker/wiki/NVIDIA-Container-Runtime-on-Jetson). Copy `bin`, `lib`, `include` folders from `install` to `/opt/tensorrtserver/`

### Known issues:
1. CUDA graph is not supported in CUDA 10.0.
2. gRPC protocol gives error:
```
tensorrtserver.api.InferenceServerException: [ 0] GRPC client failed: 14: Socket closed
```
3. NVML is not supported on Jetson.
```
E0821 06:27:34.280622 6 metrics.cc:147] failed to initialize NVML: NVML_ERROR 9
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
WARNING:

You should always run with libnvidia-ml.so that is installed with your
NVIDIA Display Driver. By default it's installed in /usr/lib and /usr/lib64.
libnvidia-ml.so in GDK package is a stub library that is attached only for
build purposes (e.g. machine that you build your application doesn't have
to have Display Driver installed).
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
```

### Build Jetson docker
1. Please follow [instruction](https://github.com/NVIDIA/nvidia-docker/wiki/NVIDIA-Container-Runtime-on-Jetson) to build/run Jetson docker.
2. Please follow this section to build/run Jetson docker image on x86 machine.
3. If you don't have F flag enabled on your host machine, you will need to add `COPY ./qemu-aarch64-static /usr/bin/qemu-aarch64-static` in your dockerfile, otherwise it will raise error `exec format error’`