### PR TITLE
Fix sync HTTP client performance

### DIFF
--- a/qa/L0_perf/test.sh
+++ b/qa/L0_perf/test.sh
@@ -84,13 +84,13 @@ for BACKEND in $BACKENDS; do
 
     set +e
     $CLIENT -m${MODEL_NAME} -b${BATCH_SIZE} -s${TENSOR_SIZE} \
-            -n${MEASURE_ITERS} >> ${BACKEND}.log 2>&1
+            -w${WARMUP_ITERS} -n${MEASURE_ITERS} >> ${BACKEND}.log 2>&1
     if (( $? != 0 )); then
         RET=1
     fi
 
-    $CLIENT -i grpc -u localhost:8001 -m${MODEL_NAME} -b${BATCH_SIZE} \
-            -s${TENSOR_SIZE} -n${MEASURE_ITERS} >> ${BACKEND}.log 2>&1
+    $CLIENT -i grpc -u localhost:8001 -m${MODEL_NAME} -b${BATCH_SIZE} -s${TENSOR_SIZE} \
+            -w${WARMUP_ITERS} -n${MEASURE_ITERS} >> ${BACKEND}.log 2>&1
     if (( $? != 0 )); then
         RET=1
     fi
@@ -102,7 +102,7 @@ for BACKEND in $BACKENDS; do
 done
 
 for BACKEND in $BACKENDS; do
-    echo -e "${BACKEND}\n"
+    echo -e "\n${BACKEND}\n************"
     cat ${BACKEND}.log
 done
 

--- a/qa/L0_perf_nomodel/perf_analysis.py
+++ b/qa/L0_perf_nomodel/perf_analysis.py
@@ -77,6 +77,9 @@ def lower_is_better(name):
     return name != INFERPERSEC
 
 def get_delta(name, baseline, result, slowdown_threshold, speedup_threshold):
+    if (float(baseline) == 0) or (float(result) == 0):
+        return None
+
     if lower_is_better(name):
         speedup = float(baseline) / float(result)
     else:
@@ -131,7 +134,10 @@ def analysis(slowdown_threshold, speedup_threshold,
             else:
                 delta = get_delta(name, baseline_result[name], result,
                                   slowdown_threshold, speedup_threshold)
-                print("{:<28}{:>12}{:>12}{:>22}".format(name, baseline_result[name], result, delta))
+                if delta is None:
+                    print("{:<28}{:>12}{:>12}{:>12}".format(name, baseline_result[name], result, "n/a"))
+                else:
+                    print("{:<28}{:>12}{:>12}{:>22}".format(name, baseline_result[name], result, delta))
 
 
 if __name__ == '__main__':

--- a/src/clients/c++/examples/simple_perf_client.cc
+++ b/src/clients/c++/examples/simple_perf_client.cc
@@ -170,7 +170,7 @@ ShowResults(
   var_us /= duration_ns.size();
   uint64_t stddev_us = std::sqrt(var_us);
 
-  std::cout << std::endl << name << " (" << protocol << ")" << std::endl;
+  std::cout << name << " (" << protocol << ")" << std::endl;
   std::cout << "Total time: " << (sum_us / 1000.0) << " ms" << std::endl;
   std::cout << "Mean time: " << (mean_us / 1000.0) << " ms" << std::endl;
   std::cout << "Stddev: " << (stddev_us / 1000.0) << " ms" << std::endl;


### PR DESCRIPTION
curl_easy has significant delay in handling responses when a
curl_easy_handle is reused. curl_easy_reset does not fix the
problem. So create a new curl_easy_handle for each sync request.