### PR TITLE
Fix libtorch output flattening for non-contiguous tensors

### DIFF
--- a/src/backends/pytorch/libtorch_backend.cc
+++ b/src/backends/pytorch/libtorch_backend.cc
@@ -468,7 +468,7 @@ LibTorchBackend::Context::GetOutputTensor(
     size_t* byte_size, std::vector<int64_t>* content_shape)
 {
   try {
-    torch::Tensor output_flat = (*outputs_)[op_index].flatten();
+    torch::Tensor output_flat = (*outputs_)[op_index].contiguous().flatten();
 
     // verify output datatype matches datatype from model config
     DataType rec_dtype = ConvertTorchTypeToDataType(output_flat.scalar_type());


### PR DESCRIPTION
It is possible that the model output can be non-contiguous. Flattening this may cause unexpected behavior as mentioned [here](https://pytorch.org/docs/stable/torch.html#torch.flatten). Thus we make the tensor contiguous before calling `flatten()`. 

