### PR TITLE
Add simple gRPC Go client

### DIFF
--- a/src/clients/go/gen_go_stubs.sh
+++ b/src/clients/go/gen_go_stubs.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Local
+PACKAGE_PATH="nvidia_inferenceserver"
+# Or add to GOPATH and remove "./" from import path in grpc_simple_client.go
+#PACKAGE_PATH="${GOPATH}/src/nvidia_inferenceserver"
+
+mkdir -p ${PACKAGE_PATH} 
+# Requires protoc and protoc-gen-go plugin: https://github.com/golang/protobuf#installation
+protoc -I ../../core --go_out=plugins=grpc:${PACKAGE_PATH} ../../core/*.proto

--- a/src/clients/go/grpc_simple_client.go
+++ b/src/clients/go/grpc_simple_client.go
@@ -1,0 +1,210 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"flag"
+	"fmt"
+	"log"
+	"time"
+
+	trtis "./nvidia_inferenceserver"
+
+	"google.golang.org/grpc"
+)
+
+const (
+	inputSize  = 16
+	outputSize = 16
+)
+
+type Flags struct {
+	ModelName    string
+	ModelVersion int64
+	BatchSize    int
+	URL          string
+}
+
+func parseFlags() Flags {
+	var flags Flags
+	// https://github.com/NVIDIA/tensorrt-inference-server/tree/master/docs/examples/model_repository/simple
+	flag.StringVar(&flags.ModelName, "m", "simple", "Name of model being served. (Required)")
+	flag.Int64Var(&flags.ModelVersion, "x", -1, "Version of model. Default: Latest Version.")
+	flag.IntVar(&flags.BatchSize, "b", 1, "Batch size. Default: 1.")
+	flag.StringVar(&flags.URL, "u", "localhost:8001", "Inference Server URL. Default: localhost:8001")
+	flag.Parse()
+	return flags
+}
+
+// mode should be either "live" or "ready"
+func HealthRequest(client trtis.GRPCServiceClient, mode string) *trtis.HealthResponse {
+	// Create context for our request with 10 second timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Create health request for given mode {"live", "ready"}
+	healthRequest := trtis.HealthRequest{
+		Mode: mode,
+	}
+	// Submit health request to server
+	healthResponse, err := client.Health(ctx, &healthRequest)
+	if err != nil {
+		log.Fatalf("Couldn't get server health: %v", err)
+	}
+	return healthResponse
+}
+
+func StatusRequest(client trtis.GRPCServiceClient, modelName string) *trtis.StatusResponse {
+	// Create context for our request with 10 second timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Create status request for a given model
+	statusRequest := trtis.StatusRequest{
+		ModelName: modelName,
+	}
+	// Submit status request to server
+	statusResponse, err := client.Status(ctx, &statusRequest)
+	if err != nil {
+		log.Fatalf("Couldn't get server status: %v", err)
+	}
+	return statusResponse
+}
+
+func InferRequest(client trtis.GRPCServiceClient, rawInput [][]byte, modelName string, modelVersion int64, batchSize int) *trtis.InferResponse {
+	// Create context for our request with 10 second timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Create request header which describes inputs, outputs, and batch size
+	inferRequestHeader := &trtis.InferRequestHeader{
+		Input: []*trtis.InferRequestHeader_Input{
+			&trtis.InferRequestHeader_Input{
+				Name: "INPUT0",
+			},
+			&trtis.InferRequestHeader_Input{
+				Name: "INPUT1",
+			},
+		},
+		Output: []*trtis.InferRequestHeader_Output{
+			&trtis.InferRequestHeader_Output{
+				Name: "OUTPUT0",
+			},
+			&trtis.InferRequestHeader_Output{
+				Name: "OUTPUT1",
+			},
+		},
+		BatchSize: uint32(batchSize),
+	}
+
+	// Create inference request for specific model/version
+	inferRequest := trtis.InferRequest{
+		ModelName:    modelName,
+		ModelVersion: modelVersion,
+		MetaData:     inferRequestHeader,
+		RawInput:     rawInput,
+	}
+
+	// Submit inference request to server
+	inferResponse, err := client.Infer(ctx, &inferRequest)
+	if err != nil {
+		log.Fatalf("Error processing InferRequest: %v", err)
+	}
+	return inferResponse
+}
+
+// Convert int32 input data into raw bytes (assumes Little Endian)
+func Preprocess(inputs [][]uint32) [][]byte {
+	inputData0 := inputs[0]
+	inputData1 := inputs[1]
+
+	var inputBytes0 []byte
+	var inputBytes1 []byte
+	// Temp variable to hold our converted int32 -> []byte
+	bs := make([]byte, 4)
+	for i := 0; i < inputSize; i++ {
+		binary.LittleEndian.PutUint32(bs, inputData0[i])
+		inputBytes0 = append(inputBytes0, bs...)
+		binary.LittleEndian.PutUint32(bs, inputData1[i])
+		inputBytes1 = append(inputBytes1, bs...)
+	}
+
+	return [][]byte{inputBytes0, inputBytes1}
+}
+
+// Convert slice of 4 bytes to int32 (assumes Little Endian)
+func readInt32(fourBytes []byte) int32 {
+	buf := bytes.NewBuffer(fourBytes)
+	var retval int32
+	binary.Read(buf, binary.LittleEndian, &retval)
+	return retval
+}
+
+// Convert output's raw bytes into int32 data (assumes Little Endian)
+func Postprocess(inferResponse *trtis.InferResponse) [][]int32 {
+	var outputs [][]byte
+	outputs = inferResponse.RawOutput
+	outputBytes0 := outputs[0]
+	outputBytes1 := outputs[1]
+
+	outputData0 := make([]int32, outputSize)
+	outputData1 := make([]int32, outputSize)
+	for i := 0; i < outputSize; i++ {
+		outputData0[i] = readInt32(outputBytes0[i*4 : i*4+4])
+		outputData1[i] = readInt32(outputBytes1[i*4 : i*4+4])
+	}
+	return [][]int32{outputData0, outputData1}
+}
+
+func main() {
+	FLAGS := parseFlags()
+	fmt.Println("FLAGS:", FLAGS)
+
+	// Connect to gRPC server
+	conn, err := grpc.Dial(FLAGS.URL, grpc.WithInsecure())
+	if err != nil {
+		log.Fatalf("Couldn't connect to endpoint %s: %v", FLAGS.URL, err)
+	}
+	defer conn.Close()
+
+	// Create client from gRPC server connection
+	client := trtis.NewGRPCServiceClient(conn)
+
+	liveHealthResponse := HealthRequest(client, "live")
+	fmt.Printf("TRTIS Health - Live: %v\n", liveHealthResponse.Health)
+
+	readyHealthResponse := HealthRequest(client, "ready")
+	fmt.Printf("TRTIS Health - Ready: %v\n", readyHealthResponse.Health)
+
+	statusResponse := StatusRequest(client, FLAGS.ModelName)
+	fmt.Println(statusResponse)
+
+	inputData0 := make([]uint32, inputSize)
+	inputData1 := make([]uint32, inputSize)
+	for i := 0; i < inputSize; i++ {
+		inputData0[i] = uint32(i)
+		inputData1[i] = 1
+	}
+	inputs := [][]uint32{inputData0, inputData1}
+	rawInput := Preprocess(inputs)
+
+	/* We use a simple model that takes 2 input tensors of 16 integers
+	each and returns 2 output tensors of 16 integers each. One
+	output tensor is the element-wise sum of the inputs and one
+	output is the element-wise difference. */
+	inferResponse := InferRequest(client, rawInput, FLAGS.ModelName, FLAGS.ModelVersion, FLAGS.BatchSize)
+
+	/* We expect there to be 2 results (each with batch-size 1). Walk
+	over all 16 result elements and print the sum and difference
+	calculated by the model. */
+	outputs := Postprocess(inferResponse)
+	outputData0 := outputs[0]
+	outputData1 := outputs[1]
+
+	fmt.Println("\nChecking Inference Outputs\n--------------------------")
+	for i := 0; i < outputSize; i++ {
+		fmt.Printf("%d + %d = %d\n", inputData0[i], inputData1[i], outputData0[i])
+		fmt.Printf("%d - %d = %d\n", inputData0[i], inputData1[i], outputData1[i])
+	}
+}


### PR DESCRIPTION
Add baseline reference for a Go client as requested in #175 

This sample script assumes that the protobuf stubs will be compiled local to the client, under the `nvidia_inferenceserver` directory. This can be easily tweaked by uncommenting `gen_go_stubs.sh` to generate the stubs in `${GOPATH}/src/nvidia_inferenceserver` to have something more global instead.

Usage:
```bash
# Clone repo
git clone https://github.com/NVIDIA/tensorrt-inference-server.git

# Setup "simple" model from example model_repository
cd tensorrt-inference-server/docs/examples
./fetch_models.sh

# Launch (detached) TRTIS
docker run -d -p8000:8000 -p8001:8001 -p8002:8002 \
           -it -v $(pwd)/model_repository:/models \
           nvcr.io/nvidia/tensorrtserver:19.07-py3 \
           trtserver --model-store=/models

# Use client
cd ../../src/clients/go
# Compiles *.proto to *.pb.go
./gen_go_stubs.sh
go run grpc_simple_client.go
```

<details>
<summary>Sample Output</summary>
<p>

```bash
$ go run grpc_simple_client.go
TRTIS Health - Live: true
TRTIS Health - Ready: true
request_status:<code:SUCCESS server_id:"inference:0" request_id:3 > server_status:<id:"inference:0" version:"1.4.0" ready_state:SERVER_READY uptime_ns:39273850004 model_status:<key:"simple" value:<config:<name:"simple" platform:"tensorflow_graphdef" version_policy:<latest:<num_versions:1 > > max_batch_size:8 input:<name:"INPUT0" data_type:TYPE_INT32 dims:16 > input:<name:"INPUT1" data_type:TYPE_INT32 dims:16 > output:<name:"OUTPUT0" data_type:TYPE_INT32 dims:16 > output:<name:"OUTPUT1" data_type:TYPE_INT32 dims:16 > instance_group:<name:"simple" kind:KIND_CPU count:1 > default_model_filename:"model.graphdef" > version_status:<key:1 value:<ready_state:MODEL_READY > > > > > 

Checking Inference Outputs
--------------------------
0 + 1 = 1
0 - 1 = -1
1 + 1 = 2
1 - 1 = 0
2 + 1 = 3
2 - 1 = 1
3 + 1 = 4
3 - 1 = 2
4 + 1 = 5
4 - 1 = 3
5 + 1 = 6
5 - 1 = 4
6 + 1 = 7
6 - 1 = 5
7 + 1 = 8
7 - 1 = 6
8 + 1 = 9
8 - 1 = 7
9 + 1 = 10
9 - 1 = 8
10 + 1 = 11
10 - 1 = 9
11 + 1 = 12
11 - 1 = 10
12 + 1 = 13
12 - 1 = 11
13 + 1 = 14
13 - 1 = 12
14 + 1 = 15
14 - 1 = 13
15 + 1 = 16
15 - 1 = 14
```

</p>
</details>

Signed-off-by: Ryan McCormick <rmccormick@nvidia.com>