### PR TITLE
Support 'memory_type_id' along with 'memory_type'

### DIFF
--- a/src/backends/caffe2/netdef_backend.cc
+++ b/src/backends/caffe2/netdef_backend.cc
@@ -385,7 +385,7 @@ NetDefBackend::Context::SetFixedSizedInputTensor(
   }
 
   *cuda_copy |= SetInputBuffer(
-      name, expected_byte_sizes, payloads, TRTSERVER_MEMORY_CPU, buffer);
+      name, expected_byte_sizes, payloads, TRTSERVER_MEMORY_CPU, 0, buffer);
 
   Caffe2Workspace::Error err = workspace_->SetInputTensor(
       name, shape, dtype, static_cast<const char*>(buffer), total_byte_size);

--- a/src/backends/caffe2/netdef_backend.cc
+++ b/src/backends/caffe2/netdef_backend.cc
@@ -446,9 +446,10 @@ NetDefBackend::Context::ReadFixedSizedOutputTensor(
   //                                ? TRTSERVER_MEMORY_CPU
   //                                : TRTSERVER_MEMORY_GPU;
   auto content_memory_type = TRTSERVER_MEMORY_CPU;
+  int64_t memory_type_id = 0;
   *cuda_copy |= SetFixedSizeOutputBuffer(
       name, batch1_byte_size, content, content_shape, content_memory_type,
-      payloads);
+      memory_type_id, payloads);
   return Status::Success;
 }
 

--- a/src/backends/custom/custom.h
+++ b/src/backends/custom/custom.h
@@ -220,10 +220,13 @@ typedef bool (*CustomGetNextInputV2Fn_t)(
 /// \param memory_type Acts as both input and output. On input
 /// gives the buffer memory type preferred by the function caller.
 /// Returns the actual memory type of 'content'.
+/// \param memory_type_id Acts as both input and output. On input
+/// gives the buffer memory type id preferred by the function caller.
+/// Returns the actual memory type id of 'content'.
 typedef bool (*CustomGetOutputV2Fn_t)(
     void* output_context, const char* name, size_t shape_dim_cnt,
     int64_t* shape_dims, uint64_t content_byte_size, void** content,
-    CustomMemoryType* memory_type);
+    CustomMemoryType* memory_type, int64_t* memory_type_id);
 
 /// Type for the CustomExecuteV2 function.
 typedef int (*CustomExecuteV2Fn_t)(

--- a/src/backends/custom/custom.h
+++ b/src/backends/custom/custom.h
@@ -211,9 +211,13 @@ typedef int (*CustomExecuteFn_t)(
 /// \param memory_type Acts as both input and output. On input
 /// gives the buffer memory type preferred by the function caller.
 /// Returns the actual memory type of 'content'.
+/// \param memory_type_id Acts as both input and output. On input
+/// gives the buffer memory type id preferred by the function caller.
+/// Returns the actual memory type id of 'content'.
 typedef bool (*CustomGetNextInputV2Fn_t)(
     void* input_context, const char* name, const void** content,
-    uint64_t* content_byte_size, CustomMemoryType* memory_type);
+    uint64_t* content_byte_size, CustomMemoryType* memory_type,
+    int64_t* memory_type_id);
 
 /// See CustomGetOutputFn_t
 ///

--- a/src/backends/custom/custom_backend.cc
+++ b/src/backends/custom/custom_backend.cc
@@ -657,8 +657,11 @@ CustomGetOutput(
     void* output_context, const char* name, size_t shape_dim_cnt,
     int64_t* shape_dims, uint64_t content_byte_size, void** content)
 {
-  // [TODO] below assumption no longer hold, need to do internal buffering
-  // like for CustomGetNextInput()
+  // [TODO] below assumption no longer hold after
+  // https://github.com/NVIDIA/tensorrt-inference-server/pull/780,
+  // either to perform internal buffering like for CustomGetNextInput(),
+  // or to return error if actual type is not CPU.
+  // The former requires work on CustomBackend::Context::Run().
   // internally call V2 as CPU memory request is default option and will
   // always be permitted
   auto memory_type = CUSTOM_MEMORY_CPU;

--- a/src/backends/custom/custom_backend.h
+++ b/src/backends/custom/custom_backend.h
@@ -126,7 +126,7 @@ class CustomBackend : public InferenceBackend {
     bool GetOutput(
         GetInputOutputContext* output_context, const char* name,
         size_t shape_dim_cnt, int64_t* shape_dims, uint64_t content_byte_size,
-        void** content, CustomMemoryType* memory_type);
+        void** content, CustomMemoryType* memory_type, int64_t* memory_type_id);
 
     // The handle to the shared library associated with this context.
     void* library_handle_;
@@ -165,7 +165,7 @@ bool CustomGetOutput(
     int64_t* shape_dims, uint64_t content_byte_size, void** content);
 
 // See CustomGetNextInput, except that the block may not be in CPU memory.
-// Thus 'memory_type' Acts as both input and output. On input gives the buffer
+// Thus 'memory_type' acts as both input and output. On input gives the buffer
 // memory type preferred by the function caller. On output returns
 // the actual memory type of 'content'.
 bool CustomGetNextInputV2(
@@ -173,12 +173,13 @@ bool CustomGetNextInputV2(
     uint64_t* content_byte_size, CustomMemoryType* memory_type);
 
 // See CustomGetOutput, except that the buffer is not limited to be
-// in CPU memory. 'memory_type' Acts as both input and output. On input
+// in CPU memory. 'memory_type' acts as both input and output. On input
 // gives the buffer memory type preferred by the function caller. On output
-// returns the actual memory type of 'content'.
+// returns the actual memory type of 'content'. 'memory_type_id' also acts as
+// both input and output in the same fashion.
 bool CustomGetOutputV2(
     void* output_context, const char* name, size_t shape_dim_cnt,
     int64_t* shape_dims, uint64_t content_byte_size, void** content,
-    CustomMemoryType* memory_type);
+    CustomMemoryType* memory_type, int64_t* memory_type_id);
 
 }}  // namespace nvidia::inferenceserver

--- a/src/backends/custom/custom_backend.h
+++ b/src/backends/custom/custom_backend.h
@@ -71,7 +71,7 @@ class CustomBackend : public InferenceBackend {
       void*, const char*, const void**, uint64_t*, CustomMemoryType*);
   friend bool CustomGetOutputV2(
       void*, const char*, size_t, int64_t*, uint64_t, void**,
-      CustomMemoryType*);
+      CustomMemoryType*, int64_t*);
 
   // For each model instance there is a context.
   struct Context : BackendContext {

--- a/src/backends/custom/custom_backend.h
+++ b/src/backends/custom/custom_backend.h
@@ -168,7 +168,8 @@ bool CustomGetOutput(
 // Thus 'memory_type' acts as both input and output. On input gives the buffer
 // memory type preferred by the function caller. On output returns
 // the actual memory type of 'content'. 'memory_type_id' also acts as
-// both input and output in the same fashion.
+// both input and output. On input gives the buffer memory type id preferred by
+// the function caller. On output returns the actual memory type of 'content'.
 bool CustomGetNextInputV2(
     void* input_context, const char* name, const void** content,
     uint64_t* content_byte_size, CustomMemoryType* memory_type,
@@ -178,7 +179,8 @@ bool CustomGetNextInputV2(
 // in CPU memory. 'memory_type' acts as both input and output. On input
 // gives the buffer memory type preferred by the function caller. On output
 // returns the actual memory type of 'content'. 'memory_type_id' also acts as
-// both input and output in the same fashion.
+// both input and output. On input gives the buffer memory type id preferred by
+// the function caller. On output returns the actual memory type of 'content'.
 bool CustomGetOutputV2(
     void* output_context, const char* name, size_t shape_dim_cnt,
     int64_t* shape_dims, uint64_t content_byte_size, void** content,

--- a/src/backends/custom/custom_backend.h
+++ b/src/backends/custom/custom_backend.h
@@ -68,10 +68,10 @@ class CustomBackend : public InferenceBackend {
   friend bool CustomGetOutput(
       void*, const char*, size_t, int64_t*, uint64_t, void**);
   friend bool CustomGetNextInputV2(
-      void*, const char*, const void**, uint64_t*, CustomMemoryType*);
+      void*, const char*, const void**, uint64_t*, CustomMemoryType*, int64_t*);
   friend bool CustomGetOutputV2(
-      void*, const char*, size_t, int64_t*, uint64_t, void**,
-      CustomMemoryType*, int64_t*);
+      void*, const char*, size_t, int64_t*, uint64_t, void**, CustomMemoryType*,
+      int64_t*);
 
   // For each model instance there is a context.
   struct Context : BackendContext {
@@ -119,7 +119,7 @@ class CustomBackend : public InferenceBackend {
     bool GetNextInput(
         GetInputOutputContext* input_context, const char* name,
         const void** content, uint64_t* content_byte_size,
-        CustomMemoryType* memory_type);
+        CustomMemoryType* memory_type, int64_t* memory_type_id);
 
     // Callback used by custom backends to get the output buffer for a
     // 'name'd output tensor.
@@ -167,10 +167,12 @@ bool CustomGetOutput(
 // See CustomGetNextInput, except that the block may not be in CPU memory.
 // Thus 'memory_type' acts as both input and output. On input gives the buffer
 // memory type preferred by the function caller. On output returns
-// the actual memory type of 'content'.
+// the actual memory type of 'content'. 'memory_type_id' also acts as
+// both input and output in the same fashion.
 bool CustomGetNextInputV2(
     void* input_context, const char* name, const void** content,
-    uint64_t* content_byte_size, CustomMemoryType* memory_type);
+    uint64_t* content_byte_size, CustomMemoryType* memory_type,
+    int64_t* memory_type_id);
 
 // See CustomGetOutput, except that the buffer is not limited to be
 // in CPU memory. 'memory_type' acts as both input and output. On input

--- a/src/backends/onnx/onnx_backend.cc
+++ b/src/backends/onnx/onnx_backend.cc
@@ -663,7 +663,7 @@ OnnxBackend::Context::SetInputTensor(
 
   // Store data into input buffer
   SetInputBuffer(
-      name, expected_byte_sizes, payloads, TRTSERVER_MEMORY_CPU, buffer);
+      name, expected_byte_sizes, payloads, TRTSERVER_MEMORY_CPU, 0, buffer);
 
   if (data_type != TYPE_STRING) {
     const OrtMemoryInfo* allocator_info;

--- a/src/backends/onnx/onnx_backend.cc
+++ b/src/backends/onnx/onnx_backend.cc
@@ -222,11 +222,10 @@ OnnxBackend::CreateExecutionContext(
                .execution_accelerators()
                .gpu_execution_accelerator()) {
         if (execution_accelerator.name() == kTensorRTExecutionAccelerator) {
-          RETURN_IF_ORT_ERROR(
-              OrtSessionOptionsAppendExecutionProvider_Tensorrt(
-                  session_options, gpu_device));
+          RETURN_IF_ORT_ERROR(OrtSessionOptionsAppendExecutionProvider_Tensorrt(
+              session_options, gpu_device));
           LOG_VERBOSE(1) << "TensorRT Execution Accelerator is set for "
-                          << instance_name << " on device " << gpu_device;
+                         << instance_name << " on device " << gpu_device;
         } else {
           return Status(
               RequestStatusCode::INVALID_ARG,
@@ -253,9 +252,8 @@ OnnxBackend::CreateExecutionContext(
       if (execution_accelerator.name() == kOpenVINOExecutionAccelerator) {
 #ifdef TRTIS_ENABLE_ONNXRUNTIME_OPENVINO
         need_lock = true;
-        RETURN_IF_ORT_ERROR(
-            OrtSessionOptionsAppendExecutionProvider_OpenVINO(
-                session_options, "CPU"));
+        RETURN_IF_ORT_ERROR(OrtSessionOptionsAppendExecutionProvider_OpenVINO(
+            session_options, "CPU"));
         LOG_VERBOSE(1) << "OpenVINO Execution Accelerator is set for "
                        << instance_name << " on device CPU";
 #else
@@ -844,9 +842,10 @@ OnnxBackend::Context::ReadOutputTensors(
       // [TODO] currently ONNX output data are always on CPU
       // https://github.com/microsoft/onnxruntime/issues/1621
       auto content_memory_type = TRTSERVER_MEMORY_CPU;
+      int64_t memory_type_id = 0;
       cuda_copy |= SetFixedSizeOutputBuffer(
           name, batch1_byte_size, content, content_shape, content_memory_type,
-          payloads);
+          memory_type_id, payloads);
     }
   }
 

--- a/src/backends/pytorch/libtorch_backend.cc
+++ b/src/backends/pytorch/libtorch_backend.cc
@@ -552,8 +552,9 @@ LibTorchBackend::Context::SetFixedSizedInputBuffer(
   // entire dynamic batched input.
   auto memory_type = (gpu_device_ == NO_GPU_DEVICE) ? TRTSERVER_MEMORY_CPU
                                                     : TRTSERVER_MEMORY_GPU;
+  int64_t memory_type_id = (gpu_device_ == NO_GPU_DEVICE) ? 0 : gpu_device_;
   meta_data->input_buffer_.reset(
-      new AllocatedSystemMemory(total_byte_size, memory_type));
+      new AllocatedSystemMemory(total_byte_size, memory_type, memory_type_id));
   char* buffer = meta_data->input_buffer_->MutableBuffer(&memory_type);
 
   // Visit the payloads in order and copy the input tensors to 'buffer'.

--- a/src/backends/pytorch/libtorch_backend.cc
+++ b/src/backends/pytorch/libtorch_backend.cc
@@ -395,11 +395,10 @@ LibTorchBackend::Context::SetInputTensor(
       meta_data.input_buffer_->MutableBuffer(&memory_type, &memory_type_id);
 
   torch::TensorOptions options{meta_data.torch_type_};
-  auto updated_options = options.device(
-      (memory_type == TRTSERVER_MEMORY_CPU) ? torch::kCPU : torch::kCUDA);
+  auto updated_options = (memory_type == TRTSERVER_MEMORY_CPU) ?
+    options.device(torch::kCPU) : options.device(torch::kCUDA, memory_type_id);
   torch::Tensor input_tensor =
       torch::from_blob(buffer, meta_data.shape_, updated_options);
-  input_tensor = input_tensor.to(device_);
 
   if (input_tensor.nbytes() != total_byte_size) {
     return Status(

--- a/src/backends/pytorch/libtorch_backend.cc
+++ b/src/backends/pytorch/libtorch_backend.cc
@@ -454,9 +454,10 @@ LibTorchBackend::Context::ReadFixedSizedOutputTensor(
 
   auto content_memory_type =
       (device_ == torch::kCPU) ? TRTSERVER_MEMORY_CPU : TRTSERVER_MEMORY_GPU;
+  int64_t memory_type_id = (device_ == torch::kCPU) ? 0 : gpu_device_;
   *cuda_copy |= SetFixedSizeOutputBuffer(
       name, batch1_byte_size, (char*)content, content_shape,
-      content_memory_type, payloads);
+      content_memory_type, memory_type_id, payloads);
 
   return Status::Success;
 }

--- a/src/backends/tensorflow/base_backend.cc
+++ b/src/backends/tensorflow/base_backend.cc
@@ -664,9 +664,11 @@ BaseBackend::Context::ReadFixedSizedOutputTensor(
                                  : TRTSERVER_MEMORY_CPU;
   LOG_VERBOSE(1) << "output '" << output_name
                  << "' is GPU tensor: " << TRTISTF_TensorIsGPUTensor(tensor);
+  int64_t memory_type_id =
+      (TRTISTF_TensorIsGPUTensor(tensor)) ? gpu_device_ : 0;
   *cuda_copy |= SetFixedSizeOutputBuffer(
       output_name, batch1_byte_size, TRTISTF_TensorData(tensor), shape,
-      content_memory_type, payloads);
+      content_memory_type, memory_type_id, payloads);
 }
 
 Status

--- a/src/backends/tensorflow/base_backend.cc
+++ b/src/backends/tensorflow/base_backend.cc
@@ -538,10 +538,13 @@ BaseBackend::Context::SetFixedSizedInputTensor(
   auto content_memory_type = (TRTISTF_TensorIsGPUTensor(tensor))
                                  ? TRTSERVER_MEMORY_GPU
                                  : TRTSERVER_MEMORY_CPU;
+  int64_t content_memory_type_id =
+      (TRTISTF_TensorIsGPUTensor(tensor)) ? gpu_device_ : 0;
   LOG_VERBOSE(1) << "input '" << input_name
                  << "' is GPU tensor: " << TRTISTF_TensorIsGPUTensor(tensor);
   SetInputBuffer(
-      input_name, expected_byte_sizes, payloads, content_memory_type, buffer);
+      input_name, expected_byte_sizes, payloads, content_memory_type,
+      content_memory_type_id, buffer);
 }
 
 void
@@ -564,10 +567,12 @@ BaseBackend::Context::SetStringInputTensor(
     // For string data type, we always need to copy the data to CPU so that
     // we can read string length and construct the string properly.
     auto src_memory_type = TRTSERVER_MEMORY_CPU;
+    int64_t src_memory_type_id = 0;
     const void* vcontent;
     size_t content_byte_size = expected_element_cnt * sizeof(uint32_t);
     payload.status_ = payload.request_provider_->GetNextInputContent(
-        input_name, &vcontent, &content_byte_size, &src_memory_type, true);
+        input_name, &vcontent, &content_byte_size, &src_memory_type,
+        &src_memory_type_id, true);
 
     const char* content = reinterpret_cast<const char*>(vcontent);
 #ifdef TRTIS_ENABLE_GPU

--- a/src/backends/tensorrt/plan_backend.cc
+++ b/src/backends/tensorrt/plan_backend.cc
@@ -892,7 +892,7 @@ PlanBackend::Context::Run(std::vector<Scheduler::Payload>* payloads)
     }
 
     SetInputBuffer(
-        name, expected_byte_sizes, payloads, TRTSERVER_MEMORY_GPU,
+        name, expected_byte_sizes, payloads, TRTSERVER_MEMORY_GPU, gpu_device_,
         static_cast<char*>(buffers_[binding_offset_ + bindex]));
 
     // Set the binding dimension so that output dimensions can be obtained

--- a/src/backends/tensorrt/plan_backend.cc
+++ b/src/backends/tensorrt/plan_backend.cc
@@ -1018,7 +1018,7 @@ PlanBackend::Context::Run(std::vector<Scheduler::Payload>* payloads)
     cuda_copy |= SetFixedSizeOutputBuffer(
         name, batch1_byte_size,
         static_cast<char*>(buffers_[binding_offset_ + bindex]), shape,
-        TRTSERVER_MEMORY_GPU /* src_memory_type */, payloads);
+        TRTSERVER_MEMORY_GPU /* src_memory_type */, gpu_device_, payloads);
   }
 
   // Wait for the copy-out to complete

--- a/src/core/backend_context.cc
+++ b/src/core/backend_context.cc
@@ -80,7 +80,8 @@ bool
 BackendContext::SetInputBuffer(
     const std::string& name, const std::vector<size_t>& expected_byte_sizes,
     std::vector<Scheduler::Payload>* payloads,
-    TRTSERVER_Memory_Type dst_memory_type, char* input_buffer)
+    TRTSERVER_Memory_Type dst_memory_type, int64_t dst_memory_type_id,
+    char* input_buffer)
 {
   bool cuda_copy = false;
   // Visit the payloads in order and copy the input tensors to
@@ -93,10 +94,12 @@ BackendContext::SetInputBuffer(
     size_t copied_byte_size = 0;
     while (payload.status_.IsOk()) {
       auto src_memory_type = dst_memory_type;
+      auto src_memory_type_id = dst_memory_type_id;
       const void* content;
       size_t content_byte_size = expected_byte_size - copied_byte_size;
       payload.status_ = payload.request_provider_->GetNextInputContent(
-          name, &content, &content_byte_size, &src_memory_type, false);
+          name, &content, &content_byte_size, &src_memory_type,
+          &src_memory_type_id, false);
       if (!payload.status_.IsOk()) {
         break;
       }

--- a/src/core/backend_context.cc
+++ b/src/core/backend_context.cc
@@ -144,7 +144,7 @@ bool
 BackendContext::SetFixedSizeOutputBuffer(
     const std::string& name, const size_t batch1_byte_size, const char* content,
     const std::vector<int64_t>& content_shape,
-    TRTSERVER_Memory_Type src_memory_type,
+    TRTSERVER_Memory_Type src_memory_type, int64_t src_memory_type_id,
     std::vector<Scheduler::Payload>* payloads)
 {
   bool cuda_copy = false;
@@ -166,7 +166,8 @@ BackendContext::SetFixedSizeOutputBuffer(
 
       // try to get buffer with the same memory type as the output tensor
       Status status = payload.response_provider_->AllocateOutputBuffer(
-          name, &buffer, expected_byte_size, content_shape, src_memory_type);
+          name, &buffer, expected_byte_size, content_shape, src_memory_type,
+          src_memory_type_id);
 
       if (status.IsOk() && (expected_byte_size != 0)) {
         if ((buffer == nullptr) && (src_memory_type != TRTSERVER_MEMORY_CPU)) {

--- a/src/core/backend_context.h
+++ b/src/core/backend_context.h
@@ -62,7 +62,8 @@ struct BackendContext {
   bool SetInputBuffer(
       const std::string& name, const std::vector<size_t>& expected_byte_sizes,
       std::vector<Scheduler::Payload>* payloads,
-      TRTSERVER_Memory_Type dst_memory_type, char* input_buffer);
+      TRTSERVER_Memory_Type dst_memory_type, int64_t dst_memory_type_id,
+      char* input_buffer);
 
   // Helper function to set output buffer of fixed size data type to payloads
   // Return true if cudaMemcpyAsync is called, and the caller should call

--- a/src/core/backend_context.h
+++ b/src/core/backend_context.h
@@ -70,7 +70,7 @@ struct BackendContext {
   bool SetFixedSizeOutputBuffer(
       const std::string& name, const size_t batch1_byte_size,
       const char* content, const std::vector<int64_t>& content_shape,
-      TRTSERVER_Memory_Type src_memory_type,
+      TRTSERVER_Memory_Type src_memory_type, int64_t src_memory_type_id,
       std::vector<Scheduler::Payload>* payloads);
 
   Status CopyBuffer(

--- a/src/core/ensemble_scheduler.cc
+++ b/src/core/ensemble_scheduler.cc
@@ -325,8 +325,8 @@ EnsembleContext::ResponseAlloc(
   *buffer = nullptr;
   *buffer_userp = nullptr;
 
-  auto allocated_buffer =
-      std::make_shared<AllocatedSystemMemory>(byte_size, memory_type);
+  auto allocated_buffer = std::make_shared<AllocatedSystemMemory>(
+      byte_size, memory_type, memory_type_id);
 
   TRTSERVER_Memory_Type allocated_memory_type;
   auto mutable_buffer = allocated_buffer->MutableBuffer(&allocated_memory_type);
@@ -657,9 +657,11 @@ EnsembleContext::CheckAndSetEnsembleOutput()
     // Use the memory type of the memory block as preferred memory type
     TRTSERVER_Memory_Type dst_memory_type;
     size_t content_size;
+    // [TODO] buffer at should also return id
     memory_block->BufferAt(0, &content_size, &dst_memory_type);
 
     void* buffer;
+    // [TODO] pass 'memory_type_id' return by BufferAt()
     RETURN_IF_ERROR(response_provider_->AllocateOutputBuffer(
         output_pair.first, &buffer, expected_byte_size, shape,
         dst_memory_type));

--- a/src/core/ensemble_scheduler.cc
+++ b/src/core/ensemble_scheduler.cc
@@ -329,7 +329,9 @@ EnsembleContext::ResponseAlloc(
       byte_size, memory_type, memory_type_id);
 
   TRTSERVER_Memory_Type allocated_memory_type;
-  auto mutable_buffer = allocated_buffer->MutableBuffer(&allocated_memory_type);
+  int64_t allocated_memory_type_id;
+  auto mutable_buffer = allocated_buffer->MutableBuffer(
+      &allocated_memory_type, &allocated_memory_type_id);
   if ((mutable_buffer != nullptr) || (byte_size == 0)) {
     if (byte_size != 0) {
       *buffer = static_cast<void*>(mutable_buffer);
@@ -337,7 +339,8 @@ EnsembleContext::ResponseAlloc(
     tensor_data_map->emplace(tensor_name, std::move(allocated_buffer));
     LOG_VERBOSE(1) << "Internal response allocation: " << tensor_name
                    << ", size " << byte_size << ", addr " << *buffer
-                   << ", memory type " << allocated_memory_type;
+                   << ", memory type " << allocated_memory_type << ", type id "
+                   << allocated_memory_type_id;
   }
 
   return nullptr;  // Success
@@ -656,15 +659,14 @@ EnsembleContext::CheckAndSetEnsembleOutput()
 
     // Use the memory type of the memory block as preferred memory type
     TRTSERVER_Memory_Type dst_memory_type;
+    int64_t memory_type_id;
     size_t content_size;
-    // [TODO] buffer at should also return id
-    memory_block->BufferAt(0, &content_size, &dst_memory_type);
+    memory_block->BufferAt(0, &content_size, &dst_memory_type, &memory_type_id);
 
     void* buffer;
-    // [TODO] pass 'memory_type_id' return by BufferAt()
     RETURN_IF_ERROR(response_provider_->AllocateOutputBuffer(
-        output_pair.first, &buffer, expected_byte_size, shape,
-        dst_memory_type));
+        output_pair.first, &buffer, expected_byte_size, shape, dst_memory_type,
+        memory_type_id));
 
     // Done with this output if 'expected_byte_size' is 0
     if (expected_byte_size == 0) {
@@ -672,9 +674,10 @@ EnsembleContext::CheckAndSetEnsembleOutput()
     } else if (buffer == nullptr) {
       if (dst_memory_type != TRTSERVER_MEMORY_CPU) {
         dst_memory_type = TRTSERVER_MEMORY_CPU;
+        memory_type_id = 0;
         RETURN_IF_ERROR(response_provider_->AllocateOutputBuffer(
             output_pair.first, &buffer, expected_byte_size, shape,
-            dst_memory_type));
+            dst_memory_type, memory_type_id));
       }
       if (buffer == nullptr) {
         return Status(
@@ -688,8 +691,8 @@ EnsembleContext::CheckAndSetEnsembleOutput()
     size_t content_idx = 0;
     TRTSERVER_Memory_Type src_memory_type;
 
-    const char* content =
-        memory_block->BufferAt(content_idx, &content_size, &src_memory_type);
+    const char* content = memory_block->BufferAt(
+        content_idx, &content_size, &src_memory_type, &memory_type_id);
     while (content != nullptr) {
       if ((src_memory_type == TRTSERVER_MEMORY_CPU) &&
           (dst_memory_type == TRTSERVER_MEMORY_CPU)) {
@@ -732,8 +735,8 @@ EnsembleContext::CheckAndSetEnsembleOutput()
 
       content_offset += content_size;
       content_idx++;
-      content =
-          memory_block->BufferAt(content_idx, &content_size, &src_memory_type);
+      content = memory_block->BufferAt(
+          content_idx, &content_size, &src_memory_type, &memory_type_id);
     }
   }
 

--- a/src/core/provider.cc
+++ b/src/core/provider.cc
@@ -48,24 +48,28 @@ SystemMemoryReference::SystemMemoryReference() : SystemMemory() {}
 
 const char*
 SystemMemoryReference::BufferAt(
-    size_t idx, size_t* byte_size, TRTSERVER_Memory_Type* memory_type) const
+    size_t idx, size_t* byte_size, TRTSERVER_Memory_Type* memory_type,
+    int64_t* memory_type_id) const
 {
   if (idx >= buffer_.size()) {
     *byte_size = 0;
     *memory_type = TRTSERVER_MEMORY_CPU;
+    *memory_type_id = 0;
     return nullptr;
   }
-  *memory_type = std::get<2>(buffer_[idx]);
-  *byte_size = std::get<1>(buffer_[idx]);
-  return std::get<0>(buffer_[idx]);
+  *memory_type = buffer_[idx].memory_type_;
+  *memory_type_id = buffer_[idx].memory_type_id_;
+  *byte_size = buffer_[idx].byte_size_;
+  return buffer_[idx].buffer_;
 }
 
 size_t
 SystemMemoryReference::AddBuffer(
-    const char* buffer, size_t byte_size, TRTSERVER_Memory_Type memory_type)
+    const char* buffer, size_t byte_size, TRTSERVER_Memory_Type memory_type,
+    int64_t memory_type_id)
 {
   total_byte_size_ += byte_size;
-  buffer_.emplace_back(std::make_tuple(buffer, byte_size, memory_type));
+  buffer_.emplace_back(buffer, byte_size, memory_type, memory_type_id);
   return buffer_.size() - 1;
 }
 
@@ -112,7 +116,10 @@ AllocatedSystemMemory::~AllocatedSystemMemory()
       }
     } else {
 #ifdef TRTIS_ENABLE_GPU
-      cudaError_t err = cudaFree(buffer_);
+      auto err = cudaSetDevice(memory_type_id_);
+      if (err == cudaSuccess) {
+        err = cudaFree(buffer_);
+      }
       if (err != cudaSuccess) {
         LOG_ERROR << "failed to free GPU memory at address " << buffer_ << ": "
                   << std::string(cudaGetErrorString(err));
@@ -125,22 +132,27 @@ AllocatedSystemMemory::~AllocatedSystemMemory()
 
 const char*
 AllocatedSystemMemory::BufferAt(
-    size_t idx, size_t* byte_size, TRTSERVER_Memory_Type* memory_type) const
+    size_t idx, size_t* byte_size, TRTSERVER_Memory_Type* memory_type,
+    int64_t* memory_type_id) const
 {
   if (idx != 0) {
     *byte_size = 0;
     *memory_type = TRTSERVER_MEMORY_CPU;
+    *memory_type_id = 0;
     return nullptr;
   }
   *byte_size = total_byte_size_;
   *memory_type = memory_type_;
+  *memory_type_id = memory_type_id_;
   return buffer_;
 }
 
 char*
-AllocatedSystemMemory::MutableBuffer(TRTSERVER_Memory_Type* memory_type)
+AllocatedSystemMemory::MutableBuffer(
+    TRTSERVER_Memory_Type* memory_type, int64_t* memory_type_id)
 {
   *memory_type = memory_type_;
+  *memory_type_id = memory_type_id_;
   return buffer_;
 }
 
@@ -224,7 +236,8 @@ InferRequestProvider::GetInputOverrideContent(
 Status
 InferRequestProvider::GetNextInputContent(
     const std::string& name, const void** content, size_t* content_byte_size,
-    TRTSERVER_Memory_Type* memory_type, bool force_contiguous)
+    TRTSERVER_Memory_Type* memory_type, int64_t* memory_type_id,
+    bool force_contiguous)
 {
   if (*content_byte_size == 0) {
     *content = nullptr;
@@ -233,6 +246,7 @@ InferRequestProvider::GetNextInputContent(
 
   if (GetInputOverrideContent(name, content, content_byte_size)) {
     *memory_type = TRTSERVER_MEMORY_CPU;
+    *memory_type_id = 0;
   } else {
     const auto& pr = input_buffer_.find(name);
     if (pr == input_buffer_.end()) {
@@ -244,17 +258,19 @@ InferRequestProvider::GetNextInputContent(
 
     bool isLastChunk =
         (input_content.first->BufferAt(
-             input_content.second + 1, content_byte_size, memory_type) ==
-         nullptr);
+             input_content.second + 1, content_byte_size, memory_type,
+             memory_type_id) == nullptr);
     if (!force_contiguous || isLastChunk) {
       *content = input_content.first->BufferAt(
-          input_content.second++, content_byte_size, memory_type);
+          input_content.second++, content_byte_size, memory_type,
+          memory_type_id);
     } else {
       size_t total_size = 0;
       size_t start_idx = input_content.second;
       do {
         *content = input_content.first->BufferAt(
-            input_content.second++, content_byte_size, memory_type);
+            input_content.second++, content_byte_size, memory_type,
+            memory_type_id);
         total_size += *content_byte_size;
       } while (*content != nullptr);
 
@@ -262,11 +278,11 @@ InferRequestProvider::GetNextInputContent(
       std::vector<char>& buf = contiguous_buffers_.back();
       buf.reserve(total_size);
 
-      // [TODO] on 'force_contiguous', need to be careful as the data block
+      // [DLIS-825] on 'force_contiguous', need to be careful as the data block
       // may be on GPU
       for (size_t i = start_idx; i < input_content.second; i++) {
-        const auto& block =
-            input_content.first->BufferAt(i, content_byte_size, memory_type);
+        const auto& block = input_content.first->BufferAt(
+            i, content_byte_size, memory_type, memory_type_id);
         buf.insert(buf.end(), block, block + *content_byte_size);
       }
 
@@ -305,9 +321,11 @@ std::mutex NULLInferRequestProvider::mu_;
 Status
 NULLInferRequestProvider::GetNextInputContent(
     const std::string& name, const void** content, size_t* content_byte_size,
-    TRTSERVER_Memory_Type* memory_type, bool force_contiguous)
+    TRTSERVER_Memory_Type* memory_type, int64_t* memory_type_id,
+    bool force_contiguous)
 {
   *memory_type = TRTSERVER_MEMORY_CPU;
+  *memory_type_id = 0;
   if (*content_byte_size == 0) {
     *content = nullptr;
     return Status::Success;
@@ -405,13 +423,14 @@ InferResponseProvider::RequiresOutput(const std::string& name)
 Status
 InferResponseProvider::OutputBufferContents(
     const std::string& name, const void** content, size_t* content_byte_size,
-    TRTSERVER_Memory_Type* memory_type) const
+    TRTSERVER_Memory_Type* memory_type, int64_t* memory_type_id) const
 {
   for (const auto& output : outputs_) {
     if ((name == output.name_) && (output.cls_count_ == 0)) {
       *content = output.ptr_;
       *content_byte_size = output.byte_size_;
       *memory_type = output.memory_type_;
+      *memory_type_id = output.memory_type_id_;
       return Status::Success;
     }
   }
@@ -620,7 +639,7 @@ InferResponseProvider::~InferResponseProvider()
     if (output.release_buffer_ != nullptr) {
       TRTSERVER_Error* err = release_fn_(
           allocator_, output.release_buffer_, output.release_userp_,
-          output.byte_size_, output.memory_type_, 0);
+          output.byte_size_, output.memory_type_, output.memory_type_id_);
       if (err != nullptr) {
         LOG_ERROR << "failed to release result tensor '" << output.name_
                   << "': " << TRTSERVER_ErrorMessage(err);
@@ -669,6 +688,7 @@ InferResponseProvider::AllocateOutputBuffer(
   loutput->ptr_ = nullptr;
   loutput->byte_size_ = content_byte_size;
   loutput->memory_type_ = preferred_memory_type;
+  loutput->memory_type_id_ = preferred_memory_type_id;
 
   // For cls result, the provider will be responsible for allocating
   // the requested memory. The user-provided allocator should only be invoked

--- a/src/core/provider.cc
+++ b/src/core/provider.cc
@@ -659,9 +659,27 @@ InferResponseProvider::~InferResponseProvider()
 {
   for (const auto& output : outputs_) {
     if (output.release_buffer_ != nullptr) {
+#ifdef TRTIS_ENABLE_GPU
+      int current_device;
+      auto cuerr = cudaGetDevice(&current_device);
+      // Ignore error caused by CPU-only system.
+      if ((cuerr != cudaSuccess) && (cuerr != cudaErrorNoDevice) &&
+          (cuerr != cudaErrorInsufficientDriver)) {
+        LOG_ERROR << "unable to get current CUDA device: "
+                  << cudaGetErrorString(cuerr);
+      }
+#endif  // TRTIS_ENABLE_GPU
       TRTSERVER_Error* err = release_fn_(
           allocator_, output.release_buffer_, output.release_userp_,
           output.byte_size_, output.memory_type_, output.memory_type_id_);
+#ifdef TRTIS_ENABLE_GPU
+      cuerr = cudaSetDevice(current_device);
+      if ((cuerr != cudaSuccess) && (cuerr != cudaErrorNoDevice) &&
+          (cuerr != cudaErrorInsufficientDriver)) {
+        LOG_ERROR << "unable to recover current CUDA device: "
+                  << cudaGetErrorString(cuerr);
+      }
+#endif  // TRTIS_ENABLE_GPU
       if (err != nullptr) {
         LOG_ERROR << "failed to release result tensor '" << output.name_
                   << "': " << TRTSERVER_ErrorMessage(err);
@@ -746,28 +764,28 @@ InferResponseProvider::AllocateOutputBuffer(
   void* buffer_userp = nullptr;
 #ifdef TRTIS_ENABLE_GPU
   int current_device;
-  // Not checking error here as "no device" will be returned on CPU-only system.
-  // We still need to get device since provider doesn't know, however, the
-  // actual memory type returned from 'alloc_fn_' implies whether the provider
-  // should (can) recover current device.
-  cudaGetDevice(&current_device);
+  auto cuerr = cudaGetDevice(&current_device);
+  // Ignore error caused by CPU-only system.
+  if ((cuerr != cudaSuccess) && (cuerr != cudaErrorNoDevice) &&
+      (cuerr != cudaErrorInsufficientDriver)) {
+    return Status(
+        RequestStatusCode::INTERNAL,
+        "unable to get current CUDA device: " +
+            std::string(cudaGetErrorString(cuerr)));
+  }
 #endif  // TRTIS_ENABLE_GPU
   TRTSERVER_Error* err = alloc_fn_(
       allocator_, &buffer, &buffer_userp, name.c_str(), alloc_byte_size,
       preferred_memory_type, preferred_memory_type_id, alloc_userp_);
   Status status;
 #ifdef TRTIS_ENABLE_GPU
-  // [TODO] change to check actual memory type after
-  // https://github.com/NVIDIA/tensorrt-inference-server/pull/780
-  if (preferred_memory_type == TRTSERVER_MEMORY_GPU) {
-    auto cuerr = cudaSetDevice(current_device);
-    if (cuerr != cudaSuccess) {
-      // Not returning as we may need to delete 'err'
-      status = Status(
-          RequestStatusCode::INTERNAL,
-          "unable to recover CUDA device: " +
-              std::string(cudaGetErrorString(cuerr)));
-    }
+  cuerr = cudaSetDevice(current_device);
+  if ((cuerr != cudaSuccess) && (cuerr != cudaErrorNoDevice) &&
+      (cuerr != cudaErrorInsufficientDriver)) {
+    status = Status(
+        RequestStatusCode::INTERNAL,
+        "unable to recover current CUDA device: " +
+            std::string(cudaGetErrorString(cuerr)));
   }
 #endif  // TRTIS_ENABLE_GPU
   if (err != nullptr) {

--- a/src/core/provider.cc
+++ b/src/core/provider.cc
@@ -643,7 +643,8 @@ Status
 InferResponseProvider::AllocateOutputBuffer(
     const std::string& name, void** content, size_t content_byte_size,
     const std::vector<int64_t>& content_shape,
-    const TRTSERVER_Memory_Type preferred_memory_type)
+    TRTSERVER_Memory_Type preferred_memory_type,
+    int64_t preferred_memory_type_id)
 {
   *content = nullptr;
 
@@ -701,7 +702,7 @@ InferResponseProvider::AllocateOutputBuffer(
 
   TRTSERVER_Error* err = alloc_fn_(
       allocator_, &buffer, &buffer_userp, name.c_str(), alloc_byte_size,
-      preferred_memory_type, 0 /* region_id */, alloc_userp_);
+      preferred_memory_type, preferred_memory_type_id, alloc_userp_);
   if (err != nullptr) {
     Status status = Status(
         TrtServerCodeToRequestStatus(TRTSERVER_ErrorCode(err)),

--- a/src/core/provider.cc
+++ b/src/core/provider.cc
@@ -70,8 +70,8 @@ SystemMemoryReference::AddBuffer(
 }
 
 AllocatedSystemMemory::AllocatedSystemMemory(
-    size_t byte_size, TRTSERVER_Memory_Type memory_type)
-    : SystemMemory(), memory_type_(memory_type)
+    size_t byte_size, TRTSERVER_Memory_Type memory_type, int64_t memory_type_id)
+    : SystemMemory(), memory_type_(memory_type), memory_type_id_(memory_type_id)
 {
   buffer_ = nullptr;
   if (byte_size != 0) {
@@ -84,7 +84,10 @@ AllocatedSystemMemory::AllocatedSystemMemory(
       }
     } else {
 #ifdef TRTIS_ENABLE_GPU
-      cudaError_t err = cudaMalloc((void**)&buffer_, byte_size);
+      auto err = cudaSetDevice(memory_type_id_);
+      if (err == cudaSuccess) {
+        err = cudaMalloc((void**)&buffer_, byte_size);
+      }
       if (err != cudaSuccess) {
         LOG_ERROR << "failed to allocate GPU memory with byte size" << byte_size
                   << ": " << std::string(cudaGetErrorString(err));

--- a/src/core/provider.h
+++ b/src/core/provider.h
@@ -269,7 +269,8 @@ class InferResponseProvider {
   Status AllocateOutputBuffer(
       const std::string& name, void** content, size_t content_byte_size,
       const std::vector<int64_t>& content_shape,
-      const TRTSERVER_Memory_Type preferred_memory_type = TRTSERVER_MEMORY_CPU);
+      TRTSERVER_Memory_Type preferred_memory_type = TRTSERVER_MEMORY_CPU,
+      int64_t preferred_memory_type_id = 0);
 
   // Get the address and byte-size of an output buffer. Error is
   // returned if the buffer is not already allocated.

--- a/src/core/provider.h
+++ b/src/core/provider.h
@@ -84,8 +84,11 @@ class SystemMemoryReference : public SystemMemory {
 
 class AllocatedSystemMemory : public SystemMemory {
  public:
-  // Create a continuous data buffer with 'byte_size' and 'memory_type'.
-  AllocatedSystemMemory(size_t byte_size, TRTSERVER_Memory_Type memory_type);
+  // Create a continuous data buffer with 'byte_size', 'memory_type' and
+  // 'memory_id.
+  AllocatedSystemMemory(
+      size_t byte_size, TRTSERVER_Memory_Type memory_type,
+      int64_t memory_type_id);
 
   ~AllocatedSystemMemory();
 
@@ -101,6 +104,7 @@ class AllocatedSystemMemory : public SystemMemory {
  private:
   char* buffer_;
   TRTSERVER_Memory_Type memory_type_;
+  int64_t memory_type_id_;
 };
 
 //
@@ -129,6 +133,7 @@ class InferRequestProvider {
   // batch-byte-size defined.
   const InferRequestHeader& RequestHeader() const { return request_header_; }
 
+  // [TODO] add 'memory_type_id' option, same reason as 'memory_type'
   // Get the next contiguous chunk of bytes for the 'name'd
   // input. Return a pointer to the chunk in 'content'.
   // If there are no more bytes for the input return 'content' == nullptr.

--- a/src/core/provider.h
+++ b/src/core/provider.h
@@ -163,8 +163,12 @@ class InferRequestProvider {
   // buffer and the buffer owner may collect such information for other use.
   // On return 'memory_type' gives the actual memory type of the chunk
   // pointed to by 'content'.
-  // 'memory_type_id' also acts as both input and output in the same fashion
-  // as 'memory_type'.
+  // 'memory_type_id' acts as both input and output. On input 'memory_type_id'
+  // is the buffer memory type id preferred by the function caller, it will
+  // not affect the function behavior, but it will be propagated to the
+  // buffer and the buffer owner may collect such information for other use.
+  // On return 'memory_type_id' gives the actual memory type id of the chunk
+  // pointed to by 'content'.
   // If 'force_contiguous' is true then the entire (remaining) input will
   // be returned as a single chunk. In some cases this will require
   // copying the data.

--- a/src/core/provider.h
+++ b/src/core/provider.h
@@ -48,11 +48,12 @@ class SystemMemory {
   // 'idx' zero base index. Valid indices are continuous.
   // 'byte_size' returns the byte size of the chunk of bytes.
   // 'memory_type' returns the memory type of the chunk of bytes.
+  // 'memory_type_id' returns the memory type id of the chunk of bytes.
   // Return the pointer to the data block. Returns nullptr if 'idx' is
   // out of range
   virtual const char* BufferAt(
-      size_t idx, size_t* byte_size,
-      TRTSERVER_Memory_Type* memory_type) const = 0;
+      size_t idx, size_t* byte_size, TRTSERVER_Memory_Type* memory_type,
+      int64_t* memory_type_id) const = 0;
 
   // Return the total byte size of the data buffer
   size_t TotalByteSize() const { return total_byte_size_; }
@@ -69,16 +70,29 @@ class SystemMemoryReference : public SystemMemory {
 
   //\see SystemMemory::BufferAt()
   const char* BufferAt(
-      size_t idx, size_t* byte_size,
-      TRTSERVER_Memory_Type* memory_type) const override;
+      size_t idx, size_t* byte_size, TRTSERVER_Memory_Type* memory_type,
+      int64_t* memory_type_id) const override;
 
   // Add a 'buffer' with 'byte_size' as part of this data buffer
   // Return the index of the buffer
   size_t AddBuffer(
-      const char* buffer, size_t byte_size, TRTSERVER_Memory_Type memory_type);
+      const char* buffer, size_t byte_size, TRTSERVER_Memory_Type memory_type,
+      int64_t memory_type_id);
 
  private:
-  using Block = std::tuple<const char*, size_t, TRTSERVER_Memory_Type>;
+  struct Block {
+    Block(
+        const char* buffer, size_t byte_size, TRTSERVER_Memory_Type memory_type,
+        int64_t memory_type_id)
+        : buffer_(buffer), byte_size_(byte_size), memory_type_(memory_type),
+          memory_type_id_(memory_type_id)
+    {
+    }
+    const char* buffer_;
+    size_t byte_size_;
+    TRTSERVER_Memory_Type memory_type_;
+    int64_t memory_type_id_;
+  };
   std::vector<Block> buffer_;
 };
 
@@ -94,12 +108,14 @@ class AllocatedSystemMemory : public SystemMemory {
 
   //\see SystemMemory::BufferAt()
   const char* BufferAt(
-      size_t idx, size_t* byte_size,
-      TRTSERVER_Memory_Type* memory_type) const override;
+      size_t idx, size_t* byte_size, TRTSERVER_Memory_Type* memory_type,
+      int64_t* memory_type_id) const override;
 
   // 'memory_type' returns the memory type of the chunk of bytes.
+  // 'memory_type_id' returns the memory type id of the chunk of bytes.
   // Return the mutable buffer
-  char* MutableBuffer(TRTSERVER_Memory_Type* memory_type);
+  char* MutableBuffer(
+      TRTSERVER_Memory_Type* memory_type, int64_t* memory_type_id);
 
  private:
   char* buffer_;
@@ -133,7 +149,6 @@ class InferRequestProvider {
   // batch-byte-size defined.
   const InferRequestHeader& RequestHeader() const { return request_header_; }
 
-  // [TODO] add 'memory_type_id' option, same reason as 'memory_type'
   // Get the next contiguous chunk of bytes for the 'name'd
   // input. Return a pointer to the chunk in 'content'.
   // If there are no more bytes for the input return 'content' == nullptr.
@@ -148,12 +163,15 @@ class InferRequestProvider {
   // buffer and the buffer owner may collect such information for other use.
   // On return 'memory_type' gives the actual memory type of the chunk
   // pointed to by 'content'.
+  // 'memory_type_id' also acts as both input and output in the same fashion
+  // as 'memory_type'.
   // If 'force_contiguous' is true then the entire (remaining) input will
   // be returned as a single chunk. In some cases this will require
   // copying the data.
   virtual Status GetNextInputContent(
       const std::string& name, const void** content, size_t* content_byte_size,
-      TRTSERVER_Memory_Type* memory_type, bool force_contiguous);
+      TRTSERVER_Memory_Type* memory_type, int64_t* memory_type_id,
+      bool force_contiguous);
 
   // Retrieve the data buffer of input 'name'.
   Status GetSystemMemory(
@@ -228,7 +246,8 @@ class NULLInferRequestProvider : public InferRequestProvider {
 
   Status GetNextInputContent(
       const std::string& name, const void** content, size_t* content_byte_size,
-      TRTSERVER_Memory_Type* memory_type, bool force_contiguous) override;
+      TRTSERVER_Memory_Type* memory_type, int64_t* memory_type_id,
+      bool force_contiguous) override;
 
  private:
   // A buffer of zero bytes that is used commonly as the NULL input.
@@ -281,7 +300,7 @@ class InferResponseProvider {
   // returned if the buffer is not already allocated.
   Status OutputBufferContents(
       const std::string& name, const void** content, size_t* content_byte_size,
-      TRTSERVER_Memory_Type* memory_type) const;
+      TRTSERVER_Memory_Type* memory_type, int64_t* memory_type_id) const;
 
   // Get label provider.
   const std::shared_ptr<LabelProvider>& GetLabelProvider() const
@@ -323,6 +342,7 @@ class InferResponseProvider {
     void* ptr_;
     size_t byte_size_;
     TRTSERVER_Memory_Type memory_type_;
+    int64_t memory_type_id_;
 
     // Created buffer for non-RAW results
     std::unique_ptr<char[]> buffer_;

--- a/src/core/trtserver.h
+++ b/src/core/trtserver.h
@@ -408,6 +408,7 @@ TRTSERVER_InferenceRequestProviderInputBatchByteSize(
     TRTSERVER_InferenceRequestProvider* request_provider, const char* name,
     uint64_t* byte_size);
 
+// [TODO] add 'memory_type_id' option, same reason as 'memory_type'
 /// Assign a buffer of data to an input. The buffer will be appended
 /// to any existing buffers for that input. The 'request_provider'
 /// takes ownership of the buffer and so the caller should not modify
@@ -424,7 +425,8 @@ TRTSERVER_InferenceRequestProviderInputBatchByteSize(
 TRTSERVER_EXPORT TRTSERVER_Error*
 TRTSERVER_InferenceRequestProviderSetInputData(
     TRTSERVER_InferenceRequestProvider* request_provider, const char* name,
-    const void* base, size_t byte_size, TRTSERVER_Memory_Type memory_type);
+    const void* base, size_t byte_size, TRTSERVER_Memory_Type memory_type,
+    int64_t memory_type_id);
 
 /// TRTSERVER_InferenceResponse
 ///
@@ -470,7 +472,8 @@ TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_InferenceResponseHeader(
 /// \return a TRTSERVER_Error indicating success or failure.
 TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_InferenceResponseOutputData(
     TRTSERVER_InferenceResponse* response, const char* name, const void** base,
-    size_t* byte_size, TRTSERVER_Memory_Type* memory_type);
+    size_t* byte_size, TRTSERVER_Memory_Type* memory_type,
+    int64_t* memory_type_id);
 
 /// TRTSERVER_ServerOptions
 ///

--- a/src/core/trtserver.h
+++ b/src/core/trtserver.h
@@ -408,7 +408,6 @@ TRTSERVER_InferenceRequestProviderInputBatchByteSize(
     TRTSERVER_InferenceRequestProvider* request_provider, const char* name,
     uint64_t* byte_size);
 
-// [TODO] add 'memory_type_id' option, same reason as 'memory_type'
 /// Assign a buffer of data to an input. The buffer will be appended
 /// to any existing buffers for that input. The 'request_provider'
 /// takes ownership of the buffer and so the caller should not modify
@@ -421,6 +420,7 @@ TRTSERVER_InferenceRequestProviderInputBatchByteSize(
 /// \param base The base address of the input data.
 /// \param byte_size The size, in bytes, of the input data.
 /// \param memory_type The memory type of the input data.
+/// \param memory_type_id The memory type id of the input data.
 /// \return a TRTSERVER_Error indicating success or failure.
 TRTSERVER_EXPORT TRTSERVER_Error*
 TRTSERVER_InferenceRequestProviderSetInputData(
@@ -469,6 +469,7 @@ TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_InferenceResponseHeader(
 /// \param base Returns the result data for the named output.
 /// \param byte_size Returns the size, in bytes, of the output data.
 /// \param memory_type Returns the memory type of the output data.
+/// \param memory_type_id Returns the memory type id of the output data.
 /// \return a TRTSERVER_Error indicating success or failure.
 TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_InferenceResponseOutputData(
     TRTSERVER_InferenceResponse* response, const char* name, const void** base,

--- a/src/custom/identity/identity.cc
+++ b/src/custom/identity/identity.cc
@@ -247,10 +247,14 @@ Context::Execute(
       }
 
       auto dst_memory_type = src_memory_type;
+      // [TODO] should be able to get from 'input_fn', i.e. in this case,
+      // we would like to allocate output buffer on the same device as input
+      int64_t dst_memory_type_id = 0;
       void* obuffer;
       if (!output_fn(
               payload.output_context, output_cname, shape.size(), &shape[0],
-              batchn_byte_size, &obuffer, &dst_memory_type)) {
+              batchn_byte_size, &obuffer, &dst_memory_type,
+              &dst_memory_type_id)) {
         payload.error_code = kOutputBuffer;
         break;
       }

--- a/src/custom/identity/identity.cc
+++ b/src/custom/identity/identity.cc
@@ -235,21 +235,21 @@ Context::Execute(
       }
 
       // copy....
-      // Peek memory type of the input content and use it as preferred type
+      // Peek memory type and id of the input content as
+      // we would like to allocate output buffer on the same device as input
       CustomMemoryType src_memory_type = CUSTOM_MEMORY_CPU;
+      int64_t src_memory_type_id = 0;
       const void* content;
       uint64_t content_byte_size = 128 * 1024;
       if (!input_fn(
               payload.input_context, input_name.c_str(), &content,
-              &content_byte_size, &src_memory_type)) {
+              &content_byte_size, &src_memory_type, &src_memory_type_id)) {
         payload.error_code = kInputContents;
         break;
       }
 
       auto dst_memory_type = src_memory_type;
-      // [TODO] should be able to get from 'input_fn', i.e. in this case,
-      // we would like to allocate output buffer on the same device as input
-      int64_t dst_memory_type_id = 0;
+      int64_t dst_memory_type_id = src_memory_type_id;
       void* obuffer;
       if (!output_fn(
               payload.output_context, output_cname, shape.size(), &shape[0],
@@ -303,7 +303,7 @@ Context::Execute(
 
         if (!input_fn(
                 payload.input_context, input_name.c_str(), &content,
-                &content_byte_size, &src_memory_type)) {
+                &content_byte_size, &src_memory_type, &src_memory_type_id)) {
           payload.error_code = kInputContents;
           break;
         }

--- a/src/servers/grpc_server.cc
+++ b/src/servers/grpc_server.cc
@@ -263,10 +263,7 @@ class HandlerState {
     response_.Clear();
   }
 
-  void Release()
-  {
-    context_ = nullptr;
-  }
+  void Release() { context_ = nullptr; }
 
   std::shared_ptr<Context> context_;
 
@@ -802,7 +799,7 @@ InferGRPCToInput(
 
     RETURN_IF_ERR(TRTSERVER_InferenceRequestProviderSetInputData(
         request_provider, io.name().c_str(), base, byte_size,
-        TRTSERVER_MEMORY_CPU));
+        TRTSERVER_MEMORY_CPU, 0 /* memory_type_id */));
   }
 
   return nullptr;  // success

--- a/src/servers/http_server.cc
+++ b/src/servers/http_server.cc
@@ -880,7 +880,7 @@ HTTPAPIServer::EVBufferToInput(
     if (byte_size == 0) {
       RETURN_IF_ERR(TRTSERVER_InferenceRequestProviderSetInputData(
           request_provider, io.name().c_str(), nullptr, 0 /* byte_size */,
-          TRTSERVER_MEMORY_CPU));
+          TRTSERVER_MEMORY_CPU, 0 /* memory_type_id */));
     } else {
       // If input is in shared memory then verify that the size is
       // correct and set input from the shared memory.
@@ -904,7 +904,7 @@ HTTPAPIServer::EVBufferToInput(
             io.shared_memory().byte_size(), &base));
         RETURN_IF_ERR(TRTSERVER_InferenceRequestProviderSetInputData(
             request_provider, io.name().c_str(), base, byte_size,
-            TRTSERVER_MEMORY_CPU));
+            TRTSERVER_MEMORY_CPU, 0 /* memory_type_id */));
       } else {
         while ((byte_size > 0) && (v_idx < n)) {
           char* base = static_cast<char*>(v[v_idx].iov_base);
@@ -922,7 +922,7 @@ HTTPAPIServer::EVBufferToInput(
 
           RETURN_IF_ERR(TRTSERVER_InferenceRequestProviderSetInputData(
               request_provider, io.name().c_str(), base, base_size,
-              TRTSERVER_MEMORY_CPU));
+              TRTSERVER_MEMORY_CPU, 0 /* memory_type_id */));
         }
 
         if (byte_size != 0) {

--- a/src/servers/simple.cc
+++ b/src/servers/simple.cc
@@ -111,24 +111,13 @@ ResponseAlloc(
       allocated_ptr = malloc(byte_size);
 #ifdef TRTIS_ENABLE_GPU
     } else if (use_gpu_memory) {
-      int current_device;
-      auto err = cudaGetDevice(&current_device);
-      bool overridden = false;
-      if (err == cudaSuccess) {
-        overridden = (current_device != memory_type_id);
-        if (overridden) {
-          err = cudaSetDevice(memory_type_id);
-        }
-      }
+      auto err = cudaSetDevice(memory_type_id);
       if (err == cudaSuccess) {
         err = cudaMalloc(&allocated_ptr, byte_size);
       }
       if (err != cudaSuccess) {
         LOG_INFO << "cudaMalloc failed: " << cudaGetErrorString(err);
         allocated_ptr = nullptr;
-      }
-      if (overridden) {
-        cudaSetDevice(current_device);
       }
 #endif  // TRTIS_ENABLE_GPU
     }
@@ -164,24 +153,13 @@ ResponseRelease(
     free(buffer);
 #ifdef TRTIS_ENABLE_GPU
   } else if (use_gpu_memory) {
-    int current_device;
-    auto err = cudaGetDevice(&current_device);
-    bool overridden = false;
-    if (err == cudaSuccess) {
-      overridden = (current_device != memory_type_id);
-      if (overridden) {
-        err = cudaSetDevice(memory_type_id);
-      }
-    }
+    auto err = cudaSetDevice(memory_type_id);
     if (err == cudaSuccess) {
       err = cudaFree(buffer);
     }
     if (err != cudaSuccess) {
       LOG_ERROR << "error: failed to cudaFree " << buffer << ": "
                 << cudaGetErrorString(err);
-    }
-    if (overridden) {
-      cudaSetDevice(current_device);
     }
 #endif  // TRTIS_ENABLE_GPU
   } else {

--- a/src/servers/simple.cc
+++ b/src/servers/simple.cc
@@ -491,12 +491,12 @@ main(int argc, char** argv)
   FAIL_IF_ERR(
       TRTSERVER_InferenceRequestProviderSetInputData(
           request_provider, input0->name().c_str(), input0_base, input0_size,
-          memory_type),
+          memory_type, 0 /* memory_type_id */),
       "assigning INPUT0 data");
   FAIL_IF_ERR(
       TRTSERVER_InferenceRequestProviderSetInputData(
           request_provider, input1->name().c_str(), input1_base, input1_size,
-          memory_type),
+          memory_type, 0 /* memory_type_id */),
       "assigning INPUT1 data");
 
   // Perform inference...
@@ -551,10 +551,11 @@ main(int argc, char** argv)
   const void* output0_content;
   size_t output0_byte_size;
   TRTSERVER_Memory_Type output0_memory_type;
+  int64_t memory_type_id;
   FAIL_IF_ERR(
       TRTSERVER_InferenceResponseOutputData(
           response, output0->name().c_str(), &output0_content,
-          &output0_byte_size, &output0_memory_type),
+          &output0_byte_size, &output0_memory_type, &memory_type_id),
       "getting output0 result");
   if (output0_byte_size != input0_size) {
     FAIL(
@@ -567,7 +568,8 @@ main(int argc, char** argv)
         "unexpected output0 memory type, expected to be allocated "
         "in " +
         MemoryTypeString(TRTSERVER_MEMORY_CPU) + ", got " +
-        MemoryTypeString(output0_memory_type));
+        MemoryTypeString(output0_memory_type) + ", id " +
+        std::to_string(memory_type_id));
   }
 
   const void* output1_content;
@@ -576,7 +578,7 @@ main(int argc, char** argv)
   FAIL_IF_ERR(
       TRTSERVER_InferenceResponseOutputData(
           response, output1->name().c_str(), &output1_content,
-          &output1_byte_size, &output1_memory_type),
+          &output1_byte_size, &output1_memory_type, &memory_type_id),
       "getting output1 result");
   if (output1_byte_size != input1_size) {
     FAIL(
@@ -589,7 +591,8 @@ main(int argc, char** argv)
         "unexpected output1 memory type, expected to be allocated "
         "in " +
         MemoryTypeString(TRTSERVER_MEMORY_CPU) + ", got " +
-        MemoryTypeString(output1_memory_type));
+        MemoryTypeString(output1_memory_type) + ", id " +
+        std::to_string(memory_type_id));
   }
 
   const void* output0_result = output0_content;

--- a/src/servers/simple.cc
+++ b/src/servers/simple.cc
@@ -111,7 +111,10 @@ ResponseAlloc(
       allocated_ptr = malloc(byte_size);
 #ifdef TRTIS_ENABLE_GPU
     } else if (use_gpu_memory) {
-      auto err = cudaMalloc(&allocated_ptr, byte_size);
+      auto err = cudaSetDevice(memory_type_id);
+      if (err == cudaSuccess) {
+        err = cudaMalloc(&allocated_ptr, byte_size);
+      }
       if (err != cudaSuccess) {
         LOG_INFO << "cudaMalloc failed: " << cudaGetErrorString(err);
         allocated_ptr = nullptr;


### PR DESCRIPTION
Major change is let TRTIS internal be aware of 'memory_type_id', this is done by tying it with all occurrences of 'memory_type'.

Fix custom backend implementation to match description (return acutal memory type and type id)