### PR TITLE
Fix string serialization to tensor to allow null characters

### DIFF
--- a/src/backends/tensorflow/base_backend.cc
+++ b/src/backends/tensorflow/base_backend.cc
@@ -377,7 +377,7 @@ void
 FillStringTensor(TRTISTF_Tensor* tensor, const size_t idx, const size_t cnt)
 {
   for (size_t c = 0; c < cnt; ++c) {
-    TRTISTF_TensorSetString(tensor, idx + c, nullptr);
+    TRTISTF_TensorSetString(tensor, idx + c, nullptr, 0);
   }
 }
 
@@ -609,7 +609,7 @@ BaseBackend::Context::SetStringInputTensor(
       content_byte_size -= len;
 
       TRTISTF_TensorSetString(
-          tensor, tensor_element_idx + element_idx, str.c_str());
+          tensor, tensor_element_idx + element_idx, str.c_str(), len);
       element_idx++;
     }
 

--- a/src/backends/tensorflow/base_backend.cc
+++ b/src/backends/tensorflow/base_backend.cc
@@ -604,12 +604,10 @@ BaseBackend::Context::SetStringInputTensor(
         break;
       }
 
-      std::string str(content, len);
+      TRTISTF_TensorSetString(
+          tensor, tensor_element_idx + element_idx, content, len);
       content += len;
       content_byte_size -= len;
-
-      TRTISTF_TensorSetString(
-          tensor, tensor_element_idx + element_idx, str.c_str(), len);
       element_idx++;
     }
 

--- a/src/backends/tensorflow/tensorflow_backend_tf.cc
+++ b/src/backends/tensorflow/tensorflow_backend_tf.cc
@@ -631,12 +631,13 @@ TRTISTF_TensorString(TRTISTF_Tensor* tensor, size_t idx)
 }
 
 void
-TRTISTF_TensorSetString(TRTISTF_Tensor* tensor, size_t idx, const char* cstr)
+TRTISTF_TensorSetString(
+    TRTISTF_Tensor* tensor, size_t idx, const char* cstr, size_t length)
 {
   TensorImpl* t = reinterpret_cast<TensorImpl*>(tensor);
   std::string str;
   if (cstr != nullptr) {
-    str = cstr;
+    str = std::string(cstr, length);
   }
 
   t->SetString(idx, str);

--- a/src/backends/tensorflow/tensorflow_backend_tf.h
+++ b/src/backends/tensorflow/tensorflow_backend_tf.h
@@ -194,9 +194,10 @@ TRTISTF_EXPORT const char* TRTISTF_TensorString(
 // string type.. bad things might happen if called for non-string type
 // tensor. The provided string is copied by the tensor so the caller
 // retains ownership of 'str'. 'str' may be NULL to indicate that the
-// string should be set to empty.
+// string should be set to empty. 'length' denotes the size of the
+// character sequence to copy into the string within the tensor.
 TRTISTF_EXPORT void TRTISTF_TensorSetString(
-    TRTISTF_Tensor* tensor, size_t idx, const char* str);
+    TRTISTF_Tensor* tensor, size_t idx, const char* str, size_t length);
 
 //
 // Model


### PR DESCRIPTION
Fixes the TRTISTF_TensorSetString function to also use string length to include intermediate null characters.
PS: This does not have any test coverage Should I add the same.