### PR TITLE
Make CURL dependency PRIVATE in CMake

### DIFF
--- a/src/clients/c++/examples/CMakeLists.example
+++ b/src/clients/c++/examples/CMakeLists.example
@@ -61,8 +61,8 @@ target_link_libraries(
   PRIVATE request_static
   PRIVATE gRPC::grpc++
   PRIVATE gRPC::grpc
+  PRIVATE CURL::libcurl
   PUBLIC protobuf::libprotobuf
-  PUBLIC CURL::libcurl
 )
 install(
   TARGETS simple_client_static

--- a/src/clients/c++/library/CMakeLists.txt
+++ b/src/clients/c++/library/CMakeLists.txt
@@ -84,8 +84,8 @@ target_link_libraries(
   request_static
   PRIVATE gRPC::grpc++
   PRIVATE gRPC::grpc
+  PRIVATE CURL::libcurl
   PUBLIC protobuf::libprotobuf
-  PUBLIC CURL::libcurl
 )
 if(NOT WIN32)
   target_link_libraries(
@@ -114,8 +114,8 @@ target_link_libraries(
   request
   PRIVATE gRPC::grpc++
   PRIVATE gRPC::grpc
+  PRIVATE CURL::libcurl
   PUBLIC protobuf::libprotobuf
-  PUBLIC CURL::libcurl
 )
 if(NOT WIN32)
   target_link_libraries(


### PR DESCRIPTION
It seems like CURL should be a private dep(?).
Even though that means nothing for a static library, at least
it makes it clearer that the interface used by librequest(_static)
is not tied to CURL in any way and its consumers don't need 
to see CURL headers.

Seems to me that CURL is not used in the public C++ API and is
hidden in code. It should be the same for CMake, since
it's the same for gRPC (although that seems to be linked
statically).

Signed-off-by: Andrei-Florin BENCSIK <andrei.bencsik@gmail.com>