### PR TITLE
Helper function ByteSize that returns size in bytes

### DIFF
--- a/src/clients/c++/request.h.in
+++ b/src/clients/c++/request.h.in
@@ -653,6 +653,16 @@ class InferContext {
   /// \return Error object indicating success or failure.
   virtual Error SetRunOptions(const Options& options) = 0;
 
+  /// Get the byte size of an input ot output given the shape and the datatype.
+  /// \param shape The shape of the input/output.
+  /// \param dtype The datatype of the input/output.
+  /// \return The size in bytes of this input/output. This is the size for
+  /// one instance of the input/output, not the entire size of a batched
+  /// input/output. When the byte-size is not known, for example for
+  /// non-fixed-sized types like TYPE_STRING or for inputs/outputs with
+  /// variable-size dimensions, this will return -1.
+  virtual int64_t ByteSize(const DimsList& shape, const DataType& dtype) const = 0;
+
   /// Get the current statistics of the InferContext.
   /// \param stat Returns the Stat object holding the statistics.
   /// \return Error object indicating success or failure.

--- a/src/clients/c++/request.h.in
+++ b/src/clients/c++/request.h.in
@@ -653,7 +653,7 @@ class InferContext {
   /// \return Error object indicating success or failure.
   virtual Error SetRunOptions(const Options& options) = 0;
 
-  /// Get the byte size of an input ot output given the shape and the datatype.
+  /// Get the byte size of an input or output given the shape and the datatype.
   /// \param shape The shape of the input/output.
   /// \param dtype The datatype of the input/output.
   /// \return The size in bytes of this input/output. This is the size for
@@ -661,7 +661,7 @@ class InferContext {
   /// input/output. When the byte-size is not known, for example for
   /// non-fixed-sized types like TYPE_STRING or for inputs/outputs with
   /// variable-size dimensions, this will return -1.
-  virtual int64_t ByteSize(const DimsList& shape, const DataType& dtype) const = 0;
+  virtual int64_t ByteSize(const DimsList& shape, DataType dtype) const = 0;
 
   /// Get the current statistics of the InferContext.
   /// \param stat Returns the Stat object holding the statistics.

--- a/src/clients/c++/request_common.cc
+++ b/src/clients/c++/request_common.cc
@@ -906,61 +906,9 @@ InferContextImpl::GetOutput(
 }
 
 int64_t
-InferContextImpl::ByteSize(const DimsList& dims, const DataType& dtype) const
+InferContextImpl::ByteSize(const DimsList& dims, DataType dtype) const
 {
-  int dtype_size = -1;
-  switch (dtype) {
-    case TYPE_BOOL:
-      dtype_size = 1;
-      break;
-    case TYPE_UINT8:
-      dtype_size = 1;
-      break;
-    case TYPE_INT8:
-      dtype_size = 1;
-      break;
-    case TYPE_INT16:
-      dtype_size = 2;
-      break;
-    case TYPE_INT32:
-      dtype_size = 4;
-      break;
-    case TYPE_INT64:
-      dtype_size = 8;
-      break;
-    case TYPE_FP16:
-      dtype_size = 2;
-      break;
-    case TYPE_FP32:
-      dtype_size = 4;
-      break;
-    case TYPE_FP64:
-      dtype_size = 8;
-      break;
-    case TYPE_UINT16:
-      dtype_size = 2;
-      break;
-    case TYPE_UINT32:
-      dtype_size = 4;
-      break;
-    case TYPE_UINT64:
-      dtype_size = 8;
-      break;
-    case TYPE_STRING:
-    default:
-      return -1;
-  }
-
-  int byte_size = 1;
-  for (const auto dim : dims) {
-    if (dim == -1) {
-      return -1;
-    }
-    byte_size *= dim;
-  }
-
-  byte_size *= dtype_size;
-  return byte_size;
+  return GetByteSize(dtype, dims);
 }
 
 Error

--- a/src/clients/c++/request_common.cc
+++ b/src/clients/c++/request_common.cc
@@ -905,6 +905,64 @@ InferContextImpl::GetOutput(
       "unknown output '" + name + "' for '" + model_name_ + "'");
 }
 
+int64_t
+InferContextImpl::ByteSize(const DimsList& dims, const DataType& dtype) const
+{
+  int dtype_size = -1;
+  switch (dtype) {
+    case TYPE_BOOL:
+      dtype_size = 1;
+      break;
+    case TYPE_UINT8:
+      dtype_size = 1;
+      break;
+    case TYPE_INT8:
+      dtype_size = 1;
+      break;
+    case TYPE_INT16:
+      dtype_size = 2;
+      break;
+    case TYPE_INT32:
+      dtype_size = 4;
+      break;
+    case TYPE_INT64:
+      dtype_size = 8;
+      break;
+    case TYPE_FP16:
+      dtype_size = 2;
+      break;
+    case TYPE_FP32:
+      dtype_size = 4;
+      break;
+    case TYPE_FP64:
+      dtype_size = 8;
+      break;
+    case TYPE_UINT16:
+      dtype_size = 2;
+      break;
+    case TYPE_UINT32:
+      dtype_size = 4;
+      break;
+    case TYPE_UINT64:
+      dtype_size = 8;
+      break;
+    case TYPE_STRING:
+    default:
+      return -1;
+  }
+
+  int byte_size = 1;
+  for (const auto dim : dims) {
+    if (dim == -1) {
+      return -1;
+    }
+    byte_size *= dim;
+  }
+
+  byte_size *= dtype_size;
+  return byte_size;
+}
+
 Error
 InferContextImpl::SetRunOptions(const InferContext::Options& boptions)
 {

--- a/src/clients/c++/request_common.h
+++ b/src/clients/c++/request_common.h
@@ -447,7 +447,7 @@ class InferContextImpl : public InferContext {
 
   Error SetRunOptions(const Options& options) override;
   Error GetStat(Stat* stat) const override;
-  int64_t ByteSize(const DimsList& dims, const DataType& dtype) const override;
+  int64_t ByteSize(const DimsList& dims, DataType dtype) const override;
 
   virtual Error GetReadyAsyncRequest(
       std::shared_ptr<Request>* async_request, bool* is_ready,

--- a/src/clients/c++/request_common.h
+++ b/src/clients/c++/request_common.h
@@ -447,6 +447,7 @@ class InferContextImpl : public InferContext {
 
   Error SetRunOptions(const Options& options) override;
   Error GetStat(Stat* stat) const override;
+  int64_t ByteSize(const DimsList& dims, const DataType& dtype) const override;
 
   virtual Error GetReadyAsyncRequest(
       std::shared_ptr<Request>* async_request, bool* is_ready,

--- a/src/clients/c++/simple_shm_client.cc
+++ b/src/clients/c++/simple_shm_client.cc
@@ -272,8 +272,11 @@ main(int argc, char** argv)
   FAIL_IF_ERR(input0->Reset(), "unable to reset INPUT0");
   FAIL_IF_ERR(input1->Reset(), "unable to reset INPUT1");
 
-  size_t input_byte_size = 16 * sizeof(int32_t);
-  size_t output_byte_size = 16 * sizeof(int32_t);
+  // Get the size of the inputs and outputs from the Shape and DataType
+  int input_byte_size =
+      infer_ctx->ByteSize(input0->Dims(), ni::DataType::TYPE_INT32);
+  int output_byte_size =
+      infer_ctx->ByteSize(output0->Dims(), ni::DataType::TYPE_INT32);
 
   // Create Output0 and Output1 in Shared Memory
   std::string shm_key = "/output_simple";


### PR DESCRIPTION
Solves #562
Returns size in bytes given a shape and datatype.
See simple_shm_client.cc for example.