### PR TITLE
cc_model_names -> cc_model_filenames typo in docs

### DIFF
--- a/src/core/model_config.proto
+++ b/src/core/model_config.proto
@@ -851,7 +851,7 @@ message ModelConfig
   //@@
   //@@     Optional filename of the model file to use if a
   //@@     compute-capability specific model is not specified in
-  //@@     :cpp:var:`cc_model_names`. If not specified the default name
+  //@@     :cpp:var:`cc_model_filenames`. If not specified the default name
   //@@     is 'model.graphdef', 'model.savedmodel', 'model.plan' or
   //@@     'model.netdef' depending on the model type.
   //@@


### PR DESCRIPTION
Fixes `cc_model_names` typo at https://docs.nvidia.com/deeplearning/sdk/tensorrt-inference-server-guide/docs/protobuf_api/model_config.proto.html#_CPPv4N6nvidia15inferenceserver11ModelConfig22default_model_filenameE