### PR TITLE
Use python-dev to satisfy Python package dependency

### DIFF
--- a/Dockerfile.QA
+++ b/Dockerfile.QA
@@ -202,7 +202,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
                               libopencv-dev \
                               libopencv-core-dev \
                               libzmq3-dev \
-                              python \
+                              python-dev \
                               python-protobuf \
                               swig && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
One of the nested dependencies "cffi" has a newer version 1.13 and now `pip install` will pick up this version. It requires "Python.h" file which can be obtained from `python-dev`