### PR TITLE
Feature/cmake minor improvements

### DIFF
--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -29,6 +29,7 @@ project (tensorrt-inference-server)
 
 include(CMakeDependentOption)
 include(ExternalProject)
+include(GNUInstallDirs)
 
 # Backends
 option(TRTIS_ENABLE_TENSORRT "Include TensorRT backend in server" OFF)
@@ -110,14 +111,6 @@ ExternalProject_Add(protobuf
   DEPENDS grpc-repo
 )
 
-# Location where protobuf-config.cmake will be installed varies by
-# platform
-if (WIN32)
-  set(_FINDPACKAGE_PROTOBUF_CONFIG_DIR "${CMAKE_CURRENT_BINARY_DIR}/protobuf/cmake")
-else()
-  set(_FINDPACKAGE_PROTOBUF_CONFIG_DIR "${CMAKE_CURRENT_BINARY_DIR}/protobuf/lib/cmake/protobuf")
-endif()
-
 #
 # Build c-area project from grpc-repo
 #
@@ -146,7 +139,7 @@ ExternalProject_Add(grpc
     -DgRPC_BUILD_TESTS:BOOL=OFF
     -DgRPC_PROTOBUF_PROVIDER:STRING=package
     -DgRPC_PROTOBUF_PACKAGE_TYPE:STRING=CONFIG
-    -DProtobuf_DIR:PATH=${_FINDPACKAGE_PROTOBUF_CONFIG_DIR}
+    -DProtobuf_DIR:PATH=${CMAKE_CURRENT_BINARY_DIR}/protobuf/${CMAKE_INSTALL_LIBDIR}/cmake/protobuf
     -DgRPC_ZLIB_PROVIDER:STRING=package
     -DgRPC_CARES_PROVIDER:STRING=package
     -Dc-ares_DIR:PATH=${CMAKE_CURRENT_BINARY_DIR}/c-ares/lib/cmake/c-ares
@@ -254,7 +247,7 @@ set(GCS_CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH}
    ${CMAKE_CURRENT_BINARY_DIR}/c-ares/lib/cmake/c-ares
    ${CMAKE_CURRENT_BINARY_DIR}/grpc/lib/cmake/grpc
    ${CMAKE_CURRENT_BINARY_DIR}/crc32c/lib/cmake/Crc32c
-   ${_FINDPACKAGE_PROTOBUF_CONFIG_DIR})
+   ${CMAKE_CURRENT_BINARY_DIR}/protobuf/${CMAKE_INSTALL_LIBDIR}/cmake/protobuf)
 
 #
 # Build google-cloud-cpp
@@ -327,7 +320,7 @@ ExternalProject_Add(trtis-custom-backends
   BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/trtis-custom-backends"
   BUILD_ALWAYS 1
   CMAKE_CACHE_ARGS
-    -DProtobuf_DIR:PATH=${_FINDPACKAGE_PROTOBUF_CONFIG_DIR}
+    -DProtobuf_DIR:PATH=${CMAKE_CURRENT_BINARY_DIR}/protobuf/${CMAKE_INSTALL_LIBDIR}/cmake/protobuf
     -Dc-ares_DIR:PATH=${CMAKE_CURRENT_BINARY_DIR}/c-ares/lib/cmake/c-ares
     ${_CMAKE_ARGS_OPENSSL_ROOT_DIR}
     -DgRPC_DIR:PATH=${CMAKE_CURRENT_BINARY_DIR}/grpc/lib/cmake/grpc
@@ -347,14 +340,17 @@ else()
   set(TRTIS_CLIENTS_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
 endif()
 
+# version
+file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/../VERSION" TRTIS_VERSION)
+
 ExternalProject_Add(trtis-clients
   PREFIX trtis-clients
   SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/trtis-clients"
   BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/trtis-clients"
   BUILD_ALWAYS 1
   CMAKE_CACHE_ARGS
-    -DCURL_DIR:PATH=${CMAKE_CURRENT_BINARY_DIR}/curl/install/lib/cmake/CURL
-    -DProtobuf_DIR:PATH=${_FINDPACKAGE_PROTOBUF_CONFIG_DIR}
+    -DCURL_DIR:PATH=${CMAKE_CURRENT_BINARY_DIR}/curl/install/${CMAKE_INSTALL_LIBDIR}/cmake/CURL
+    -DProtobuf_DIR:PATH=${CMAKE_CURRENT_BINARY_DIR}/protobuf/${CMAKE_INSTALL_LIBDIR}/cmake/protobuf
     -Dc-ares_DIR:PATH=${CMAKE_CURRENT_BINARY_DIR}/c-ares/lib/cmake/c-ares
     ${_CMAKE_ARGS_OPENSSL_ROOT_DIR}
     -DgRPC_DIR:PATH=${CMAKE_CURRENT_BINARY_DIR}/grpc/lib/cmake/grpc
@@ -362,6 +358,7 @@ ExternalProject_Add(trtis-clients
     -DCMAKE_BUILD_TYPE:BOOL=${CMAKE_BUILD_TYPE}
     -DTRTIS_ENABLE_GPU:BOOL=${TRTIS_ENABLE_GPU}
     -DCMAKE_INSTALL_PREFIX:PATH=${TRTIS_CLIENTS_INSTALL_PREFIX}
+    -DTRTIS_VERSION:STRING=${TRTIS_VERSION}
   DEPENDS curl protobuf grpc
 )
 
@@ -397,7 +394,7 @@ ExternalProject_Add(trtis
   BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/trtis"
   BUILD_ALWAYS 1
   CMAKE_CACHE_ARGS
-    -DProtobuf_DIR:PATH=${_FINDPACKAGE_PROTOBUF_CONFIG_DIR}
+    -DProtobuf_DIR:PATH=${CMAKE_CURRENT_BINARY_DIR}/protobuf/${CMAKE_INSTALL_LIBDIR}/cmake/protobuf
     -Dc-ares_DIR:PATH=${CMAKE_CURRENT_BINARY_DIR}/c-ares/lib/cmake/c-ares
     ${_CMAKE_ARGS_OPENSSL_ROOT_DIR}
     -DgRPC_DIR:PATH=${CMAKE_CURRENT_BINARY_DIR}/grpc/lib/cmake/grpc

--- a/src/clients/c++/examples/CMakeLists.txt
+++ b/src/clients/c++/examples/CMakeLists.txt
@@ -60,7 +60,7 @@ install(
 add_executable(ensemble_image_client ensemble_image_client.cc)
 target_link_libraries(
   ensemble_image_client
-  PRIVATE request_static
+  PRIVATE TRTIS::request_static
 )
 install(
   TARGETS ensemble_image_client
@@ -75,7 +75,7 @@ add_executable(image_client image_client.cc)
 target_include_directories(image_client PRIVATE ${OpenCV_INCLUDE_DIRS})
 target_link_libraries(
   image_client
-  PRIVATE request_static
+  PRIVATE TRTIS::request_static
   PRIVATE ${OpenCV_LIBS}
 )
 install(
@@ -89,7 +89,7 @@ install(
 add_executable(simple_callback_client simple_callback_client.cc)
 target_link_libraries(
   simple_callback_client
-  PRIVATE request_static
+  PRIVATE TRTIS::request_static
 )
 install(
   TARGETS simple_callback_client
@@ -105,7 +105,7 @@ add_executable(
 )
 target_link_libraries(
   simple_client
-  PRIVATE request_static
+  PRIVATE TRTIS::request_static
 )
 install(
   TARGETS simple_client
@@ -123,7 +123,7 @@ install(
 add_executable(simple_shm_client simple_shm_client.cc)
 target_link_libraries(
   simple_shm_client
-  PRIVATE request_static
+  PRIVATE TRTIS::request_static
   rt
 )
 install(
@@ -137,7 +137,7 @@ install(
 add_executable(simple_sequence_client simple_sequence_client.cc)
 target_link_libraries(
   simple_sequence_client
-  PRIVATE request_static
+  PRIVATE TRTIS::request_static
 )
 install(
   TARGETS simple_sequence_client
@@ -151,7 +151,7 @@ install(
 add_executable(simple_string_client simple_string_client.cc)
 target_link_libraries(
   simple_string_client
-  PRIVATE request_static
+  PRIVATE TRTIS::request_static
 )
 install(
   TARGETS simple_string_client
@@ -164,7 +164,7 @@ install(
 add_executable(simple_perf_client simple_perf_client.cc)
 target_link_libraries(
   simple_perf_client
-  PRIVATE request_static
+  PRIVATE TRTIS::request_static
 )
 install(
   TARGETS simple_perf_client

--- a/src/clients/c++/library/CMakeLists.txt
+++ b/src/clients/c++/library/CMakeLists.txt
@@ -26,12 +26,13 @@
 
 cmake_minimum_required (VERSION 3.5)
 
-
 #
 # librequest.so and librequest_static.a
 #
 find_package(CURL CONFIG REQUIRED)
 message(STATUS "Using curl ${CURL_VERSION}")
+
+find_package(Threads REQUIRED)
 
 configure_file(librequest.ldscript librequest.ldscript COPYONLY)
 
@@ -80,22 +81,29 @@ add_library(
   $<TARGET_OBJECTS:proto-library>
   $<TARGET_OBJECTS:request-library>
 )
+add_library(
+  TRTIS::request_static ALIAS request_static
+)
+
 if(${TRTIS_ENABLE_GPU})
   target_include_directories(request_static PRIVATE ${CUDA_INCLUDE_DIRS})
 endif() # TRTIS_ENABLE_GPU
+
+target_include_directories(
+  request_static
+  PUBLIC
+    $<INSTALL_INTERFACE:include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/flat_include>
+)
 target_link_libraries(
   request_static
   PRIVATE gRPC::grpc++
   PRIVATE gRPC::grpc
   PRIVATE CURL::libcurl
   PUBLIC protobuf::libprotobuf
+  PUBLIC Threads::Threads
 )
-if(NOT WIN32)
-  target_link_libraries(
-    request_static
-    PUBLIC -lpthread
-  )
-endif()
 
 # librequest.so
 add_library(
@@ -105,13 +113,20 @@ add_library(
   $<TARGET_OBJECTS:proto-library>
   $<TARGET_OBJECTS:request-library>
 )
-set_target_properties(
-  request
-  PROPERTIES LINK_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/librequest.ldscript
+add_library(
+  TRTIS::request ALIAS request
 )
 set_target_properties(
   request
-  PROPERTIES LINK_FLAGS "-Wl,--version-script=librequest.ldscript"
+  PROPERTIES
+    LINK_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/librequest.ldscript
+    LINK_FLAGS "-Wl,--version-script=librequest.ldscript"
+)
+target_include_directories (request
+  PUBLIC
+    $<INSTALL_INTERFACE:include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/flat_include>
 )
 target_link_libraries(
   request
@@ -119,20 +134,15 @@ target_link_libraries(
   PRIVATE gRPC::grpc
   PRIVATE CURL::libcurl
   PUBLIC protobuf::libprotobuf
+  PUBLIC Threads::Threads
 )
-if(NOT WIN32)
-  target_link_libraries(
-    request
-    PUBLIC -lpthread
-  )
-endif()
 
 install(
-  TARGETS request
+  TARGETS
+    request
+    request_static
+  EXPORT trtis-export
   LIBRARY DESTINATION lib
-)
-install(
-  TARGETS request_static
   ARCHIVE DESTINATION lib
 )
 install(
@@ -150,3 +160,30 @@ install(
     ${CMAKE_CURRENT_BINARY_DIR}/../../../core/server_status.pb.h
   DESTINATION include
 )
+
+# cmake configuration
+include (CMakePackageConfigHelpers)
+set (_LIB_CMAKE_DIR lib/cmake/TRTIS)
+install(
+  EXPORT trtis-export
+  FILE TRTISTargets.cmake
+  NAMESPACE TRTIS::
+  DESTINATION ${_LIB_CMAKE_DIR}
+)
+write_basic_package_version_file(
+  ${CMAKE_CURRENT_BINARY_DIR}/TRTISConfigVersion.cmake
+  VERSION ${TRTIS_VERSION}
+  COMPATIBILITY ExactVersion
+)
+configure_package_config_file (
+  ${CMAKE_CURRENT_LIST_DIR}/cmake/TRTISConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/TRTISConfig.cmake
+  INSTALL_DESTINATION ${_LIB_CMAKE_DIR}
+)
+install(
+  FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/TRTISConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/TRTISConfigVersion.cmake
+  DESTINATION ${_LIB_CMAKE_DIR}
+)
+

--- a/src/clients/c++/library/cmake/TRTISConfig.cmake.in
+++ b/src/clients/c++/library/cmake/TRTISConfig.cmake.in
@@ -24,64 +24,28 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-cmake_minimum_required (VERSION 3.5)
+# specific version required for protobuf
+if(NOT PROTOBUF_FOUND AND NOT Protobuf_FOUND)
+  find_package(Protobuf @Protobuf_VERSION@ CONFIG REQUIRED)
+endif()
 
-#
-# Dependencies
-#
+if(NOT c-ares_FOUND)
+  find_package(c-ares CONFIG REQUIRED)
+endif()
 
-# Protobuf
-set(protobuf_MODULE_COMPATIBLE TRUE CACHE BOOL "protobuf_MODULE_COMPATIBLE" FORCE)
-find_package(Protobuf CONFIG REQUIRED)
-message(STATUS "Using protobuf ${Protobuf_VERSION}")
-include_directories(${Protobuf_INCLUDE_DIRS})
+if(NOT CURL_FOUND)
+  find_package(CURL REQUIRED)
+endif()
 
-# GRPC
-find_package(gRPC CONFIG REQUIRED)
-message(STATUS "Using gRPC ${gRPC_VERSION}")
-include_directories($<TARGET_PROPERTY:gRPC::grpc,INTERFACE_INCLUDE_DIRECTORIES>)
+# specific version required for grpc
+if(NOT GRPC_FOUND AND NOT gRPC_FOUND)
+  find_package(gRPC @gRPC_VERSION@ CONFIG REQUIRED)
+endif()
 
-# Curl
-find_package(CURL CONFIG REQUIRED)
-message(STATUS "Using curl ${CURL_VERSION}")
+if(NOT Threads_FOUND)
+  find_package(Threads REQUIRED)
+endif()
 
-#
-# Example applications
-#
-include_directories("${PROJECT_SOURCE_DIR}/../../../include")
-
-# simple_client using static library, librequest_static.a
-add_executable(
-  simple_client_static
-  ${PROJECT_SOURCE_DIR}/../../simple_client.cc
-)
-target_link_libraries(
-  simple_client_static
-  PRIVATE -L${PROJECT_SOURCE_DIR}/../../../lib
-  PRIVATE TRTIS::request_static
-  PRIVATE gRPC::grpc++
-  PRIVATE gRPC::grpc
-  PRIVATE CURL::libcurl
-  PUBLIC protobuf::libprotobuf
-)
-install(
-  TARGETS simple_client_static
-  RUNTIME DESTINATION bin
-)
-
-# simple_client using shared library, librequest.so
-add_executable(
-  simple_client_shared
-  ${PROJECT_SOURCE_DIR}/../../simple_client.cc
-)
-target_link_libraries(
-  simple_client_shared
-  PRIVATE -L${PROJECT_SOURCE_DIR}/../../../lib
-  PRIVATE TRTIS::request
-  PUBLIC protobuf::libprotobuf
-)
-install(
-  TARGETS simple_client_shared
-  RUNTIME DESTINATION bin
-)
-
+if (NOT (TARGET TRTIS::request))
+  include ("${CMAKE_CURRENT_LIST_DIR}/TRTISTargets.cmake")
+endif ()

--- a/src/clients/c++/perf_client/CMakeLists.txt
+++ b/src/clients/c++/perf_client/CMakeLists.txt
@@ -47,7 +47,7 @@ add_executable(perf_client
   ${PERF_CLIENT_SRCS} ${PERF_CLIENT_HDRS})
 target_link_libraries(
   perf_client
-  PRIVATE request_static
+  PRIVATE TRTIS::request_static
 )
 install(
   TARGETS perf_client

--- a/src/clients/python/CMakeLists.txt
+++ b/src/clients/python/CMakeLists.txt
@@ -32,7 +32,7 @@ cmake_minimum_required (VERSION 3.5)
 add_library(crequest SHARED crequest.cc)
 target_link_libraries(
   crequest
-  PUBLIC request
+  PUBLIC TRTIS::request
 )
 
 if(NOT WIN32)


### PR DESCRIPTION
Some minor improvements and additions to the cmake build are made in 2 commits.

The first one is quite the small change: use Threads::Threads instead of relying on the if(NOT WIN32) check. This does the right thing behind the scenes and makes the CMake code the same on both WIN32 and Linux. Also, use the GNUInstallDirs from CMake to provide certain packages that also use it with the proper library directory on certain distros (eg. Fedora/CentOS use lib64 instead of lib). Also these resolve to an empty string on windows, which was the case before as well.

Second, is a more complex change involving the addition of some cmake configuration files. First, added targets in the namespace Trtis:: (i.e. request, request_static).
There is a chance that someone might use it as a subdirectory in cmake. Also I find it useful only for the client as I doubt anything similar would be done with the server, but who knows? If you wish to do the same for that I will add another commit. There is also a TrtisVersion file being generated and it uses the VERSION file present in the repo. Please correct me if this is not the best approach

I could always split these in smaller chunks if you find it better. 