### PR TITLE
Rollback ONNX Runtime to specific commit as rel-0.5.0 is broken

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -108,7 +108,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends git
 # Check out stable commit on master until new release
 # to support cloud-based filesystems
 RUN git clone --recursive https://github.com/Microsoft/onnxruntime && \
-    (cd onnxruntime && git checkout 2f698bd54b713bb87dbd0bbb913e94bcf7fd480c)
+    (cd onnxruntime && \
+            git checkout c0acb8b6c3b2e3e174627dcb3100009e97c2293d && \
+            git submodule update)
 
 ENV PATH="/opt/cmake/bin:${PATH}"
 ARG SCRIPT_DIR=/workspace/onnxruntime/tools/ci_build/github/linux/docker/scripts

--- a/Dockerfile
+++ b/Dockerfile
@@ -99,13 +99,16 @@ FROM ${BASE_IMAGE} AS trtserver_onnx
 # needs to be built from source
 
 # Onnx Runtime release version
-ARG ONNX_RUNTIME_VERSION=0.5.0
+ARG ONNX_RUNTIME_VERSION=0.4.0
 
 # Get release version of Onnx Runtime
 WORKDIR /workspace
 RUN apt-get update && apt-get install -y --no-install-recommends git
 
-RUN git clone -b rel-${ONNX_RUNTIME_VERSION} --recursive https://github.com/Microsoft/onnxruntime
+# Check out stable commit on master until new release
+# to support cloud-based filesystems
+RUN git clone --recursive https://github.com/Microsoft/onnxruntime && \
+    (cd onnxruntime && git checkout 2f698bd54b713bb87dbd0bbb913e94bcf7fd480c)
 
 ENV PATH="/opt/cmake/bin:${PATH}"
 ARG SCRIPT_DIR=/workspace/onnxruntime/tools/ci_build/github/linux/docker/scripts
@@ -231,14 +234,8 @@ COPY --from=trtserver_caffe2 /opt/conda/lib/python3.6/site-packages/torch/lib/li
       /opt/tensorrtserver/lib/
 
 # Onnx Runtime headers and library
-# Put include files to same directory as ONNX Runtime changed the include path
-# https://github.com/microsoft/onnxruntime/pull/1461
-ARG ONNX_RUNTIME_VERSION=0.5.0
-COPY --from=trtserver_onnx /workspace/onnxruntime/include/onnxruntime/core/session/onnxruntime_c_api.h \
-     /opt/tensorrtserver/include/onnxruntime/
-COPY --from=trtserver_onnx /workspace/onnxruntime/include/onnxruntime/core/providers/cpu/cpu_provider_factory.h \
-     /opt/tensorrtserver/include/onnxruntime/
-COPY --from=trtserver_onnx /workspace/onnxruntime/include/onnxruntime/core/providers/cuda/cuda_provider_factory.h \
+ARG ONNX_RUNTIME_VERSION=0.4.0
+COPY --from=trtserver_onnx /workspace/onnxruntime/include/onnxruntime \
      /opt/tensorrtserver/include/onnxruntime/
 COPY --from=trtserver_onnx /workspace/build/Release/libonnxruntime.so.${ONNX_RUNTIME_VERSION} \
      /opt/tensorrtserver/lib/

--- a/src/backends/onnx/autofill.cc
+++ b/src/backends/onnx/autofill.cc
@@ -308,14 +308,12 @@ AutoFillOnnx::Create(
   }
 
   // Create resource wrapper to manage release of resource
-  OrtSessionOptions* session_options;
-
-  RETURN_IF_ORT_ERROR(OrtCreateSessionOptions(&session_options));
+  OrtSessionOptions* session_options = OrtCreateSessionOptions();
 
   OrtResourceWrapper<OrtSessionOptions*> options_wrapper(
       session_options, &OrtReleaseSessionOptions);
-  RETURN_IF_ORT_ERROR(OrtSetSessionThreadPoolSize(session_options, 1));
-  RETURN_IF_ORT_ERROR(OrtSetSessionGraphOptimizationLevel(session_options, 0));
+  OrtSetSessionThreadPoolSize(session_options, 1);
+  OrtSetSessionGraphOptimizationLevel(session_options, 0);
 
   OrtSession* session;
 

--- a/src/backends/onnx/loader.h
+++ b/src/backends/onnx/loader.h
@@ -25,7 +25,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
-#include <onnxruntime_c_api.h>
+#include <core/session/onnxruntime_c_api.h>
 #include "src/core/status.h"
 
 namespace nvidia { namespace inferenceserver {

--- a/src/backends/onnx/onnx_backend.cc
+++ b/src/backends/onnx/onnx_backend.cc
@@ -38,7 +38,7 @@
 #include "src/core/server_status.h"
 
 #ifdef TRTIS_ENABLE_GPU
-#include <cuda_provider_factory.h>
+#include <core/providers/cuda/cuda_provider_factory.h>
 #include <cuda_runtime_api.h>
 #endif  // TRTIS_ENABLE_GPU
 

--- a/src/backends/onnx/onnx_backend.h
+++ b/src/backends/onnx/onnx_backend.h
@@ -25,7 +25,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
-#include <onnxruntime_c_api.h>
+#include <core/session/onnxruntime_c_api.h>
 #include "src/core/backend.h"
 #include "src/core/backend_context.h"
 #include "src/core/model_config.pb.h"

--- a/src/backends/onnx/onnx_utils.cc
+++ b/src/backends/onnx/onnx_utils.cc
@@ -99,18 +99,14 @@ InputOutputInfos(
 
     OrtResourceWrapper<OrtTypeInfo*> typeinfo_wrapper(
         typeinfo, &OrtReleaseTypeInfo);
-    const OrtTensorTypeAndShapeInfo* tensor_info;
-    RETURN_IF_ORT_ERROR(OrtCastTypeInfoToTensorInfo(typeinfo, &tensor_info));
+    const OrtTensorTypeAndShapeInfo* tensor_info = OrtCastTypeInfoToTensorInfo(typeinfo);
 
-    ONNXTensorElementDataType type;
-    RETURN_IF_ORT_ERROR(OrtGetTensorElementType(tensor_info, &type));
+    ONNXTensorElementDataType type = OrtGetTensorElementType(tensor_info);
 
-    size_t num_dims;
-    RETURN_IF_ORT_ERROR(OrtGetDimensionsCount(tensor_info, &num_dims));
+    size_t num_dims = OrtGetNumOfDimensions(tensor_info);
 
     std::vector<int64_t> dims(num_dims);
-    RETURN_IF_ORT_ERROR(
-        OrtGetDimensions(tensor_info, (int64_t*)dims.data(), num_dims));
+    OrtGetDimensions(tensor_info, (int64_t*)dims.data(), num_dims);
 
     infos.emplace(name, OnnxTensorInfo(type, dims));
   }

--- a/src/backends/onnx/onnx_utils.h
+++ b/src/backends/onnx/onnx_utils.h
@@ -26,7 +26,7 @@
 
 #pragma once
 
-#include <onnxruntime_c_api.h>
+#include <core/session/onnxruntime_c_api.h>
 #include "src/core/model_config.h"
 #include "src/core/status.h"
 


### PR DESCRIPTION
The ONNX Runtime commit selected is the earliest commit that contains the API needed for cloud storage, and this commit also avoids the [slow down](https://github.com/microsoft/onnxruntime/issues/1675) we are seeing