### PR TITLE
Fix Python aysnc_run_with_cb() documentation and example

### DIFF
--- a/src/clients/python/__init__.py
+++ b/src/clients/python/__init__.py
@@ -1394,13 +1394,6 @@ class InferContext:
             The flags to use for the inference. The bitwise-or of
             InferRequestHeader.Flag values.
 
-        Returns
-        -------
-        int
-            Integer identifier which must be passed to
-            get_async_run_results() to wait on and retrieve the
-            inference results.
-
         Raises
         ------
         InferenceServerException

--- a/src/clients/python/simple_callback_client.py
+++ b/src/clients/python/simple_callback_client.py
@@ -88,7 +88,7 @@ if __name__ == '__main__':
 
     # Send async inference
     for idx in range(request_cnt):
-        result = ctx.async_run_with_cb(partial(completion_callback, user_data, idx),
+        ctx.async_run_with_cb(partial(completion_callback, user_data, idx),
                                         { 'INPUT0' : (input0_data,),
                                           'INPUT1' : (input1_data,) },
                                         { 'OUTPUT0' : InferContext.ResultFormat.RAW,


### PR DESCRIPTION
Request ID can only be retrieve via callback function.