### PR TITLE
Advance ONNX Runtime version to a fixed commit after rel-0.5.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -108,8 +108,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends git
 # Use a fixed commit after rel-0.5.0
 RUN git clone --recursive https://github.com/Microsoft/onnxruntime && \
     (cd onnxruntime && \
-            git checkout 810ee0068f5d9c91426fe941f961410792337b7a && \
-            git submodule update)
+            git checkout a0ba25f98f210fa506300bb5040695e2b7a636a8 && \
+            git submodule update --init --recursive)
 
 ENV PATH="/opt/cmake/bin:${PATH}"
 ARG SCRIPT_DIR=/workspace/onnxruntime/tools/ci_build/github/linux/docker/scripts

--- a/Dockerfile
+++ b/Dockerfile
@@ -99,17 +99,16 @@ FROM ${BASE_IMAGE} AS trtserver_onnx
 # needs to be built from source
 
 # Onnx Runtime release version
-ARG ONNX_RUNTIME_VERSION=0.4.0
+ARG ONNX_RUNTIME_VERSION=0.5.0
 
 # Get release version of Onnx Runtime
 WORKDIR /workspace
 RUN apt-get update && apt-get install -y --no-install-recommends git
 
-# Check out stable commit on master until new release
-# to support cloud-based filesystems
+# Use a fixed commit after rel-0.5.0
 RUN git clone --recursive https://github.com/Microsoft/onnxruntime && \
     (cd onnxruntime && \
-            git checkout 2f698bd54b713bb87dbd0bbb913e94bcf7fd480c && \
+            git checkout 810ee0068f5d9c91426fe941f961410792337b7a && \
             git submodule update)
 
 ENV PATH="/opt/cmake/bin:${PATH}"
@@ -236,8 +235,14 @@ COPY --from=trtserver_caffe2 /opt/conda/lib/python3.6/site-packages/torch/lib/li
      /opt/tensorrtserver/lib/
 
 # Onnx Runtime headers and library
-ARG ONNX_RUNTIME_VERSION=0.4.0
-COPY --from=trtserver_onnx /workspace/onnxruntime/include/onnxruntime \
+# Put include files to same directory as ONNX Runtime changed the include path
+# https://github.com/microsoft/onnxruntime/pull/1461
+ARG ONNX_RUNTIME_VERSION=0.5.0
+COPY --from=trtserver_onnx /workspace/onnxruntime/include/onnxruntime/core/session/onnxruntime_c_api.h \
+     /opt/tensorrtserver/include/onnxruntime/
+COPY --from=trtserver_onnx /workspace/onnxruntime/include/onnxruntime/core/providers/cpu/cpu_provider_factory.h \
+     /opt/tensorrtserver/include/onnxruntime/
+COPY --from=trtserver_onnx /workspace/onnxruntime/include/onnxruntime/core/providers/cuda/cuda_provider_factory.h \
      /opt/tensorrtserver/include/onnxruntime/
 COPY --from=trtserver_onnx /workspace/build/Release/libonnxruntime.so.${ONNX_RUNTIME_VERSION} \
      /opt/tensorrtserver/lib/

--- a/src/backends/onnx/autofill.cc
+++ b/src/backends/onnx/autofill.cc
@@ -315,7 +315,7 @@ AutoFillOnnx::Create(
   OrtResourceWrapper<OrtSessionOptions*> options_wrapper(
       session_options, &OrtReleaseSessionOptions);
   RETURN_IF_ORT_ERROR(OrtSetSessionThreadPoolSize(session_options, 1));
-  RETURN_IF_ORT_ERROR(OrtSetSessionGraphOptimizationLevel(session_options, 0));
+  RETURN_IF_ORT_ERROR(OrtSetSessionGraphOptimizationLevel(session_options, ORT_DISABLE_ALL));
 
   OrtSession* session;
 
@@ -369,9 +369,7 @@ AutoFillOnnx::Create(
   RETURN_IF_ERROR(status);
 
   OrtAllocator* allocator;
-  OrtStatus* ort_status = OrtCreateDefaultAllocator(&allocator);
-  OrtResourceWrapper<OrtAllocator*> allocator_wrapper(
-      allocator, &OrtReleaseAllocator);
+  OrtStatus* ort_status = OrtGetAllocatorWithDefaultOptions(&allocator);
 
   if (ort_status == nullptr) {
     status = local_autofill->SetConfigFromOrtSession(session, allocator);

--- a/src/backends/onnx/loader.h
+++ b/src/backends/onnx/loader.h
@@ -25,7 +25,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
-#include <core/session/onnxruntime_c_api.h>
+#include <onnxruntime_c_api.h>
 #include "src/core/status.h"
 
 namespace nvidia { namespace inferenceserver {

--- a/src/backends/onnx/onnx_backend.cc
+++ b/src/backends/onnx/onnx_backend.cc
@@ -38,7 +38,7 @@
 #include "src/core/server_status.h"
 
 #ifdef TRTIS_ENABLE_GPU
-#include <core/providers/cuda/cuda_provider_factory.h>
+#include <cuda_provider_factory.h>
 #include <cuda_runtime_api.h>
 #endif  // TRTIS_ENABLE_GPU
 
@@ -59,9 +59,7 @@ OnnxBackend::Context::~Context()
   if (session_ != nullptr) {
     OnnxLoader::UnloadSession(session_);
   }
-  if (allocator_ != nullptr) {
-    OrtReleaseAllocator(allocator_);
-  }
+  // 'allocator_' is default allocator which is managed by ONNX Runtime
 }
 
 Status
@@ -87,7 +85,7 @@ OnnxBackend::CreateExecutionContexts(
       session_options, &OrtReleaseSessionOptions);
   RETURN_IF_ORT_ERROR(OrtSetSessionThreadPoolSize(session_options, 1));
   // disable graph optimization
-  RETURN_IF_ORT_ERROR(OrtSetSessionGraphOptimizationLevel(session_options, 0));
+  RETURN_IF_ORT_ERROR(OrtSetSessionGraphOptimizationLevel(session_options, ORT_DISABLE_ALL));
 
   Status status = CreateExecutionContextsHelper(session_options, models);
 
@@ -218,7 +216,7 @@ OnnxBackend::CreateExecutionContext(
   // Create Onnx session
   RETURN_IF_ERROR(OnnxLoader::LoadSession(
       op_itr->second, session_options, &context->session_));
-  RETURN_IF_ORT_ERROR(OrtCreateDefaultAllocator(&context->allocator_));
+  RETURN_IF_ORT_ERROR(OrtGetAllocatorWithDefaultOptions(&context->allocator_));
 
   // If this is a sequence model then make sure that the required
   // inputs are present in the model and have the correct shape and

--- a/src/backends/onnx/onnx_backend.cc
+++ b/src/backends/onnx/onnx_backend.cc
@@ -586,7 +586,7 @@ OnnxBackend::Context::SetInputTensor(
       name, expected_byte_sizes, payloads, TRTSERVER_MEMORY_CPU, buffer);
 
   if (data_type != TYPE_STRING) {
-    const OrtAllocatorInfo* allocator_info;
+    const OrtMemoryInfo* allocator_info;
     RETURN_IF_ORT_ERROR(OrtAllocatorGetInfo(allocator_, &allocator_info));
     RETURN_IF_ORT_ERROR(OrtCreateTensorWithDataAsOrtValue(
         allocator_info, (void*)input_buffers->back().get(), total_byte_size,

--- a/src/backends/onnx/onnx_backend.h
+++ b/src/backends/onnx/onnx_backend.h
@@ -25,7 +25,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
-#include <core/session/onnxruntime_c_api.h>
+#include <onnxruntime_c_api.h>
 #include "src/core/backend.h"
 #include "src/core/backend_context.h"
 #include "src/core/model_config.pb.h"

--- a/src/backends/onnx/onnx_utils.cc
+++ b/src/backends/onnx/onnx_utils.cc
@@ -45,7 +45,7 @@ InputOutputNames(
 
   // iterate over all input / output nodes
   OrtAllocator* allocator;
-  RETURN_IF_ORT_ERROR(OrtCreateDefaultAllocator(&allocator));
+  RETURN_IF_ORT_ERROR(OrtGetAllocatorWithDefaultOptions(&allocator));
   OrtStatus* onnx_status = nullptr;
   for (size_t i = 0; i < num_nodes; i++) {
     char* node_name;
@@ -60,7 +60,6 @@ InputOutputNames(
     }
     names.emplace(node_name);
   }
-  OrtReleaseAllocator(allocator);
   RETURN_IF_ORT_ERROR(onnx_status);
 
   return Status::Success;

--- a/src/backends/onnx/onnx_utils.h
+++ b/src/backends/onnx/onnx_utils.h
@@ -26,7 +26,7 @@
 
 #pragma once
 
-#include <core/session/onnxruntime_c_api.h>
+#include <onnxruntime_c_api.h>
 #include "src/core/model_config.h"
 #include "src/core/status.h"
 


### PR DESCRIPTION
The commit includes fixes to:
* [deploying model across multiple GPUs](https://github.com/microsoft/onnxruntime/issues/1592)
* [building ONNX Runtime C libraray with TensorRT Execution Provider](https://github.com/microsoft/onnxruntime/issues/1803)
* [ONNX Runtime slowdown due to tensor copies between CPU and GPU](https://github.com/microsoft/onnxruntime/issues/1675)