### PR TITLE
Changes to include supported TRT IO datatypes in testing

### DIFF
--- a/qa/L0_batcher/batcher_test.py
+++ b/qa/L0_batcher/batcher_test.py
@@ -69,7 +69,7 @@ class BatcherTest(unittest.TestCase):
                                use_grpc=False, skip_request_id_check=True,
                                use_streaming=False)
             elif trial == "plan":
-                tensor_shape = (input_size,1,1)
+                tensor_shape = (input_size)
                 iu.infer_exact(self, trial, tensor_shape, bs,
                                np.float32, np.float32, np.float32, swap=False,
                                model_version=1, outputs=requested_outputs,

--- a/qa/L0_batcher/batcher_test.py
+++ b/qa/L0_batcher/batcher_test.py
@@ -61,15 +61,9 @@ class BatcherTest(unittest.TestCase):
             start_ms = int(round(time.time() * 1000))
 
             if trial == "savedmodel" or trial == "graphdef" or trial == "netdef" \
-                    or trial == "custom" or trial == "libtorch" or trial == "onnx":
+                    or trial == "custom" or trial == "libtorch" or trial == "onnx" \
+                    or trial == "plan":
                 tensor_shape = (input_size,)
-                iu.infer_exact(self, trial, tensor_shape, bs,
-                               np.float32, np.float32, np.float32, swap=False,
-                               model_version=1, outputs=requested_outputs,
-                               use_grpc=False, skip_request_id_check=True,
-                               use_streaming=False)
-            elif trial == "plan":
-                tensor_shape = (input_size)
                 iu.infer_exact(self, trial, tensor_shape, bs,
                                np.float32, np.float32, np.float32, swap=False,
                                model_version=1, outputs=requested_outputs,

--- a/qa/L0_infer_variable/infer_variable_test.py
+++ b/qa/L0_infer_variable/infer_variable_test.py
@@ -86,9 +86,14 @@ class InferVariableTest(unittest.TestCase):
         if tu.validate_for_trt_model(input_dtype, output0_dtype, output1_dtype,
                                     input_shape, output0_shape, output1_shape):
             for prefix in ensemble_prefix:
-                _infer_exact_helper(self, prefix + 'plan', input_shape + (1, 1), 8,
-                                input_dtype, output0_dtype, output1_dtype,
-                                output0_raw=output0_raw, output1_raw=output1_raw, swap=swap)
+                if input_dtype == np.int8:
+                    _infer_exact_helper(self, prefix + 'plan', input_shape + (1,1), 8,
+                                    input_dtype, output0_dtype, output1_dtype,
+                                    output0_raw=output0_raw, output1_raw=output1_raw, swap=swap)
+                else:
+                    _infer_exact_helper(self, prefix + 'plan', input_shape, 8,
+                                    input_dtype, output0_dtype, output1_dtype,
+                                    output0_raw=output0_raw, output1_raw=output1_raw, swap=swap)
 
         if tu.validate_for_c2_model(input_dtype, output0_dtype, output1_dtype,
                                     input_shape, output0_shape, output1_shape):

--- a/qa/L0_lifecycle/lifecycle_test.py
+++ b/qa/L0_lifecycle/lifecycle_test.py
@@ -193,7 +193,7 @@ class LifeCycleTest(unittest.TestCase):
                 iu.infer_exact(self, model_name, tensor_shape, 1,
                                np.float32, np.float32, np.float32, swap=True)
             for version in [1, 3]:
-                iu.infer_exact(self, 'plan', (input_size, 1, 1), 1,
+                iu.infer_exact(self, 'plan', (input_size), 1,
                                np.float32, np.float32, np.float32,
                                swap=(version == 3), model_version=version)
         except InferenceServerException as ex:
@@ -685,7 +685,7 @@ class LifeCycleTest(unittest.TestCase):
     def test_dynamic_model_modify(self):
         input_size = 16
         models_base = ('savedmodel', 'plan')
-        models_shape = ((input_size,), (input_size, 1, 1))
+        models_shape = ((input_size,), (input_size,))
         models = list()
         for m in models_base:
             models.append(tu.get_model_name(m, np.float32, np.float32, np.float32))

--- a/qa/L0_lifecycle/lifecycle_test.py
+++ b/qa/L0_lifecycle/lifecycle_test.py
@@ -193,7 +193,7 @@ class LifeCycleTest(unittest.TestCase):
                 iu.infer_exact(self, model_name, tensor_shape, 1,
                                np.float32, np.float32, np.float32, swap=True)
             for version in [1, 3]:
-                iu.infer_exact(self, 'plan', (input_size), 1,
+                iu.infer_exact(self, 'plan', (input_size,), 1,
                                np.float32, np.float32, np.float32,
                                swap=(version == 3), model_version=version)
         except InferenceServerException as ex:

--- a/qa/L0_model_config/autofill_noplatform/tensorrt/bad_input_dims/config.pbtxt
+++ b/qa/L0_model_config/autofill_noplatform/tensorrt/bad_input_dims/config.pbtxt
@@ -3,7 +3,7 @@ input [
   {
     name: "INPUT0"
     data_type: TYPE_FP32
-    dims: [ 16, 1, 1 ]
+    dims: [ 16]
   },
   {
     name: "INPUT1"
@@ -15,11 +15,11 @@ output [
   {
     name: "OUTPUT0"
     data_type: TYPE_FP32
-    dims: [ 16, 1, 1 ]
+    dims: [ 16 ]
   },
   {
     name: "OUTPUT1"
     data_type: TYPE_FP32
-    dims: [ 16, 1, 1 ]
+    dims: [ 16 ]
   }
 ]

--- a/qa/L0_model_config/autofill_noplatform/tensorrt/bad_input_dims/expected
+++ b/qa/L0_model_config/autofill_noplatform/tensorrt/bad_input_dims/expected
@@ -1,1 +1,1 @@
-binding 'INPUT1' shape expected by framework \[16,1,1\] doesn't match model configuration shape \[16,1\]
+binding 'INPUT1' shape expected by framework \[16\] doesn't match model configuration shape \[16,1\]

--- a/qa/L0_model_config/autofill_noplatform/tensorrt/bad_input_type/config.pbtxt
+++ b/qa/L0_model_config/autofill_noplatform/tensorrt/bad_input_type/config.pbtxt
@@ -3,23 +3,23 @@ input [
   {
     name: "INPUT0"
     data_type: TYPE_FP16
-    dims: [ 16, 1, 1 ]
+    dims: [ 16 ]
   },
   {
     name: "INPUT1"
     data_type: TYPE_FP32
-    dims: [ 16, 1, 1 ]
+    dims: [ 16 ]
   }
 ]
 output [
   {
     name: "OUTPUT0"
     data_type: TYPE_FP32
-    dims: [ 16, 1, 1 ]
+    dims: [ 16 ]
   },
   {
     name: "OUTPUT1"
     data_type: TYPE_FP32
-    dims: [ 16, 1, 1 ]
+    dims: [ 16 ]
   }
 ]

--- a/qa/L0_model_config/autofill_noplatform/tensorrt/bad_output_dims/config.pbtxt
+++ b/qa/L0_model_config/autofill_noplatform/tensorrt/bad_output_dims/config.pbtxt
@@ -3,19 +3,19 @@ input [
   {
     name: "INPUT0"
     data_type: TYPE_FP32
-    dims: [ 16, 1, 1 ]
+    dims: [ 16 ]
   },
   {
     name: "INPUT1"
     data_type: TYPE_FP32
-    dims: [ 16, 1, 1 ]
+    dims: [ 16 ]
   }
 ]
 output [
   {
     name: "OUTPUT0"
     data_type: TYPE_FP32
-    dims: [ 16, 1, 1 ]
+    dims: [ 16 ]
   },
   {
     name: "OUTPUT1"

--- a/qa/L0_model_config/autofill_noplatform/tensorrt/bad_output_dims/expected
+++ b/qa/L0_model_config/autofill_noplatform/tensorrt/bad_output_dims/expected
@@ -1,1 +1,1 @@
-binding 'OUTPUT1' shape expected by framework \[16,1,1\] doesn't match model configuration shape \[7\]
+binding 'OUTPUT1' shape expected by framework \[16\] doesn't match model configuration shape \[7\]

--- a/qa/L0_model_config/autofill_noplatform/tensorrt/bad_output_type/config.pbtxt
+++ b/qa/L0_model_config/autofill_noplatform/tensorrt/bad_output_type/config.pbtxt
@@ -3,23 +3,23 @@ input [
   {
     name: "INPUT0"
     data_type: TYPE_FP32
-    dims: [ 16, 1, 1 ]
+    dims: [ 16 ]
   },
   {
     name: "INPUT1"
     data_type: TYPE_FP32
-    dims: [ 16, 1, 1 ]
+    dims: [ 16 ]
   }
 ]
 output [
   {
     name: "OUTPUT0"
     data_type: TYPE_FP32
-    dims: [ 16, 1, 1 ]
+    dims: [ 16 ]
   },
   {
     name: "OUTPUT1"
     data_type: TYPE_INT8
-    dims: [ 16, 1, 1 ]
+    dims: [ 16 ]
   }
 ]

--- a/qa/L0_model_config/autofill_noplatform/tensorrt/too_few_inputs/config.pbtxt
+++ b/qa/L0_model_config/autofill_noplatform/tensorrt/too_few_inputs/config.pbtxt
@@ -3,18 +3,18 @@ input [
   {
     name: "INPUT1"
     data_type: TYPE_FP32
-    dims: [ 16, 1, 1 ]
+    dims: [ 16 ]
   }
 ]
 output [
   {
     name: "OUTPUT0"
     data_type: TYPE_FP32
-    dims: [ 16, 1, 1 ]
+    dims: [ 16 ]
   },
   {
     name: "OUTPUT1"
     data_type: TYPE_FP32
-    dims: [ 16, 1, 1 ]
+    dims: [ 16 ]
   }
 ]

--- a/qa/L0_model_config/autofill_noplatform/tensorrt/too_many_inputs/config.pbtxt
+++ b/qa/L0_model_config/autofill_noplatform/tensorrt/too_many_inputs/config.pbtxt
@@ -3,28 +3,28 @@ input [
   {
     name: "INPUT_EXTRA"
     data_type: TYPE_FP32
-    dims: [ 16, 1, 1 ]
+    dims: [ 16 ]
   },
   {
     name: "INPUT0"
     data_type: TYPE_FP32
-    dims: [ 16, 1, 1 ]
+    dims: [ 16 ]
   },
   {
     name: "INPUT1"
     data_type: TYPE_FP32
-    dims: [ 16, 1, 1 ]
+    dims: [ 16 ]
   }
 ]
 output [
   {
     name: "OUTPUT0"
     data_type: TYPE_FP32
-    dims: [ 16, 1, 1 ]
+    dims: [ 16 ]
   },
   {
     name: "OUTPUT1"
     data_type: TYPE_FP32
-    dims: [ 16, 1, 1 ]
+    dims: [ 16 ]
   }
 ]

--- a/qa/L0_model_config/autofill_noplatform/tensorrt/unknown_input/config.pbtxt
+++ b/qa/L0_model_config/autofill_noplatform/tensorrt/unknown_input/config.pbtxt
@@ -3,23 +3,23 @@ input [
   {
     name: "INPUT0"
     data_type: TYPE_FP32
-    dims: [ 16, 1, 1 ]
+    dims: [ 16 ]
   },
   {
     name: "INPUT_UNKNOWN"
     data_type: TYPE_FP32
-    dims: [ 16, 1, 1 ]
+    dims: [ 16 ]
   }
 ]
 output [
   {
     name: "OUTPUT0"
     data_type: TYPE_FP32
-    dims: [ 16, 1, 1 ]
+    dims: [ 16 ]
   },
   {
     name: "OUTPUT1"
     data_type: TYPE_FP32
-    dims: [ 16, 1, 1 ]
+    dims: [ 16 ]
   }
 ]

--- a/qa/L0_model_config/autofill_noplatform/tensorrt/unknown_output/config.pbtxt
+++ b/qa/L0_model_config/autofill_noplatform/tensorrt/unknown_output/config.pbtxt
@@ -3,23 +3,23 @@ input [
   {
     name: "INPUT0"
     data_type: TYPE_FP32
-    dims: [ 16, 1, 1 ]
+    dims: [ 16 ]
   },
   {
     name: "INPUT1"
     data_type: TYPE_FP32
-    dims: [ 16, 1, 1 ]
+    dims: [ 16 ]
   }
 ]
 output [
   {
     name: "OUTPUT_UNKNOWN"
     data_type: TYPE_FP32
-    dims: [ 16, 1, 1 ]
+    dims: [ 16 ]
   },
   {
     name: "OUTPUT1"
     data_type: TYPE_FP32
-    dims: [ 16, 1, 1 ]
+    dims: [ 16 ]
   }
 ]

--- a/qa/L0_model_config/autofill_noplatform_success/tensorrt/empty_config/expected
+++ b/qa/L0_model_config/autofill_noplatform_success/tensorrt/empty_config/expected
@@ -10,29 +10,21 @@ input {
   name: "INPUT0"
   data_type: TYPE_FP32
   dims: 16
-  dims: 1
-  dims: 1
 }
 input {
   name: "INPUT1"
   data_type: TYPE_FP32
   dims: 16
-  dims: 1
-  dims: 1
 }
 output {
   name: "OUTPUT0"
   data_type: TYPE_FP32
   dims: 16
-  dims: 1
-  dims: 1
 }
 output {
   name: "OUTPUT1"
   data_type: TYPE_FP32
   dims: 16
-  dims: 1
-  dims: 1
 }
 instance_group {
   name: "empty_config"

--- a/qa/L0_model_config/autofill_noplatform_success/tensorrt/incomplete_input/config.pbtxt
+++ b/qa/L0_model_config/autofill_noplatform_success/tensorrt/incomplete_input/config.pbtxt
@@ -5,6 +5,6 @@ input [
   },
   {
     name: "INPUT1"
-    dims: [ 16, 1, 1 ]
+    dims: [ 16 ]
   }
 ]

--- a/qa/L0_model_config/autofill_noplatform_success/tensorrt/incomplete_input/expected
+++ b/qa/L0_model_config/autofill_noplatform_success/tensorrt/incomplete_input/expected
@@ -10,29 +10,21 @@ input {
   name: "INPUT0"
   data_type: TYPE_FP32
   dims: 16
-  dims: 1
-  dims: 1
 }
 input {
   name: "INPUT1"
   data_type: TYPE_FP32
   dims: 16
-  dims: 1
-  dims: 1
 }
 output {
   name: "OUTPUT0"
   data_type: TYPE_FP32
   dims: 16
-  dims: 1
-  dims: 1
 }
 output {
   name: "OUTPUT1"
   data_type: TYPE_FP32
   dims: 16
-  dims: 1
-  dims: 1
 }
 instance_group {
   name: "incomplete_input"

--- a/qa/L0_model_config/autofill_noplatform_success/tensorrt/incomplete_input/expected.1
+++ b/qa/L0_model_config/autofill_noplatform_success/tensorrt/incomplete_input/expected.1
@@ -10,29 +10,21 @@ input {
   name: "INPUT1"
   data_type: TYPE_FP32
   dims: 16
-  dims: 1
-  dims: 1
 }
 input {
   name: "INPUT0"
   data_type: TYPE_FP32
   dims: 16
-  dims: 1
-  dims: 1
 }
 output {
   name: "OUTPUT0"
   data_type: TYPE_FP32
   dims: 16
-  dims: 1
-  dims: 1
 }
 output {
   name: "OUTPUT1"
   data_type: TYPE_FP32
   dims: 16
-  dims: 1
-  dims: 1
 }
 instance_group {
   name: "incomplete_input"

--- a/qa/L0_model_config/autofill_noplatform_success/tensorrt/incomplete_input/expected.2
+++ b/qa/L0_model_config/autofill_noplatform_success/tensorrt/incomplete_input/expected.2
@@ -10,29 +10,21 @@ input {
   name: "INPUT0"
   data_type: TYPE_FP32
   dims: 16
-  dims: 1
-  dims: 1
 }
 input {
   name: "INPUT1"
   data_type: TYPE_FP32
   dims: 16
-  dims: 1
-  dims: 1
 }
 output {
   name: "OUTPUT1"
   data_type: TYPE_FP32
   dims: 16
-  dims: 1
-  dims: 1
 }
 output {
   name: "OUTPUT0"
   data_type: TYPE_FP32
   dims: 16
-  dims: 1
-  dims: 1
 }
 instance_group {
   name: "incomplete_input"

--- a/qa/L0_model_config/autofill_noplatform_success/tensorrt/incomplete_input/expected.3
+++ b/qa/L0_model_config/autofill_noplatform_success/tensorrt/incomplete_input/expected.3
@@ -10,29 +10,21 @@ input {
   name: "INPUT1"
   data_type: TYPE_FP32
   dims: 16
-  dims: 1
-  dims: 1
 }
 input {
   name: "INPUT0"
   data_type: TYPE_FP32
   dims: 16
-  dims: 1
-  dims: 1
 }
 output {
   name: "OUTPUT1"
   data_type: TYPE_FP32
   dims: 16
-  dims: 1
-  dims: 1
 }
 output {
   name: "OUTPUT0"
   data_type: TYPE_FP32
   dims: 16
-  dims: 1
-  dims: 1
 }
 instance_group {
   name: "incomplete_input"

--- a/qa/L0_model_config/autofill_noplatform_success/tensorrt/incomplete_output/config.pbtxt
+++ b/qa/L0_model_config/autofill_noplatform_success/tensorrt/incomplete_output/config.pbtxt
@@ -5,6 +5,6 @@ output [
   },
   {
     name: "OUTPUT1"
-    dims: [ 16, 1, 1 ]
+    dims: [ 16 ]
   }
 ]

--- a/qa/L0_model_config/autofill_noplatform_success/tensorrt/incomplete_output/expected
+++ b/qa/L0_model_config/autofill_noplatform_success/tensorrt/incomplete_output/expected
@@ -10,29 +10,21 @@ input {
   name: "INPUT0"
   data_type: TYPE_FP32
   dims: 16
-  dims: 1
-  dims: 1
 }
 input {
   name: "INPUT1"
   data_type: TYPE_FP32
   dims: 16
-  dims: 1
-  dims: 1
 }
 output {
   name: "OUTPUT0"
   data_type: TYPE_FP32
   dims: 16
-  dims: 1
-  dims: 1
 }
 output {
   name: "OUTPUT1"
   data_type: TYPE_FP32
   dims: 16
-  dims: 1
-  dims: 1
 }
 instance_group {
   name: "incomplete_output"

--- a/qa/L0_model_config/autofill_noplatform_success/tensorrt/incomplete_output/expected.1
+++ b/qa/L0_model_config/autofill_noplatform_success/tensorrt/incomplete_output/expected.1
@@ -10,29 +10,21 @@ input {
   name: "INPUT1"
   data_type: TYPE_FP32
   dims: 16
-  dims: 1
-  dims: 1
 }
 input {
   name: "INPUT0"
   data_type: TYPE_FP32
   dims: 16
-  dims: 1
-  dims: 1
 }
 output {
   name: "OUTPUT0"
   data_type: TYPE_FP32
   dims: 16
-  dims: 1
-  dims: 1
 }
 output {
   name: "OUTPUT1"
   data_type: TYPE_FP32
   dims: 16
-  dims: 1
-  dims: 1
 }
 instance_group {
   name: "incomplete_output"

--- a/qa/L0_model_config/autofill_noplatform_success/tensorrt/incomplete_output/expected.2
+++ b/qa/L0_model_config/autofill_noplatform_success/tensorrt/incomplete_output/expected.2
@@ -10,29 +10,21 @@ input {
   name: "INPUT0"
   data_type: TYPE_FP32
   dims: 16
-  dims: 1
-  dims: 1
 }
 input {
   name: "INPUT1"
   data_type: TYPE_FP32
   dims: 16
-  dims: 1
-  dims: 1
 }
 output {
   name: "OUTPUT1"
   data_type: TYPE_FP32
   dims: 16
-  dims: 1
-  dims: 1
 }
 output {
   name: "OUTPUT0"
   data_type: TYPE_FP32
   dims: 16
-  dims: 1
-  dims: 1
 }
 instance_group {
   name: "incomplete_output"

--- a/qa/L0_model_config/autofill_noplatform_success/tensorrt/incomplete_output/expected.3
+++ b/qa/L0_model_config/autofill_noplatform_success/tensorrt/incomplete_output/expected.3
@@ -10,29 +10,21 @@ input {
   name: "INPUT1"
   data_type: TYPE_FP32
   dims: 16
-  dims: 1
-  dims: 1
 }
 input {
   name: "INPUT0"
   data_type: TYPE_FP32
   dims: 16
-  dims: 1
-  dims: 1
 }
 output {
   name: "OUTPUT1"
   data_type: TYPE_FP32
   dims: 16
-  dims: 1
-  dims: 1
 }
 output {
   name: "OUTPUT0"
   data_type: TYPE_FP32
   dims: 16
-  dims: 1
-  dims: 1
 }
 instance_group {
   name: "incomplete_output"

--- a/qa/L0_model_config/autofill_noplatform_success/tensorrt/no_config/expected
+++ b/qa/L0_model_config/autofill_noplatform_success/tensorrt/no_config/expected
@@ -10,29 +10,21 @@ input {
   name: "INPUT0"
   data_type: TYPE_FP32
   dims: 16
-  dims: 1
-  dims: 1
 }
 input {
   name: "INPUT1"
   data_type: TYPE_FP32
   dims: 16
-  dims: 1
-  dims: 1
 }
 output {
   name: "OUTPUT0"
   data_type: TYPE_FP32
   dims: 16
-  dims: 1
-  dims: 1
 }
 output {
   name: "OUTPUT1"
   data_type: TYPE_FP32
   dims: 16
-  dims: 1
-  dims: 1
 }
 instance_group {
   name: "no_config"

--- a/qa/L0_model_config/autofill_noplatform_success/tensorrt/no_name_platform/config.pbtxt
+++ b/qa/L0_model_config/autofill_noplatform_success/tensorrt/no_name_platform/config.pbtxt
@@ -3,23 +3,23 @@ input [
   {
     name: "INPUT0"
     data_type: TYPE_FP32
-    dims: [ 16, 1, 1 ]
+    dims: [ 16 ]
   },
   {
     name: "INPUT1"
     data_type: TYPE_FP32
-    dims: [ 16, 1, 1 ]
+    dims: [ 16 ]
   }
 ]
 output [
   {
     name: "OUTPUT0"
     data_type: TYPE_FP32
-    dims: [ 16, 1, 1 ]
+    dims: [ 16 ]
   },
   {
     name: "OUTPUT1"
     data_type: TYPE_FP32
-    dims: [ 16, 1, 1 ]
+    dims: [ 16 ]
   }
 ]

--- a/qa/L0_model_config/autofill_noplatform_success/tensorrt/no_name_platform/expected
+++ b/qa/L0_model_config/autofill_noplatform_success/tensorrt/no_name_platform/expected
@@ -10,29 +10,21 @@ input {
   name: "INPUT0"
   data_type: TYPE_FP32
   dims: 16
-  dims: 1
-  dims: 1
 }
 input {
   name: "INPUT1"
   data_type: TYPE_FP32
   dims: 16
-  dims: 1
-  dims: 1
 }
 output {
   name: "OUTPUT0"
   data_type: TYPE_FP32
   dims: 16
-  dims: 1
-  dims: 1
 }
 output {
   name: "OUTPUT1"
   data_type: TYPE_FP32
   dims: 16
-  dims: 1
-  dims: 1
 }
 instance_group {
   name: "no_name_platform"

--- a/qa/L0_perf_nomodel/runtest.sh
+++ b/qa/L0_perf_nomodel/runtest.sh
@@ -102,7 +102,7 @@ for BACKEND in $BACKENDS; do
         [ $BACKEND != "custom" ] && REPO_DIR=$DATADIR/qa_reshape_model_repository && \
         [ $BACKEND != "plan" ] && [ $BACKEND != "libtorch" ] && \
         REPO_DIR=$DATADIR/qa_identity_model_repository
-    SHAPE=${TENSOR_SIZE} && [ $BACKEND == "plan" ] && SHAPE="1,1,${TENSOR_SIZE}"
+    SHAPE=${TENSOR_SIZE}
     KIND="KIND_GPU" && [ $BACKEND == "custom" ] && KIND="KIND_CPU"
 
     rm -fr models && mkdir -p models && \

--- a/qa/L0_sequence_batcher/sequence_batcher_test.py
+++ b/qa/L0_sequence_batcher/sequence_batcher_test.py
@@ -87,10 +87,9 @@ class SequenceBatcherTest(unittest.TestCase):
 
         if (("savedmodel" in trial) or ("graphdef" in trial) or
             ("netdef" in trial) or ("custom" in trial) or
-            ("onnx" in trial) or ("libtorch" in trial)):
+            ("onnx" in trial) or ("libtorch" in trial) or 
+	        ("plan" in trial)):
             tensor_shape = (1,)
-        elif "plan" in trial:
-            tensor_shape = (1,1,1)
         else:
             self.assertFalse(True, "unknown trial type: " + trial)
 
@@ -202,10 +201,9 @@ class SequenceBatcherTest(unittest.TestCase):
 
         if (("savedmodel" in trial) or ("graphdef" in trial) or
             ("netdef" in trial) or ("custom" in trial) or
-            ("onnx" in trial) or ("libtorch" in trial)):
+            ("onnx" in trial) or ("libtorch" in trial) or
+            ("plan" in trial)):
             tensor_shape = (1,)
-        elif "plan" in trial:
-            tensor_shape = (1,1,1)
         else:
             self.assertFalse(True, "unknown trial type: " + trial)
 

--- a/qa/L0_sequence_stress/sequence_stress.py
+++ b/qa/L0_sequence_stress/sequence_stress.py
@@ -61,10 +61,9 @@ def check_sequence_async(ctx, trial, model_name, input_dtype, steps,
 
     """
     if (("savedmodel" in trial) or ("graphdef" in trial) or
-        ("netdef" in trial) or ("custom" in trial)):
+        ("netdef" in trial) or ("custom" in trial) or
+        ("plan" in trial)):
         tensor_shape = (1,)
-    elif "plan" in trial:
-        tensor_shape = (1,1,1)
     else:
         assert False, "unknown trial type: " + trial
 

--- a/qa/L0_server_status/server_status_test.py
+++ b/qa/L0_server_status/server_status_test.py
@@ -163,7 +163,7 @@ class ServerStatusTest(unittest.TestCase):
         # There are 3 versions of *_float32_float32_float32 but only
         # versions 1 and 3 should be available.
         for platform in ('graphdef', 'netdef', 'plan'):
-            tensor_shape = (input_size, 1, 1) if platform == 'plan' else (input_size,)
+            tensor_shape = (input_size,)
             model_name = platform + "_float32_float32_float32"
 
             # Initially there should be no version status...

--- a/qa/L0_simple_lib/test.sh
+++ b/qa/L0_simple_lib/test.sh
@@ -111,9 +111,9 @@ mkdir -p $MODELSDIR/simple/1 && \
                 sed -i "s/^name:.*/name: \"simple\"/" config.pbtxt && \
                 sed -i "s/label_filename:.*//" config.pbtxt)
 
-cp -r $ENSEMBLEDIR/nop_TYPE_FP32_-1,-1,-1 $MODELSDIR/. && \
-    mkdir -p $MODELSDIR/nop_TYPE_FP32_-1,-1,-1/1 && \
-    cp libidentity.so $MODELSDIR/nop_TYPE_FP32_-1,-1,-1/1/.
+cp -r $ENSEMBLEDIR/nop_TYPE_FP32_-1 $MODELSDIR/. && \
+    mkdir -p $MODELSDIR/nop_TYPE_FP32_-1/1 && \
+    cp libidentity.so $MODELSDIR/nop_TYPE_FP32_-1/1/.
 
 cp -r $DATADIR/plan_float32_float32_float32 $MODELSDIR/. && \
     # make sure version 1 is used (no swap)

--- a/qa/L0_storage_GCS/infer_test.py
+++ b/qa/L0_storage_GCS/infer_test.py
@@ -74,9 +74,14 @@ class InferTest(unittest.TestCase):
 
         if tu.validate_for_trt_model(input_dtype, output0_dtype, output1_dtype,
                                     (input_size,1,1), (input_size,1,1), (input_size,1,1)):
-            _infer_exact_helper(self, 'plan', (input_size, 1, 1), 8,
-                            input_dtype, output0_dtype, output1_dtype,
-                            output0_raw=output0_raw, output1_raw=output1_raw, swap=swap)
+            if input_dtype == np.int8:
+                _infer_exact_helper(self, 'plan', (input_size, 1, 1), 8,
+                                input_dtype, output0_dtype, output1_dtype,
+                                output0_raw=output0_raw, output1_raw=output1_raw, swap=swap)
+            else:
+                _infer_exact_helper(self, 'plan', (input_size,), 8,
+                                input_dtype, output0_dtype, output1_dtype,
+                                output0_raw=output0_raw, output1_raw=output1_raw, swap=swap)
 
         if tu.validate_for_onnx_model(input_dtype, output0_dtype, output1_dtype,
                                     (input_size,), (input_size,), (input_size,)):

--- a/qa/L0_storage_S3/infer_test.py
+++ b/qa/L0_storage_S3/infer_test.py
@@ -74,9 +74,14 @@ class InferTest(unittest.TestCase):
 
         if tu.validate_for_trt_model(input_dtype, output0_dtype, output1_dtype,
                                     (input_size,1,1), (input_size,1,1), (input_size,1,1)):
-            _infer_exact_helper(self, 'plan', (input_size, 1, 1), 8,
-                            input_dtype, output0_dtype, output1_dtype,
-                            output0_raw=output0_raw, output1_raw=output1_raw, swap=swap)
+            if input_dtype == np.int8:
+                _infer_exact_helper(self, 'plan', (input_size, 1, 1), 8,
+                                input_dtype, output0_dtype, output1_dtype,
+                                output0_raw=output0_raw, output1_raw=output1_raw, swap=swap)
+            else:
+                _infer_exact_helper(self, 'plan', (input_size,), 8,
+                                input_dtype, output0_dtype, output1_dtype,
+                                output0_raw=output0_raw, output1_raw=output1_raw, swap=swap)
 
         if tu.validate_for_onnx_model(input_dtype, output0_dtype, output1_dtype,
                                     (input_size,), (input_size,), (input_size,)):

--- a/qa/L0_trt_plugin/trt_plugin_test.py
+++ b/qa/L0_trt_plugin/trt_plugin_test.py
@@ -38,7 +38,7 @@ class PluginModelTest(unittest.TestCase):
     def _full_exact(self, batch_size, input_dtype, output_dtype, model_name):
         input_list = list()
         for b in range(batch_size):
-            in0 = np.random.randn(16,1,1).astype(input_dtype)
+            in0 = np.random.randn(16).astype(input_dtype)
             input_list.append(in0)
 
         ctx = InferContext("localhost:8000", ProtocolType.HTTP, model_name,

--- a/qa/common/gen_qa_model_repository
+++ b/qa/common/gen_qa_model_repository
@@ -215,6 +215,7 @@ cat >$HOST_SRCDIR/$TRTSCRIPT <<EOF
 #!/bin/bash
 set -e
 export CUDA_VISIBLE_DEVICES=$CUDA_DEVICE
+export TRT_SUPPRESS_DEPRECATION_WARNINGS=1
 cd $SRCDIR
 python3 $SRCDIR/gen_qa_models.py --tensorrt --models_dir=$DESTDIR
 chown -R $(id -u):$(id -g) $DESTDIR

--- a/qa/common/gen_qa_reshape_models.py
+++ b/qa/common/gen_qa_reshape_models.py
@@ -977,4 +977,4 @@ if __name__ == '__main__':
     # TRT plan that reshapes neither input nor output. Needed for
     # L0_perflab_nomodel.
     create_trt_models(FLAGS.models_dir, np.float32,
-                      ([1,1,1],), ([1,1,1],))
+                      ([1],), ([1],))

--- a/qa/common/gen_qa_sequence_models.py
+++ b/qa/common/gen_qa_sequence_models.py
@@ -443,8 +443,8 @@ def create_plan_fixed_modelfile(models_dir, model_version, max_batch, dtype, sha
     builder = trt.infer.create_infer_builder(G_LOGGER)
     network = builder.create_network()
     in0 = network.add_input("INPUT", trt_dtype, shape)
-    start0 = network.add_input("START", trt_dtype, [1, 1, 1])
-    ready0 = network.add_input("READY", trt_dtype, [1, 1, 1])
+    start0 = network.add_input("START", trt_dtype, [1 for i in shape])
+    ready0 = network.add_input("READY", trt_dtype, [1 for i in shape])
     add = network.add_elementwise(in0, start0, trt.infer.ElementWiseOperation.SUM)
     out0 = network.add_elementwise(add.get_output(0), ready0, trt.infer.ElementWiseOperation.PROD)
 
@@ -471,6 +471,69 @@ def create_plan_fixed_modelfile(models_dir, model_version, max_batch, dtype, sha
     engine.destroy()
     builder.destroy()
 
+def create_plan_fixed_rf_modelfile(models_dir, model_version, max_batch, dtype, shape):
+    trt_dtype = np_to_trt_dtype(dtype)
+    trt_memory_format = trt.TensorFormat.LINEAR
+    # Create the model. For now don't implement a proper accumulator
+    # just return 0 if not-ready and 'INPUT'+'START' otherwise...  the
+    # tests know to expect this.
+    G_LOGGER = trt.infer.ConsoleLogger(trt.infer.LogSeverity.INFO)
+    builder = trt.infer.create_infer_builder(G_LOGGER)
+    network = builder.create_network()
+    in0 = network.add_input("INPUT", trt_dtype, shape)
+    start0 = network.add_input("START", trt_dtype, [1 for i in shape])
+    ready0 = network.add_input("READY", trt_dtype, [1 for i in shape])
+    add = network.add_elementwise(in0, start0, trt.infer.ElementWiseOperation.SUM)
+    out0 = network.add_elementwise(add.get_output(0), ready0, trt.infer.ElementWiseOperation.PROD)
+
+    out0.get_output(0).set_name("OUTPUT")
+    network.mark_output(out0.get_output(0))
+
+    out0.get_output(0).set_type(trt_dtype)
+
+    in0.allowed_formats = 1 << int(trt_memory_format)
+    start0.allowed_formats = 1 << int(trt_memory_format)
+    ready0.allowed_formats = 1 << int(trt_memory_format)
+    out0.get_output(0).allowed_formats = 1 << int(trt_memory_format)
+
+    if (trt_dtype == trt.DataType.INT8):
+        in0.dynamic_range = (-128.0, 127.0)
+        out0.dynamic_range = (-128.0, 127.0)
+        start0.dynamic_range = (-128.0, 127.0)
+        ready0.dynamic_range = (-128.0, 127.0)
+
+    flags = 1 <<  int(trt.BuilderFlag.STRICT_TYPES)
+
+    if (trt_dtype == trt.DataType.INT8):
+        builder.int8_mode = True
+        flags |= 1 << int(trt.BuilderFlag.INT8)
+    elif (trt_dtype == trt.DataType.HALF):
+        builder.fp16_mode = True
+        flags |= 1 << int(trt.BuilderFlag.FP16)
+    
+    builder.strict_type_constraints = True
+    config = builder.create_builder_config()
+    config.flags=flags
+    builder.set_max_workspace_size(1 << 20)
+    builder.set_max_batch_size(max(1, max_batch))
+    engine = builder.build_engine(network,config)
+
+    model_name = tu.get_sequence_model_name(
+        "plan_nobatch" if max_batch == 0 else "plan", dtype)
+    model_version_dir = models_dir + "/" + model_name + "/" + str(model_version)
+
+    try:
+        os.makedirs(model_version_dir)
+    except OSError as ex:
+        pass # ignore existing dir
+
+    with open(model_version_dir + "/model.plan", "wb") as f:
+        f.write(engine.serialize())
+
+    engine.destroy()
+    builder.destroy()
+
+
 def create_plan_dynamic_modelfile(models_dir, model_version, max_batch, dtype, shape):
     trt_dtype = np_to_trt_dtype(dtype)
     # Create the model. For now don't implement a proper accumulator
@@ -484,10 +547,11 @@ def create_plan_dynamic_modelfile(models_dir, model_version, max_batch, dtype, s
         header = []
     else:
         header =  [-1]
-
-    in0 = network.add_input("INPUT", trt_dtype, header + [i for i in shape])
-    start0 = network.add_input("START", trt_dtype, header + [1, 1, 1])
-    ready0 = network.add_input("READY", trt_dtype, header + [1, 1, 1])
+    
+    unit_shape = ([1] * len(shape))
+    in0 = network.add_input("INPUT", trt_dtype, header + shape)
+    start0 = network.add_input("START", trt_dtype, header + unit_shape)
+    ready0 = network.add_input("READY", trt_dtype, header + unit_shape)
     add = network.add_elementwise(in0, start0, trt.infer.ElementWiseOperation.SUM)
     out0 = network.add_elementwise(add.get_output(0), ready0, trt.infer.ElementWiseOperation.PROD)
 
@@ -511,15 +575,14 @@ def create_plan_dynamic_modelfile(models_dir, model_version, max_batch, dtype, s
             opt_shape = opt_shape + [i]
             max_shape = max_shape + [i]
 
-
     profile = builder.create_optimization_profile()
     profile.set_shape("INPUT", min_shape, opt_shape, max_shape)
     if max_shape != 0:
-        profile.set_shape("START", [1,1,1,1], [max(1, max_batch),1,1,1], [max(1, max_batch),1,1,1])
-        profile.set_shape("READY", [1,1,1,1], [max(1, max_batch),1,1,1], [max(1, max_batch),1,1,1])
+        profile.set_shape("START", [1] + unit_shape, [max(1, max_batch)] + unit_shape, [max(1, max_batch)] + unit_shape)
+        profile.set_shape("READY", [1] + unit_shape, [max(1, max_batch)] + unit_shape, [max(1, max_batch)] + unit_shape)
     else:
-        profile.set_shape("START", [1,1,1], [1,1,1], [1,1,1])
-        profile.set_shape("READY", [1,1,1], [1,1,1], [1,1,1])
+        profile.set_shape("START", unit_shape, unit_shape, unit_shape)
+        profile.set_shape("READY", unit_shape, unit_shape, unit_shape)
     config = builder.create_builder_config()
     config.add_optimization_profile(profile)
 
@@ -541,8 +604,101 @@ def create_plan_dynamic_modelfile(models_dir, model_version, max_batch, dtype, s
     engine.destroy()
     builder.destroy()
 
+def create_plan_dynamic_rf_modelfile(models_dir, model_version, max_batch, dtype, shape):
+    trt_dtype = np_to_trt_dtype(dtype)
+    trt_memory_format = trt.TensorFormat.LINEAR
+    
+    # Create the model. For now don't implement a proper accumulator
+    # just return 0 if not-ready and 'INPUT'+'START' otherwise...  the
+    # tests know to expect this.
+    G_LOGGER = trt.infer.ConsoleLogger(trt.infer.LogSeverity.INFO)
+    builder = trt.infer.create_infer_builder(G_LOGGER)
+    network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.EXPLICIT_BATCH))
 
+    if max_batch == 0:
+        header = []
+    else:
+        header =  [-1]
+    unit_shape = ([1] * len(shape))
 
+    in0 = network.add_input("INPUT", trt_dtype, header + [i for i in shape])
+    start0 = network.add_input("START", trt_dtype, header + unit_shape)
+    ready0 = network.add_input("READY", trt_dtype, header + unit_shape)
+    add = network.add_elementwise(in0, start0, trt.infer.ElementWiseOperation.SUM)
+    out0 = network.add_elementwise(add.get_output(0), ready0, trt.infer.ElementWiseOperation.PROD)
+
+    out0.get_output(0).set_name("OUTPUT")
+    network.mark_output(out0.get_output(0))
+
+    out0.get_output(0).set_type(trt_dtype)
+
+    in0.allowed_formats = 1 << int(trt_memory_format)
+    start0.allowed_formats = 1 << int(trt_memory_format)
+    ready0.allowed_formats = 1 << int(trt_memory_format)
+    out0.get_output(0).allowed_formats = 1 << int(trt_memory_format)
+
+    if (trt_dtype == trt.DataType.INT8):
+        in0.dynamic_range = (-128.0, 127.0)
+        out0.dynamic_range = (-128.0, 127.0)
+        start0.dynamic_range = (-128.0, 127.0)
+        ready0.dynamic_range = (-128.0, 127.0)
+
+    flags = 1 <<  int(trt.BuilderFlag.STRICT_TYPES)
+
+    if (trt_dtype == trt.DataType.INT8):
+        builder.int8_mode = True
+        flags |= 1 << int(trt.BuilderFlag.INT8)
+    elif (trt_dtype == trt.DataType.HALF):
+        builder.fp16_mode = True
+        flags |= 1 << int(trt.BuilderFlag.FP16)
+    builder.strict_type_constraints = True
+
+    min_shape = []
+    opt_shape = []
+    max_shape = []
+    if max_batch != 0:
+        min_shape = min_shape + [1]
+        opt_shape = opt_shape + [max(1, max_batch)]
+        max_shape = max_shape + [max(1, max_batch)]
+    for i in shape:
+        if i == -1:
+            min_shape = min_shape + [1]
+            opt_shape = opt_shape + [8]
+            max_shape = max_shape + [32]
+        else:
+            min_shape = min_shape + [i]
+            opt_shape = opt_shape + [i]
+            max_shape = max_shape + [i]
+
+    profile = builder.create_optimization_profile()
+    profile.set_shape("INPUT", min_shape, opt_shape, max_shape)
+    if max_shape != 0:
+        profile.set_shape("START", [1] + unit_shape, [max(1, max_batch)] + unit_shape, [max(1, max_batch)] + unit_shape)
+        profile.set_shape("READY", [1] + unit_shape, [max(1, max_batch)] + unit_shape, [max(1, max_batch)] + unit_shape)
+    else:
+        profile.set_shape("START", unit_shape, unit_shape, unit_shape)
+        profile.set_shape("READY", unit_shape, unit_shape, unit_shape)
+    config = builder.create_builder_config()
+    config.flags=flags
+    config.add_optimization_profile(profile)
+
+    builder.set_max_workspace_size(1 << 20)
+    engine = builder.build_engine(network,config)
+
+    model_name = tu.get_sequence_model_name(
+        "plan_nobatch" if max_batch == 0 else "plan", dtype)
+    model_version_dir = models_dir + "/" + model_name + "/" + str(model_version)
+
+    try:
+        os.makedirs(model_version_dir)
+    except OSError as ex:
+        pass # ignore existing dir
+
+    with open(model_version_dir + "/model.plan", "wb") as f:
+        f.write(engine.serialize())
+
+    engine.destroy()
+    builder.destroy()
 
 
 def create_plan_modelfile(
@@ -551,12 +707,16 @@ def create_plan_modelfile(
     if not tu.validate_for_trt_model(dtype, dtype, dtype, shape, shape, shape):
         return
 
-    if (not tu.shape_is_fixed(shape)):
-        create_plan_dynamic_modelfile(models_dir, model_version, max_batch, dtype, shape)
+    if dtype != np.float32:
+        if (not tu.shape_is_fixed(shape)):
+            create_plan_dynamic_rf_modelfile(models_dir, model_version, max_batch, dtype, shape)
+        else:
+            create_plan_fixed_rf_modelfile(models_dir, model_version, max_batch, dtype, shape)
     else:
-        create_plan_fixed_modelfile(models_dir, model_version, max_batch, dtype, shape)
-
-
+        if (not tu.shape_is_fixed(shape)):
+            create_plan_dynamic_modelfile(models_dir, model_version, max_batch, dtype, shape)
+        else:
+            create_plan_fixed_modelfile(models_dir, model_version, max_batch, dtype, shape)
 
 def create_plan_modelconfig(
         models_dir, model_version, max_batch, dtype, shape):
@@ -605,7 +765,7 @@ output [
   {{
     name: "OUTPUT"
     data_type: {}
-    dims: [ 1, 1, 1 ]
+    dims: [ {} ]
   }}
 ]
 instance_group [
@@ -617,7 +777,7 @@ instance_group [
            "int32" if dtype == np.int32 else "fp32",
            "int32" if dtype == np.int32 else "fp32",
            np_to_model_dtype(dtype), tu.shape_to_dims_str(shape),
-           np_to_model_dtype(dtype))
+           np_to_model_dtype(dtype), tu.shape_to_dims_str(shape))
 
     try:
         os.makedirs(config_dir)
@@ -881,11 +1041,15 @@ def create_models(models_dir, dtype, shape, no_batch=True):
             create_netdef_modelfile(models_dir, model_version, 0, dtype, shape)
 
     if FLAGS.tensorrt:
-        create_plan_modelconfig(models_dir, model_version, 8, dtype, shape + [1, 1])
-        create_plan_modelfile(models_dir, model_version, 8, dtype, shape + [1, 1])
+        suffix = []
+        if dtype == np.int8:
+            suffix = [1,1]
+
+        create_plan_modelconfig(models_dir, model_version, 8, dtype, shape + suffix)
+        create_plan_modelfile(models_dir, model_version, 8, dtype, shape + suffix)
         if no_batch:
-            create_plan_modelconfig(models_dir, model_version, 0, dtype, shape + [1, 1])
-            create_plan_modelfile(models_dir, model_version, 0, dtype, shape + [1, 1])
+            create_plan_modelconfig(models_dir, model_version, 0, dtype, shape + suffix)
+            create_plan_modelfile(models_dir, model_version, 0, dtype, shape + suffix)
 
     if FLAGS.onnx:
         create_onnx_modelconfig(models_dir, model_version, 8, dtype, shape)
@@ -903,7 +1067,7 @@ def create_models(models_dir, dtype, shape, no_batch=True):
 
     if FLAGS.ensemble:
         for pair in emu.platform_types_and_validation():
-            if pair[0] == "plan":
+            if pair[0] == "plan" and dtype == np.int8:
                 shape = shape + [1, 1]
             if not pair[1](dtype, dtype, dtype,
                             shape, shape, shape):
@@ -975,6 +1139,5 @@ if __name__ == '__main__':
     if FLAGS.ensemble:
         # Create nop models used in ensemble
         for model_dtype in ["TYPE_INT32", "TYPE_FP32"]:
-            # 3D shape for TensorRT Plan
-            for model_shape in [(-1,), (-1, -1, -1)]:
+            for model_shape in [(-1,)]:
                 emu.create_nop_modelconfig(FLAGS.models_dir, model_shape, model_dtype)

--- a/qa/common/gen_qa_trt_plugin_models.py
+++ b/qa/common/gen_qa_trt_plugin_models.py
@@ -166,8 +166,8 @@ output [
 def create_plugin_models(models_dir):
     model_version = 1
 
-    create_plan_modelconfig(models_dir, 8, model_version, (16, 1, 1), (16, 1, 1), np.float32, np.float32)
-    create_plan_modelfile(models_dir, 8, model_version, (16, 1, 1), (16, 1, 1), np.float32, np.float32)
+    create_plan_modelconfig(models_dir, 8, model_version, (16,), (16,), np.float32, np.float32)
+    create_plan_modelfile(models_dir, 8, model_version, (16,), (16,), np.float32, np.float32)
 
 
 if __name__ == '__main__':

--- a/qa/common/infer_util.py
+++ b/qa/common/infer_util.py
@@ -179,11 +179,11 @@ def infer_exact(tester, pf, tensor_shape, batch_size,
                     (result_name == OUTPUT1 and output1_raw)):
                     if result_name == OUTPUT0:
                         tester.assertTrue(np.array_equal(result_val[b], expected0_list[b]),
-                                        "{}, "+OUTPUT0+" expected: {}, got {}".format(
+                                        "{}, expected: {}, got {}".format(
                                             model_name, expected0_list[b], result_val[b]))
                     elif result_name == OUTPUT1:
                         tester.assertTrue(np.array_equal(result_val[b], expected1_list[b]),
-                                        "{}, "+OUTPUT1+" expected: {}, got {}".format(
+                                        "{}, expected: {}, got {}".format(
                                             model_name, expected1_list[b], result_val[b]))
                     else:
                         tester.assertTrue(False, "unexpected raw result {}".format(result_name))

--- a/qa/common/test_util.py
+++ b/qa/common/test_util.py
@@ -110,12 +110,20 @@ def validate_for_c2_model(input_dtype, output0_dtype, output1_dtype,
 def validate_for_trt_model(input_dtype, output0_dtype, output1_dtype,
                            input_shape, output0_shape, output1_shape):
     """Return True if input and output dtypes are supported by a TRT model."""
-
-    # TRT supports limited datatypes as of TRT 5.0. Input can be FP16 or
-    # FP32, output must be FP32.
-    if (input_dtype != np.float16) and (input_dtype != np.float32):
+    supported_datatypes = [np.int8, np.int32, np.float16, np.float32]
+    if not input_dtype in supported_datatypes:
         return False
-    if (output0_dtype != np.float32) or (output1_dtype != np.float32):
+    if not output0_dtype in supported_datatypes:
+        return False
+    if not output1_dtype in supported_datatypes:
+        return False
+
+    datatype_set = set([input_dtype, output0_dtype, output1_dtype])
+
+    # Incompatible datatype conversions
+    if (np.int32 in datatype_set) and (np.int8 in datatype_set):
+        return False
+    if (np.float32 in datatype_set) and (np.int32 in datatype_set):
         return False
 
     return True

--- a/src/backends/tensorrt/plan_backend.h
+++ b/src/backends/tensorrt/plan_backend.h
@@ -79,7 +79,8 @@ class PlanBackend : public InferenceBackend {
 
     Status InitializeInputBinding(
         const std::string& input_name, const DataType input_datatype,
-        const DimsList& input_dims, const bool support_batching);
+        const DimsList& input_dims, const bool support_batching,
+        const bool is_control = false);
     Status InitializeSequenceControlInputBindings(
         const ModelConfig& config, const bool support_batching);
     Status InitializeConfigInputBindings(


### PR DESCRIPTION
Enables the testing framework to include coverage for other supported IO data types by TRT. With the requirement of 3d tensors relaxed for datatypes except INT8, the special handling of TRT in our testing framework is somewhat relaxed as well.