### PR TITLE
Proper fix for HTTP client performance

### DIFF
--- a/src/servers/http_server.cc
+++ b/src/servers/http_server.cc
@@ -80,6 +80,7 @@ HTTPServerImpl::Start()
   if (!worker_.joinable()) {
     evbase_ = event_base_new();
     htp_ = evhtp_new(evbase_, NULL);
+    evhtp_enable_flag(htp_, EVHTP_FLAG_ENABLE_NODELAY);
     evhtp_set_gencb(htp_, HTTPServerImpl::Dispatch, this);
     evhtp_use_threads_wexit(htp_, NULL, NULL, thread_cnt_, NULL);
     evhtp_bind_socket(htp_, "0.0.0.0", port_, 1024);


### PR DESCRIPTION
This change replaces 97edcd5e4659851661d9e2dbd2af7b0ae7928816.  Use
curl_easy_reset with the aync run. Fix the server so that it disables
Nagle's so that long delays are not introduced in the response.