### PR TITLE
cleaning the perclient cli arguments

### DIFF
--- a/qa/L0_perf_client/test.sh
+++ b/qa/L0_perf_client/test.sh
@@ -58,7 +58,7 @@ fi
 
 # Sanity check on measurements are not all zero
 set +e
-$PERF_CLIENT -v -i grpc -u localhost:8001 -m graphdef_int32_int32_int32 -t 1 -p2000 -b 1 >$CLIENT_LOG 2>&1
+$PERF_CLIENT -v -i grpc -m graphdef_int32_int32_int32 -t 1 -p2000 -b 1 >$CLIENT_LOG 2>&1
 if [ $? -ne 0 ]; then
     cat $CLIENT_LOG
     echo -e "\n***\n*** Test Failed\n***"
@@ -75,7 +75,7 @@ set -e
 for MODEL in graphdef_nobatch_int32_int32_int32 graphdef_int32_int32_int32; do
     # Valid batch size
     set +e
-    $PERF_CLIENT -v -i grpc -u localhost:8001 -m $MODEL -t 1 -p20000 -b 1 >$CLIENT_LOG 2>&1
+    $PERF_CLIENT -v -i grpc -m $MODEL -t 1 -p20000 -b 1 >$CLIENT_LOG 2>&1
     if [ $? -ne 0 ]; then
         cat $CLIENT_LOG
         echo -e "\n***\n*** Test Failed\n***"
@@ -86,7 +86,7 @@ for MODEL in graphdef_nobatch_int32_int32_int32 graphdef_int32_int32_int32; do
     # Invalid batch sizes
     for STATIC_BATCH in 0 10; do
         set +e
-        $PERF_CLIENT -v -i grpc -u localhost:8001 -m $MODEL -t 1 -p20000 -b $STATIC_BATCH >$CLIENT_LOG 2>&1
+        $PERF_CLIENT -v -i grpc -m $MODEL -t 1 -p20000 -b $STATIC_BATCH >$CLIENT_LOG 2>&1
         if [ $? -eq 0 ]; then
             cat $CLIENT_LOG
             echo -e "\n***\n*** Test Failed\n***"
@@ -98,7 +98,7 @@ done
 
 # Testing with the new arguments
 set +e
-$PERF_CLIENT -v -i grpc -u localhost:8001 -m graphdef_int32_int32_int32 >$CLIENT_LOG 2>&1
+$PERF_CLIENT -v -i grpc -m graphdef_int32_int32_int32 >$CLIENT_LOG 2>&1
 if [ $? -ne 0 ]; then
     cat $CLIENT_LOG
     echo -e "\n***\n*** Test Failed\n***"
@@ -112,7 +112,7 @@ fi
 set -e
 
 set +e
-$PERF_CLIENT -v -i grpc -u localhost:8001 -m graphdef_int32_int32_int32 --search-range 1:5:2 >$CLIENT_LOG 2>&1
+$PERF_CLIENT -v -i grpc -m graphdef_int32_int32_int32 --concurrency-range 1:5:2 >$CLIENT_LOG 2>&1
 if [ $? -ne 0 ]; then
     cat $CLIENT_LOG
     echo -e "\n***\n*** Test Failed\n***"

--- a/qa/L0_perf_client/test.sh
+++ b/qa/L0_perf_client/test.sh
@@ -96,6 +96,36 @@ for MODEL in graphdef_nobatch_int32_int32_int32 graphdef_int32_int32_int32; do
     done
 done
 
+# Testing with the new arguments
+set +e
+$PERF_CLIENT -v -i grpc -u localhost:8001 -m graphdef_int32_int32_int32 >$CLIENT_LOG 2>&1
+if [ $? -ne 0 ]; then
+    cat $CLIENT_LOG
+    echo -e "\n***\n*** Test Failed\n***"
+    RET=1
+fi
+if [ $(cat $CLIENT_LOG | grep ": 0 infer/sec\|: 0 usec" | wc -l) -ne 0 ]; then
+    cat $CLIENT_LOG
+    echo -e "\n***\n*** Test Failed\n***"
+    RET=1
+fi
+set -e
+
+set +e
+$PERF_CLIENT -v -i grpc -u localhost:8001 -m graphdef_int32_int32_int32 --search-range 1:5:2 >$CLIENT_LOG 2>&1
+if [ $? -ne 0 ]; then
+    cat $CLIENT_LOG
+    echo -e "\n***\n*** Test Failed\n***"
+    RET=1
+fi
+if [ $(cat $CLIENT_LOG | grep ": 0 infer/sec\|: 0 usec|Request concurrency: 2" | wc -l) -ne 0 ]; then
+    cat $CLIENT_LOG
+    echo -e "\n***\n*** Test Failed\n***"
+    RET=1
+fi
+set -e
+
+
 kill $SERVER_PID
 wait $SERVER_PID
 

--- a/src/clients/c++/perf_client/inference_profiler.h
+++ b/src/clients/c++/perf_client/inference_profiler.h
@@ -41,7 +41,7 @@ struct LoadParams {
   // status
   uint32_t stability_window;
   // The +/- range to account for while assessing load status
-  double stable_offset;
+  double stability_threshold;
 };
 
 
@@ -121,8 +121,8 @@ class InferenceProfiler {
  public:
   /// Create a profiler that collects and summarizes inference statistic.
   /// \param verbose Whether to print verbose logging.
-  /// \param stable_offset The range that the measurement is considered as
-  /// stable. i.e. within (1 +/- stable_offset) * average value of the last
+  /// \param stability_threshold The range that the measurement is considered as
+  /// stable. i.e. within (1 +/- stability_threshold) * average value of the last
   /// 3 measurements. The criterias are "infer per second" and "average
   /// latency", or "infer per second" and "percentile latency" if valid
   /// percentile is set (see 'percentile' below).
@@ -137,7 +137,7 @@ class InferenceProfiler {
   /// \param manger Returns a new InferenceProfiler object.
   /// \return Error object indicating success or failure.
   static nic::Error Create(
-      const bool verbose, const double stable_offset,
+      const bool verbose, const double stability_threshold,
       const uint64_t measurement_window_ms, const size_t max_measurement_count,
       const int64_t percentile, std::shared_ptr<ContextFactory>& factory,
       std::unique_ptr<LoadManager> manager,
@@ -159,7 +159,7 @@ class InferenceProfiler {
 
  private:
   InferenceProfiler(
-      const bool verbose, const double stable_offset,
+      const bool verbose, const double stability_threshold,
       const int32_t measurement_window_ms, const size_t max_measurement_count,
       const bool extra_percentile, const size_t percentile,
       const ContextFactory::ModelSchedulerType scheduler_type,

--- a/src/clients/c++/perf_client/perf_client.cc
+++ b/src/clients/c++/perf_client/perf_client.cc
@@ -256,7 +256,6 @@ std::string
 FormatMessage(std::string str, int offset)
 {
   int width = 60;
-  int index = 1;
   int current_pos = offset;
   while (current_pos + width < int(str.length())) {
     int n = str.rfind(' ', current_pos + width);
@@ -264,7 +263,6 @@ FormatMessage(std::string str, int offset)
       str.replace(n, 1, "\n\t ");
       current_pos += (width + 10);
     }
-    index++;
   }
   return str;
 }
@@ -300,6 +298,7 @@ Usage(char** argv, const std::string& msg = std::string())
   std::cerr << "\t-t <number of concurrent requests>" << std::endl;
   std::cerr << "\t-c <maximum concurrency>" << std::endl;
   std::cerr << "\t-d" << std::endl;
+  std::cerr << "\t-a" << std::endl;
   std::cerr << std::endl;
   std::cerr << "II. INPUT DATA OPTIONS: " << std::endl;
   std::cerr << "\t-b <batch size>" << std::endl;
@@ -319,7 +318,6 @@ Usage(char** argv, const std::string& msg = std::string())
   std::cerr << "\t-f <filename for storing report in csv format>" << std::endl;
   std::cerr << "\t-H <HTTP header>" << std::endl;
   std::cerr << "\t--streaming" << std::endl;
-  std::cerr << "\t-a" << std::endl;
   std::cerr << std::endl;
   std::cerr << "==== OPTIONS ==== \n \n";
 
@@ -354,19 +352,19 @@ Usage(char** argv, const std::string& msg = std::string())
       << FormatMessage(
              " --search-range <m:n:o>: Determines the range of concurrency "
              "levels covered by the perf_client. The perf_client will start "
-             "from the concurrency level of m to n with steps of o. The "
-             "default value of m and o are 1. If n is not specified then "
+             "from the concurrency level of 'm' to 'n' with steps of 'o'. The "
+             "default value of 'm' and 'o' are 1. If 'n' is not specified then "
              "perf_client will run for a single concurrency level determined "
-             "by m. If n is set as 0, then the concurrency limit will be "
-             "incremented till latency threshold is met. n and -l can not be "
-             "both 0 simultaneously.",
+             "by 'm'. If 'n' is set as 0, then the concurrency limit will be "
+             "incremented by 'o' till latency threshold is met. 'n' and -l can "
+             "not be both 0 simultaneously.",
              18)
       << std::endl;
   std::cerr << FormatMessage(
                    " --latency-threshold (-l): Sets the limit on the observed "
                    "latency. Client will top incrementing the concurrency and "
                    "abort the execution once the measured latency exceeds this "
-                   "threshold. By default, latency threshold  is set 0 and "
+                   "threshold. By default, latency threshold is set 0 and "
                    "the perf_client will run for entire --search-range.",
                    18)
             << std::endl;
@@ -398,7 +396,7 @@ Usage(char** argv, const std::string& msg = std::string())
       << FormatMessage(
              " --percentile: It indicates that the specified percentile in "
              "terms of latency will also be reported and used to detemine if "
-             "the  measurement is stable instead of average latency. Default "
+             "the measurement is stable instead of average latency. Default "
              "is -1 to indicate no percentile will be used.",
              18)
       << std::endl;
@@ -428,6 +426,10 @@ Usage(char** argv, const std::string& msg = std::string())
              "request latency is above the threshold set (see -l).",
              9)
       << std::endl;
+  std::cerr << std::setw(9) << std::left << " -a: "
+            << FormatMessage(
+                   "This flag is deprecated and will not affect client.", 9)
+            << std::endl;
 
   std::cerr << std::endl;
   std::cerr << "II. INPUT DATA OPTIONS: " << std::endl;
@@ -503,7 +505,7 @@ Usage(char** argv, const std::string& msg = std::string())
   std::cerr
       << std::setw(9) << std::left << " -f: "
       << FormatMessage(
-             "The observation report will be stored in the file pointed by "
+             "The latency report will be stored in the file named by "
              "this option. By default, the result is not recorded in a file.",
              9)
       << std::endl;
@@ -521,10 +523,6 @@ Usage(char** argv, const std::string& msg = std::string())
              "only valid with gRPC protocol. By default, it is set false.",
              18)
       << std::endl;
-  std::cerr << std::setw(9) << std::left << " -a: "
-            << FormatMessage(
-                   "This flag is deprecated and will not affect client.", 9)
-            << std::endl;
 
   exit(1);
 }
@@ -602,7 +600,6 @@ main(int argc, char** argv)
         data_directory = optarg;
         break;
       case 5: {
-        using_search_range = true;
         std::string arg = optarg;
         std::string name = arg.substr(0, arg.rfind(":"));
         std::string shape_str = arg.substr(name.size() + 1);
@@ -636,6 +633,7 @@ main(int argc, char** argv)
         break;
       }
       case 7: {
+        using_search_range = true;
         std::string arg = optarg;
         size_t pos = 0;
         int index = 0;

--- a/src/clients/c++/perf_client/perf_client.cc
+++ b/src/clients/c++/perf_client/perf_client.cc
@@ -251,6 +251,24 @@ Report(
 }
 }  // namespace perfclient
 
+// Used to format the usage message
+std::string
+FormatMessage(std::string str, int offset)
+{
+  int width = 60;
+  int index = 1;
+  int current_pos = offset;
+  while (current_pos + width < int(str.length())) {
+    int n = str.rfind(' ', current_pos + width);
+    if (n != int(std::string::npos)) {
+      str.replace(n, 1, "\n\t ");
+      current_pos += (width + 10);
+    }
+    index++;
+  }
+  return str;
+}
+
 void
 Usage(char** argv, const std::string& msg = std::string())
 {
@@ -259,142 +277,293 @@ Usage(char** argv, const std::string& msg = std::string())
   }
 
   std::cerr << "Usage: " << argv[0] << " [options]" << std::endl;
-  std::cerr << "\t-v" << std::endl;
-  std::cerr << "\t-f <filename for storing report in csv format>" << std::endl;
-  std::cerr << "\t-b <batch size>" << std::endl;
-  std::cerr << "\t-t <number of concurrent requests>" << std::endl;
-  std::cerr << "\t-d" << std::endl;
-  std::cerr << "\t-a" << std::endl;
-  std::cerr << "\t-z" << std::endl;
-  std::cerr << "\t--streaming" << std::endl;
-  std::cerr << "\t--max-threads <thread counts>" << std::endl;
-  std::cerr << "\t-l <latency threshold (in msec)>" << std::endl;
-  std::cerr << "\t-c <maximum concurrency>" << std::endl;
-  std::cerr << "\t-s <deviation threshold for stable measurement"
-            << " (in percentage)>" << std::endl;
-  std::cerr << "\t-p <measurement window (in msec)>" << std::endl;
-  std::cerr << "\t-r <maximum number of measurements for each profiling>"
-            << std::endl;
-  std::cerr << "\t-n" << std::endl;
+  std::cerr << "==== SYNOPSIS ====\n \n";
   std::cerr << "\t-m <model name>" << std::endl;
   std::cerr << "\t-x <model version>" << std::endl;
+  std::cerr << "\t-v" << std::endl;
+  std::cerr << std::endl;
+  std::cerr << "I. MEASUREMENT PARAMETERS: " << std::endl;
+  std::cerr << "\t--measurement-interval (-p) <measurement window (in msec)>"
+            << std::endl;
+  std::cerr << "\t--search-range <m:n:o>" << std::endl;
+  std::cerr << "\t--latency-threshold (-l) <latency threshold (in msec)>"
+            << std::endl;
+  std::cerr << "\t--max-threads <thread counts>" << std::endl;
+  std::cerr << "\t--stability-offset (-s) <deviation threshold for stable "
+               "measurement (in percentage)>"
+            << std::endl;
+  std::cerr << "\t--max-trials (-r)  <maximum number of measurements for each "
+               "profiling>"
+            << std::endl;
+  std::cerr << "\t--percentile <percentile>" << std::endl;
+  std::cerr << "\tDEPRECATED OPTIONS" << std::endl;
+  std::cerr << "\t-t <number of concurrent requests>" << std::endl;
+  std::cerr << "\t-c <maximum concurrency>" << std::endl;
+  std::cerr << "\t-d" << std::endl;
+  std::cerr << std::endl;
+  std::cerr << "II. INPUT DATA OPTIONS: " << std::endl;
+  std::cerr << "\t-b <batch size>" << std::endl;
+  std::cerr << "\t--input-data <\"zero\"|\"random\"|<path>>" << std::endl;
+  std::cerr << "\t--shape <name:shape>" << std::endl;
+  std::cerr << "\t--sequence-length <length>" << std::endl;
+  std::cerr << "\tDEPRECATED OPTIONS" << std::endl;
+  std::cerr << "\t-z" << std::endl;
+  std::cerr << "\t--data-directory <path>" << std::endl;
+  std::cerr << std::endl;
+  std::cerr << "III. SERVER DETAILS: " << std::endl;
   std::cerr << "\t-u <URL for inference service>" << std::endl;
   std::cerr << "\t-i <Protocol used to communicate with inference service>"
             << std::endl;
-  std::cerr << "\t-H <HTTP header>" << std::endl;
-  std::cerr << "\t--sequence-length <length>" << std::endl;
-  std::cerr << "\t--percentile <percentile>" << std::endl;
-  std::cerr << "\t--shape <name:shape>" << std::endl;
-  std::cerr << "\t--data-directory <path>" << std::endl;
   std::cerr << std::endl;
+  std::cerr << "IV. OTHER OPTIONS: " << std::endl;
+  std::cerr << "\t-f <filename for storing report in csv format>" << std::endl;
+  std::cerr << "\t-H <HTTP header>" << std::endl;
+  std::cerr << "\t--streaming" << std::endl;
+  std::cerr << "\t-a" << std::endl;
+  std::cerr << std::endl;
+  std::cerr << "==== OPTIONS ==== \n \n";
+
   std::cerr
-      << "The -d flag enables dynamic concurrent request count where the number"
-      << " of concurrent requests will increase linearly until the request"
-      << " latency is above the threshold set (see -l)." << std::endl;
-  std::cerr << "The -a flag is deprecated. Enable it will not change"
-            << "perf client behaviors." << std::endl;
-  std::cerr << "The --streaming flag is only valid with gRPC protocol."
+      << std::setw(9) << std::left << " -m: "
+      << FormatMessage(
+             "This is a required argument and is used to specify the model"
+             " against which to run perf_client.",
+             9)
+      << std::endl;
+  std::cerr << std::setw(9) << std::left << " -x: "
+            << FormatMessage(
+                   "The version of the above model to be used. If not specified"
+                   " the most recent version (that is, the highest numbered"
+                   " version) of the model will be used.",
+                   9)
             << std::endl;
-  std::cerr << "The --max-threads flag sets the maximum number of threads that"
-            << " will be created for providing desired concurrency."
-            << " Default is 16." << std::endl;
+  std::cerr << std::setw(9) << std::left
+            << " -v: " << FormatMessage("Enables the verbose mode.", 9)
+            << std::endl;
+  std::cerr << std::endl;
+  std::cerr << "I. MEASUREMENT PARAMETERS: " << std::endl;
+  std::cerr << FormatMessage(
+                   " --measurement-interval (-p): It indicates the time "
+                   "interval used for each measurement. The perf client will "
+                   "sample a time interval specified by -p and take "
+                   "measurement over the requests completed within that time "
+                   "interval. The default value is 5000 msec.",
+                   18)
+            << std::endl;
   std::cerr
-      << "For -t, it indicates the number of starting concurrent requests if -d"
-      << " flag is set." << std::endl;
+      << FormatMessage(
+             " --search-range <m:n:o>: Determines the range of concurrency "
+             "levels covered by the perf_client. The perf_client will start "
+             "from the concurrency level of m to n with steps of o. The "
+             "default value of m and o are 1. If n is not specified then "
+             "perf_client will run for a single concurrency level determined "
+             "by m. If n is set as 0, then the concurrency limit will be "
+             "incremented till latency threshold is met. n and -l can not be "
+             "both 0 simultaneously.",
+             18)
+      << std::endl;
+  std::cerr << FormatMessage(
+                   " --latency-threshold (-l): Sets the limit on the observed "
+                   "latency. Client will top incrementing the concurrency and "
+                   "abort the execution once the measured latency exceeds this "
+                   "threshold. By default, latency threshold  is set 0 and "
+                   "the perf_client will run for entire --search-range.",
+                   18)
+            << std::endl;
   std::cerr
-      << "For -s, it indicates the deviation threshold for the measurements. "
-         "The measurement is considered as stable if the recent 3 measurements "
-         "are within +/- (deviation threshold)% of their average in terms of "
-         "both infer per second and latency. Default is 10(%)"
+      << FormatMessage(
+             " --max-threads: Sets the maximum number of threads that will be "
+             "created for providing desired concurrency. Default is 16.",
+             18)
       << std::endl;
   std::cerr
-      << "For -c, it indicates the maximum number of concurrent requests "
-         "allowed if -d flag is set. Once the number of concurrent requests "
-         "exceeds the maximum, the perf client will stop and exit regardless "
-         "of the latency threshold. Default is 0 to indicate that no limit is "
-         "set on the number of concurrent requests."
+      << FormatMessage(
+             " --stability-offset (-s): It indicates the deviation threshold "
+             "for the measurements. The measurement is considered as stable if "
+             "the recent 3 measurements are within +/- (deviation threshold)% "
+             "of their average in terms of both infer per second and latency. "
+             "Default is 10(%).",
+             18)
+      << std::endl;
+  std::cerr << FormatMessage(
+                   " --max-trials (-r): It indicates the maximum number of "
+                   "measurements for each profiling setting. The perf client "
+                   "will take multiple measurements and report the measurement "
+                   "until it is stable. The perf client will abort if the "
+                   "measurement is still unstable after the maximum number of "
+                   "measuremnts. The default value is 10.",
+                   18)
+            << std::endl;
+  std::cerr
+      << FormatMessage(
+             " --percentile: It indicates that the specified percentile in "
+             "terms of latency will also be reported and used to detemine if "
+             "the  measurement is stable instead of average latency. Default "
+             "is -1 to indicate no percentile will be used.",
+             18)
+      << std::endl;
+
+  std::cerr << "\tDEPRECATED OPTIONS" << std::endl;
+  std::cerr << std::setw(9) << std::left << " -t: "
+            << FormatMessage(
+                   "It indicates the number of starting concurrent requests if "
+                   "-d flag is set.",
+                   9)
+            << std::endl;
+  std::cerr
+      << std::setw(9) << std::left << " -c: "
+      << FormatMessage(
+             "It indicates the maximum number of concurrent requests allowed "
+             "if -d flag is set. Once the number of concurrent requests "
+             "exceeds the maximum, the perf client will stop and exit "
+             "regardless of the latency threshold. Default is 0 to indicate "
+             "that no limit is set on the number of concurrent requests.",
+             9)
       << std::endl;
   std::cerr
-      << "For -p, it indicates the time interval used for each measurement."
-      << " The perf client will sample a time interval specified by -p and"
-      << " take measurement over the requests completed"
-      << " within that time interval." << std::endl;
-  std::cerr << "For -r, it indicates the maximum number of measurements for "
-               "each profiling setting. The perf client will take multiple "
-               "measurements and report the measurement until it is stable. "
-               "The perf client will abort if the measurement is still "
-               "unstable after the maximum number of measuremnts."
-            << std::endl;
-  std::cerr << "For -l, it has no effect unless -d flag is set." << std::endl;
-  std::cerr
-      << "If -x is not specified the most recent version (that is, the highest "
-      << "numbered version) of the model will be used." << std::endl;
-  std::cerr << "For -i, available protocols are gRPC and HTTP. Default is HTTP."
-            << std::endl;
-  std::cerr
-      << "For -H, the header will be added to HTTP requests (ignored for GRPC "
-         "requests). The header must be specified as 'Header:Value'. -H may be "
-         "specified multiple times to add multiple headers."
+      << std::setw(9) << std::left << " -d: "
+      << FormatMessage(
+             "This flag enables dynamic concurrent request count where the "
+             "number of concurrent requests will increase linearly until the "
+             "request latency is above the threshold set (see -l).",
+             9)
       << std::endl;
-  std::cerr << "The -z flag causes input tensors to be initialized with zeros "
-               "instead of random data"
+
+  std::cerr << std::endl;
+  std::cerr << "II. INPUT DATA OPTIONS: " << std::endl;
+  std::cerr << std::setw(9) << std::left
+            << " -b: " << FormatMessage("Batch size for each request sent.", 9)
+            << std::endl;
+  std::cerr << FormatMessage(
+                   " --input-data: This option can be used to select data, "
+                   "client will use in it's inference requests. The available "
+                   "options are \"zero\", \"random\" or path to a directory. "
+                   "If the option is path to a directory then there must be a "
+                   "binary file for each input required by the model. The file "
+                   "must be named the same as the input and must contain data "
+                   "required for sending the input in a batch-1 request. The "
+                   "client will reuse the data to match the specified batch "
+                   "size. Note that the files should contain only the raw "
+                   "binary representation of the data in row major order. By "
+                   "default, the client will use random data in its requests.",
+                   18)
+            << std::endl;
+  std::cerr << FormatMessage(
+                   " --shape: The shape used for the specified input. The "
+                   "argument must be specified as 'name:shape' where the shape "
+                   "is a comma-separated list for dimension sizes, for example "
+                   "'--shape input_name:1,2,3'. --shape may be specified "
+                   "multiple times to specify shapes for different inputs.",
+                   18)
+            << std::endl;
+  std::cerr << FormatMessage(
+                   " --sequence-length: It indicates the base length of a "
+                   "sequence used for sequence models. A sequence with length "
+                   "x will be composed of x requests to be sent as the "
+                   "elements in the sequence. The length of the actual "
+                   "sequence will be within +/- 20% of the base length.",
+                   18)
+            << std::endl;
+  std::cerr << "\tDEPRECATED OPTIONS" << std::endl;
+  std::cerr << std::setw(9) << std::left << " -z: "
+            << FormatMessage(
+                   "This flag causes input tensors to be initialized with "
+                   "zeros instead of random data",
+                   9)
             << std::endl;
   std::cerr
-      << "For --sequence-length, it indicates the base length of a sequence"
-      << " used for sequence models. A sequence with length x will be composed"
-      << " of x requests to be sent as the elements in the sequence. The length"
-      << " of the actual sequence will be within +/- 20% of the base length."
+      << FormatMessage(
+             " --data-directory: It indicates that the perf client will use "
+             "user provided data instead of synthetic data for model inputs. "
+             "There must be a binary file for each input required by the "
+             "model. The file must be named the same as the input and must "
+             "contain data required for sending the input in a batch-1 "
+             "request. The perf client will reuse the data to match the "
+             "specified batch size. Note that the files should contain only "
+             "the raw binary representation of the data in row major order.",
+             18)
+      << std::endl;
+  std::cerr << std::endl;
+  std::cerr << "III. SERVER DETAILS: " << std::endl;
+  std::cerr << std::setw(9) << std::left << " -u: "
+            << FormatMessage(
+                   "This option is used to specify URL to the server. Default "
+                   "is \"localhost:8000\"",
+                   9)
+            << std::endl;
+  std::cerr
+      << std::setw(9) << std::left << " -i: "
+      << FormatMessage(
+             "This option indicates the communication protocol to use. The "
+             "available protocols are gRPC and HTTP. Default is HTTP.",
+             9)
+      << std::endl;
+  std::cerr << std::endl;
+  std::cerr << "IV. OTHER OPTIONS: " << std::endl;
+  std::cerr
+      << std::setw(9) << std::left << " -f: "
+      << FormatMessage(
+             "The observation report will be stored in the file pointed by "
+             "this option. By default, the result is not recorded in a file.",
+             9)
       << std::endl;
   std::cerr
-      << "For --percentile, it indicates that the specified percentile in terms"
-      << " of latency will also be reported and used to detemine if the"
-      << " measurement is stable instead of average latency."
-      << " Default is -1 to indicate no percentile will be used." << std::endl;
-  std::cerr << "For --shape, the shape used for the specified input. The"
-               " argument must be specified as 'name:shape' where the shape is"
-               " a comma-separated list for dimension sizes, for example"
-               " '--shape input_name:1,2,3'. --shape may be specified multiple"
-               " times to specify shapes for different inputs."
-            << std::endl;
+      << std::setw(9) << std::left << " -H: "
+      << FormatMessage(
+             "The header will be added to HTTP requests (ignored for GRPC "
+             "requests). The header must be specified as 'Header:Value'. -H "
+             "may be specified multiple times to add multiple headers.",
+             9)
+      << std::endl;
   std::cerr
-      << "For --data-directory, it indicates that the perf client will use user"
-      << " provided data instead of synthetic data for model inputs. There must"
-      << " be a binary file for each input required by the model."
-      << " The file must be named the same as the input and must contain data"
-      << " required for sending the input in a batch-1 request. The perf client"
-      << " will reuse the data to match the specified batch size."
-      << " Note that the files should contain only the raw binary"
-      << " representation of the data in row major order." << std::endl;
+      << FormatMessage(
+             " --streaming: Enables the use of streaming API. This flag is "
+             "only valid with gRPC protocol. By default, it is set false.",
+             18)
+      << std::endl;
+  std::cerr << std::setw(9) << std::left << " -a: "
+            << FormatMessage(
+                   "This flag is deprecated and will not affect client.", 9)
+            << std::endl;
 
   exit(1);
 }
+
+enum SEARCH_RANGE { kSTART = 0, kEND = 1, kSTEP = 2 };
+const uint64_t NO_LIMIT = 0;
 
 int
 main(int argc, char** argv)
 {
   bool verbose = false;
-  bool dynamic_concurrency_mode = false;
   bool streaming = false;
-  bool zero_input = false;
   size_t max_threads = 16;
   // average length of a sentence
   size_t sequence_length = 20;
   int32_t percentile = -1;
-  uint64_t latency_threshold_ms = 0;
+  uint64_t latency_threshold_ms = NO_LIMIT;
   int32_t batch_size = 1;
-  int32_t concurrent_request_count = 1;
-  size_t max_concurrency = 0;
+  uint64_t search_range[3] = {1, 1, 1};
   double stable_offset = 0.1;
-  uint64_t measurement_window_ms = 0;
+  uint64_t measurement_window_ms = 5000;
   size_t max_measurement_count = 10;
   std::string model_name;
   int64_t model_version = -1;
   std::string url("localhost:8000");
   std::string filename("");
-  std::string data_directory("");
   perfclient::ProtocolType protocol = perfclient::ProtocolType::HTTP;
   std::map<std::string, std::string> http_headers;
   std::unordered_map<std::string, std::vector<int64_t>> input_shapes;
+  std::string data_directory("");
+  bool zero_input = false;
+  int32_t concurrent_request_count = 1;
+  size_t max_concurrency = 0;
+  bool dynamic_concurrency_mode = false;
+
+  // Required for detecting the use of conflicting options
+  bool using_search_range = false;
+  bool using_old_options = false;
+
 
   // {name, has_arg, *flag, val}
   static struct option long_options[] = {{"streaming", 0, 0, 0},
@@ -403,6 +572,12 @@ main(int argc, char** argv)
                                          {"percentile", 1, 0, 3},
                                          {"data-directory", 1, 0, 4},
                                          {"shape", 1, 0, 5},
+                                         {"measurement-interval", 1, 0, 6},
+                                         {"search-range", 1, 0, 7},
+                                         {"latency-threshold", 1, 0, 8},
+                                         {"stability-offset", 1, 0, 9},
+                                         {"max-trials", 1, 0, 10},
+                                         {"input-data", 1, 0, 11},
                                          {0, 0, 0, 0}};
 
   // Parse commandline...
@@ -427,6 +602,7 @@ main(int argc, char** argv)
         data_directory = optarg;
         break;
       case 5: {
+        using_search_range = true;
         std::string arg = optarg;
         std::string name = arg.substr(0, arg.rfind(":"));
         std::string shape_str = arg.substr(name.size() + 1);
@@ -455,6 +631,64 @@ main(int argc, char** argv)
         input_shapes[name] = shape;
         break;
       }
+      case 6: {
+        measurement_window_ms = std::atoi(optarg);
+        break;
+      }
+      case 7: {
+        std::string arg = optarg;
+        size_t pos = 0;
+        int index = 0;
+        try {
+          while (pos != std::string::npos) {
+            size_t colon_pos = arg.find(":", pos);
+            if (index > 2) {
+              Usage(
+                  argv,
+                  "option search-range can have maximum of three elements");
+            }
+            if (colon_pos == std::string::npos) {
+              search_range[index] = std::stoll(arg.substr(pos, colon_pos));
+              pos = colon_pos;
+            } else {
+              search_range[index] =
+                  std::stoll(arg.substr(pos, colon_pos - pos));
+              pos = colon_pos + 1;
+              index++;
+            }
+          }
+        }
+        catch (const std::invalid_argument& ia) {
+          Usage(argv, "failed to parse search range: " + std::string(optarg));
+        }
+        break;
+      }
+      case 8: {
+        latency_threshold_ms = std::atoi(optarg);
+        break;
+      }
+      case 9: {
+        stable_offset = atof(optarg) / 100;
+        break;
+      }
+      case 10: {
+        max_measurement_count = std::atoi(optarg);
+        break;
+      }
+      case 11: {
+        std::string arg = optarg;
+        // Check whether the argument is a directory
+        if (perfclient::IsDirectory(arg)) {
+          data_directory = optarg;
+        } else if (arg.compare("zero") == 0) {
+          zero_input = true;
+        } else if (arg.compare("random") == 0) {
+          break;
+        } else {
+          Usage(argv, "unsupported input data provided " + std::string(optarg));
+        }
+        break;
+      }
       case 'v':
         verbose = true;
         break;
@@ -462,6 +696,7 @@ main(int argc, char** argv)
         zero_input = true;
         break;
       case 'd':
+        using_old_options = true;
         dynamic_concurrency_mode = true;
         break;
       case 'u':
@@ -477,6 +712,7 @@ main(int argc, char** argv)
         batch_size = std::atoi(optarg);
         break;
       case 't':
+        using_old_options = true;
         concurrent_request_count = std::atoi(optarg);
         break;
       case 'p':
@@ -495,6 +731,7 @@ main(int argc, char** argv)
         latency_threshold_ms = std::atoi(optarg);
         break;
       case 'c':
+        using_old_options = true;
         max_concurrency = std::atoi(optarg);
         break;
       case 'r':
@@ -525,8 +762,8 @@ main(int argc, char** argv)
   if (measurement_window_ms <= 0) {
     Usage(argv, "measurement window must be > 0 in msec");
   }
-  if (concurrent_request_count <= 0) {
-    Usage(argv, "concurrent request count must be > 0");
+  if (search_range[SEARCH_RANGE::kSTART] <= 0 || concurrent_request_count < 0) {
+    Usage(argv, "The start of the search range must be > 0");
   }
   if (protocol == perfclient::ProtocolType::UNKNOWN) {
     Usage(argv, "protocol should be either HTTP or gRPC");
@@ -553,6 +790,24 @@ main(int argc, char** argv)
   }
   if (zero_input && !data_directory.empty()) {
     Usage(argv, "zero input can't be set when data directory is provided");
+  }
+
+
+  if (using_search_range && using_old_options) {
+    Usage(argv, "can not use deprecated options with search_range");
+  } else if (using_old_options) {
+    if (dynamic_concurrency_mode) {
+      search_range[SEARCH_RANGE::kEND] = max_concurrency;
+    }
+    search_range[SEARCH_RANGE::kSTART] = concurrent_request_count;
+  }
+
+  if (search_range[SEARCH_RANGE::kEND] == NO_LIMIT &&
+      latency_threshold_ms == NO_LIMIT) {
+    Usage(
+        argv,
+        "The end of the search range and the latency limit can not be both 0 "
+        "simultaneously");
   }
 
   // trap SIGINT to allow threads to exit gracefully
@@ -589,11 +844,14 @@ main(int argc, char** argv)
             << "  Batch size: " << batch_size << std::endl
             << "  Measurement window: " << measurement_window_ms << " msec"
             << std::endl;
-  if (dynamic_concurrency_mode) {
+  if (search_range[SEARCH_RANGE::kEND] != 1) {
     std::cout << "  Latency limit: " << latency_threshold_ms << " msec"
               << std::endl;
-    if (max_concurrency != 0) {
-      std::cout << "  Concurrency limit: " << max_concurrency
+    if (search_range[SEARCH_RANGE::kEND] != NO_LIMIT) {
+      std::cout << "  Concurrency limit: "
+                << std::max(
+                       search_range[SEARCH_RANGE::kSTART],
+                       search_range[SEARCH_RANGE::kEND])
                 << " concurrent requests" << std::endl;
     }
   }
@@ -608,22 +866,14 @@ main(int argc, char** argv)
   perfclient::PerfStatus status_summary;
   std::vector<perfclient::PerfStatus> summary;
 
-  if (!dynamic_concurrency_mode) {
-    err = profiler->Profile(concurrent_request_count, status_summary);
+  size_t count = search_range[SEARCH_RANGE::kSTART];
+  do {
+    err = profiler->Profile(count, status_summary);
     if (err.IsOk()) {
       err = perfclient::Report(
-          status_summary, concurrent_request_count, percentile, protocol,
-          verbose);
+          status_summary, count, percentile, protocol, verbose);
       summary.push_back(status_summary);
-    }
-  } else {
-    for (size_t count = concurrent_request_count;
-         (count <= max_concurrency) || (max_concurrency == 0); count++) {
-      err = profiler->Profile(count, status_summary);
-      if (err.IsOk()) {
-        err = perfclient::Report(
-            status_summary, count, percentile, protocol, verbose);
-        summary.push_back(status_summary);
+      if (latency_threshold_ms != NO_LIMIT) {
         uint64_t stabilizing_latency_ms =
             status_summary.stabilizing_latency_ns / (1000 * 1000);
         if (!err.IsOk()) {
@@ -635,11 +885,14 @@ main(int argc, char** argv)
                     << latency_threshold_ms << " msec. " << std::endl;
           break;
         }
-      } else {
-        break;
       }
+    } else {
+      break;
     }
-  }
+    count += search_range[SEARCH_RANGE::kSTEP];
+  } while ((count <= search_range[SEARCH_RANGE::kEND]) ||
+           (search_range[SEARCH_RANGE::kEND] == NO_LIMIT));
+
 
   if (!err.IsOk()) {
     std::cerr << err << std::endl;

--- a/src/clients/c++/perf_client/perf_utils.cc
+++ b/src/clients/c++/perf_client/perf_utils.cc
@@ -75,4 +75,16 @@ ReadFile(const std::string& path, std::vector<char>* contents)
   return nic::Error::Success;
 }
 
+
+bool
+IsDirectory(const std::string& path)
+{
+  struct stat s;
+  if (stat(path.c_str(), &s) == 0 && (s.st_mode & S_IFDIR)) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
 }  // namespace perfclient

--- a/src/clients/c++/perf_client/perf_utils.h
+++ b/src/clients/c++/perf_client/perf_utils.h
@@ -30,6 +30,7 @@
 #include <iomanip>
 #include <iostream>
 
+#include <sys/stat.h>
 #include "src/clients/c++/library/request_grpc.h"
 #include "src/clients/c++/library/request_http.h"
 #include "src/core/constants.h"
@@ -74,5 +75,8 @@ ProtocolType ParseProtocol(const std::string& str);
 // \return error status. Returns Non-Ok if an error is encountered during
 //  read operation.
 nic::Error ReadFile(const std::string& path, std::vector<char>* contents);
+
+// To check whether the path points to a valid system directory
+bool IsDirectory(const std::string& path);
 
 }  // namespace perfclient


### PR DESCRIPTION
The usage message will look like:
[Note: pasting here removed some indentation in the message]

> 
> Usage: ../install/bin/perf_client [options]
> ==== SYNOPSIS ====
>  
> 	-m <model name>
> 	-x <model version>
> 	-v
> 
> I. MEASUREMENT PARAMETERS: 
> 	--measurement-interval (-p) <measurement window (in msec)>
> 	--concurrency-range <start:end:step>
> 	--latency-threshold (-l) <latency threshold (in msec)>
> 	--max-threads <thread counts>
> 	--stability-percentage (-s) <deviation threshold for stable measurement (in percentage)>
> 	--max-trials (-r)  <maximum number of measurements for each profiling>
> 	--percentile <percentile>
> 	DEPRECATED OPTIONS
> 	-t <number of concurrent requests>
> 	-c <maximum concurrency>
> 	-d
> 	-a
> 
> II. INPUT DATA OPTIONS: 
> 	-b <batch size>
> 	--input-data <"zero"|"random"|<path>>
> 	--shape <name:shape>
> 	--sequence-length <length>
> 	DEPRECATED OPTIONS
> 	-z
> 	--data-directory <path>
> 
> III. SERVER DETAILS: 
> 	-u <URL for inference service>
> 	-i <Protocol used to communicate with inference service>
> 
> IV. OTHER OPTIONS: 
> 	-f <filename for storing report in csv format>
> 	-H <HTTP header>
> 	--streaming
> 
> ==== OPTIONS ==== 
>  
>  -m:     This is a required argument and is used to specify the model against
> 	 which to run perf_client.
>  -x:     The version of the above model to be used. If not specified the most
> 	 recent version (that is, the highest numbered version) of the model
> 	 will be used.
>  -v:     Enables the verbose mode.
> 
> I. MEASUREMENT PARAMETERS: 
>  --measurement-interval (-p): Indicates the time interval used for each
> 	 measurement in milliseconds. The perf client will sample a time interval
> 	 specified by -p and take measurement over the requests completed
> 	 within that time interval. The default value is 5000 msec.
>  --concurrency-range <start:end:step>: Determines the range of concurrency
> 	 levels covered by the perf_client. The perf_client will start from the
> 	 concurrency level of 'start' and go till 'end' with a stride of
> 	 'step'. The default value of 'end' and 'step' are 1. If 'end' is not
> 	 specified then perf_client will run for a single concurrency level
> 	 determined by 'start'. If 'end' is set as 0, then the concurrency limit
> 	 will be incremented by 'step' till latency threshold is met. 'end'
> 	 and --latency-threshold can not be both 0 simultaneously.
>  --latency-threshold (-l): Sets the limit on the observed latency. Client will
> 	 terminate the concurrency search once the measured latency exceeds
> 	 this threshold. By default, latency threshold is set 0 and the
> 	 perf_client will run for entire --concurrency-range.
>  --max-threads: Sets the maximum number of threads that will be created for
> 	 providing desired concurrency. Default is 16.
>  --stability-percentage (-s): Indicates the allowed variation in latency
> 	 measurements when determining if a result is stable. The measurement is
> 	 considered as stable if the recent 3 measurements are within +/-
> 	 (stability percentage)% of their average in terms of both infer per
> 	 second and latency. Default is 10(%).
>  --max-trials (-r): Indicates the maximum number of measurements for each
> 	 concurrency level visited during search. The perf client will take
> 	 multiple measurements and report the measurement until it is stable. The
> 	 perf client will abort if the measurement is still unstable after
> 	 the maximum number of measurements. The default value is 10.
>  --percentile: Indicates the confidence value as a percentile that will be
> 	 used to determine if a measurement is stable. For example, a value of
> 	 85 indicates that the 85th percentile latency will be used to
> 	 determine stability. The percentile will also be reported in the results.
> 	 The default is -1 indicating that the average latency is used to
> 	 determine stability
> 
> II. INPUT DATA OPTIONS: 
>  -b:     Batch size for each request sent.
>  --input-data: Select the type of data that will be used for input in
> 	 inference requests. The available options are "zero", "random" or path to a
> 	 directory. If the option is path to a directory then the directory
> 	 must contain a binary file for each input, named the same as the
> 	 input. Each file must contain the data required for that input for a
> 	 batch-1 request. Each file should contain the raw binary representation
> 	 of the input in row-major order. Default is "random".
>  --shape: The shape used for the specified input. The argument must be
> 	 specified as 'name:shape' where the shape is a comma-separated list for
> 	 dimension sizes, for example '--shape input_name:1,2,3' indicate tensor
> 	 shape [ 1, 2, 3 ]. --shape may be specified multiple times to
> 	 specify shapes for different inputs.
>  --sequence-length: Indicates the base length of a sequence used for sequence
> 	 models. A sequence with length x will be composed of x requests to
> 	 be sent as the elements in the sequence. The length of the actual
> 	 sequence will be within +/- 20% of the base length.
> 
> III. SERVER DETAILS: 
>  -u:     Specify URL to the server. Default is "localhost:8000" if using HTTP
> 	 and "localhost:8001" if using gRPC. 
>  -i:     The communication protocol to use. The available protocols are gRPC
> 	 and HTTP. Default is HTTP.
> 
> IV. OTHER OPTIONS: 
>  -f:     The latency report will be stored in the file named by this option.
> 	 By default, the result is not recorded in a file.
>  -H:     The header will be added to HTTP requests (ignored for GRPC
> 	 requests). The header must be specified as 'Header:Value'. -H may be
> 	 specified multiple times to add multiple headers.
>  --streaming: Enables the use of streaming API. This flag is only valid with
> 	 gRPC protocol. By default, it is set false.