### PR TITLE
Fix Response Allocation

### DIFF
--- a/qa/L0_trt_plugin/trt_plugin_test.py
+++ b/qa/L0_trt_plugin/trt_plugin_test.py
@@ -67,10 +67,7 @@ class PluginModelTest(unittest.TestCase):
         for bs in (1, 8):
             self._full_exact(bs, np.float32, np.float32, 'plan_float32_float32_float32', 'LReLU_TRT')
 
-    def test_raw_fff_customclip(self):
-        # model that supports batching
-        for bs in (1, 8):
-            self._full_exact(bs, np.float32, np.float32, 'plan_float32_float32_float32', 'CustomClipPlugin')
+    # add test for CustomClipPlugin after model is fixed
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/backends/custom/custom_backend.cc
+++ b/src/backends/custom/custom_backend.cc
@@ -586,9 +586,10 @@ CustomBackend::Context::GetOutput(
 
     auto dst_memory_type = ToTRTServerMemoryType(*memory_type);
     auto actual_memory_type = dst_memory_type;
+    int64_t device_id;
     Status status = payload->response_provider_->AllocateOutputBuffer(
         name, content, content_byte_size, shape, dst_memory_type,
-        *memory_type_id, &actual_memory_type);
+        *memory_type_id, &actual_memory_type, &device_id);
 
     // Done with this output if 'content_byte_size' is 0
     if (content_byte_size == 0) {

--- a/src/backends/custom/custom_backend.cc
+++ b/src/backends/custom/custom_backend.cc
@@ -586,10 +586,10 @@ CustomBackend::Context::GetOutput(
 
     auto dst_memory_type = ToTRTServerMemoryType(*memory_type);
     auto actual_memory_type = dst_memory_type;
-    int64_t device_id;
+    int64_t actual_memory_type_id;
     Status status = payload->response_provider_->AllocateOutputBuffer(
         name, content, content_byte_size, shape, dst_memory_type,
-        *memory_type_id, &actual_memory_type, &device_id);
+        *memory_type_id, &actual_memory_type, &actual_memory_type_id);
 
     // Done with this output if 'content_byte_size' is 0
     if (content_byte_size == 0) {

--- a/src/backends/custom/custom_backend.cc
+++ b/src/backends/custom/custom_backend.cc
@@ -584,12 +584,12 @@ CustomBackend::Context::GetOutput(
       shape.assign(shape_dims, shape_dims + shape_dim_cnt);
     }
 
-    auto dst_memory_type = ToTRTServerMemoryType(*memory_type);
-    auto actual_memory_type = dst_memory_type;
+    TRTSERVER_Memory_Type actual_memory_type;
     int64_t actual_memory_type_id;
     Status status = payload->response_provider_->AllocateOutputBuffer(
-        name, content, content_byte_size, shape, dst_memory_type,
-        *memory_type_id, &actual_memory_type, &actual_memory_type_id);
+        name, content, content_byte_size, shape,
+        ToTRTServerMemoryType(*memory_type), *memory_type_id,
+        &actual_memory_type, &actual_memory_type_id);
 
     // Done with this output if 'content_byte_size' is 0
     if (content_byte_size == 0) {
@@ -600,6 +600,7 @@ CustomBackend::Context::GetOutput(
 
     // Update memory type with actual memory type
     *memory_type = ToCustomMemoryType(actual_memory_type);
+    *memory_type_id = actual_memory_type_id;
 
     return status.IsOk();
   }

--- a/src/backends/onnx/onnx_backend.cc
+++ b/src/backends/onnx/onnx_backend.cc
@@ -883,8 +883,11 @@ OnnxBackend::Context::SetStringOutputBuffer(
           data_byte_size + sizeof(uint32_t) * expected_element_cnt;
 
       void* buffer;
+      TRTSERVER_Memory_Type preferred_memory_type = TRTSERVER_MEMORY_CPU;
+      TRTSERVER_Memory_Type actual_memory_type;
+      int64_t device_id;
       Status status = payload.response_provider_->AllocateOutputBuffer(
-          name, &buffer, expected_byte_size, content_shape);
+          name, &buffer, expected_byte_size, content_shape, preferred_memory_type, &actual_memory_type, &device_id);
       if (status.IsOk()) {
         size_t copied_byte_size = 0;
         for (size_t e = 0; e < expected_element_cnt; ++e) {

--- a/src/backends/onnx/onnx_backend.cc
+++ b/src/backends/onnx/onnx_backend.cc
@@ -888,7 +888,7 @@ OnnxBackend::Context::SetStringOutputBuffer(
       int64_t device_id;
       Status status = payload.response_provider_->AllocateOutputBuffer(
           name, &buffer, expected_byte_size, content_shape,
-          preferred_memory_type, &actual_memory_type, &device_id);
+          preferred_memory_type, 0, &actual_memory_type, &device_id);
       if (status.IsOk()) {
         size_t copied_byte_size = 0;
         for (size_t e = 0; e < expected_element_cnt; ++e) {

--- a/src/backends/onnx/onnx_backend.cc
+++ b/src/backends/onnx/onnx_backend.cc
@@ -817,7 +817,7 @@ OnnxBackend::Context::ReadOutputTensors(
       // Mark "passed end byte offset"
       offsets[element_count] = total_length;
 
-      SetStringOutputBuffer(
+      cuda_copy |= SetStringOutputBuffer(
           name, batch1_element_cnt, content, content_shape, offsets, payloads);
     } else {
       // Fixed size data type...
@@ -858,13 +858,14 @@ OnnxBackend::Context::ReadOutputTensors(
   return Status::Success;
 }
 
-void
+bool
 OnnxBackend::Context::SetStringOutputBuffer(
     const std::string& name, const size_t batch1_element_cnt,
     const char* content, const std::vector<int64_t>& content_shape,
     const size_t* offsets, std::vector<Scheduler::Payload>* payloads)
 {
   size_t element_idx = 0;
+  bool cuda_copy = false;
   for (auto& payload : *payloads) {
     const InferRequestHeader& request_header =
         payload.request_provider_->RequestHeader();
@@ -885,10 +886,11 @@ OnnxBackend::Context::SetStringOutputBuffer(
       void* buffer;
       TRTSERVER_Memory_Type preferred_memory_type = TRTSERVER_MEMORY_CPU;
       TRTSERVER_Memory_Type actual_memory_type;
-      int64_t device_id;
+      int64_t actual_memory_type_id;
       Status status = payload.response_provider_->AllocateOutputBuffer(
           name, &buffer, expected_byte_size, content_shape,
-          preferred_memory_type, 0, &actual_memory_type, &device_id);
+          preferred_memory_type, 0 /* preferred_memory_type_id */,
+          &actual_memory_type, &actual_memory_type_id);
       if (status.IsOk()) {
         size_t copied_byte_size = 0;
         for (size_t e = 0; e < expected_element_cnt; ++e) {
@@ -907,7 +909,7 @@ OnnxBackend::Context::SetStringOutputBuffer(
                       " CUDA copy from CPU memory to get String output data: " +
                       std::string(cudaGetErrorString(err)));
             } else {
-              cudaStreamSynchronize(stream_);
+              cuda_copy = true;
             }
 #endif  // TRTIS_ENABLE_GPU
           } else {
@@ -930,7 +932,7 @@ OnnxBackend::Context::SetStringOutputBuffer(
                       " CUDA copy from CPU memory to get String output data: " +
                       std::string(cudaGetErrorString(err)));
             } else {
-              cudaStreamSynchronize(stream_);
+              cuda_copy = true;
             }
 #endif  // TRTIS_ENABLE_GPU
           } else {
@@ -947,6 +949,8 @@ OnnxBackend::Context::SetStringOutputBuffer(
 
     element_idx += expected_element_cnt;
   }
+
+  return cuda_copy;
 }
 
 void

--- a/src/backends/onnx/onnx_backend.h
+++ b/src/backends/onnx/onnx_backend.h
@@ -121,8 +121,10 @@ class OnnxBackend : public InferenceBackend {
         const std::vector<const char*>& output_names,
         std::vector<Scheduler::Payload>* payloads);
 
-    // Helper function to set output buffer of string data type to payloads
-    void SetStringOutputBuffer(
+    // Helper function to set output buffer of string data type to payloads.
+    // Return true if cudaMemcpyAsync is called, and the caller should call
+    // cudaStreamSynchronize before using the data. Otherwise, return false.
+    bool SetStringOutputBuffer(
         const std::string& name, const size_t batch1_element_cnt,
         const char* content, const std::vector<int64_t>& content_shape,
         const size_t* offsets, std::vector<Scheduler::Payload>* payloads);

--- a/src/backends/pytorch/libtorch_backend.cc
+++ b/src/backends/pytorch/libtorch_backend.cc
@@ -395,8 +395,9 @@ LibTorchBackend::Context::SetInputTensor(
       meta_data.input_buffer_->MutableBuffer(&memory_type, &memory_type_id);
 
   torch::TensorOptions options{meta_data.torch_type_};
-  auto updated_options = (memory_type == TRTSERVER_MEMORY_CPU) ?
-    options.device(torch::kCPU) : options.device(torch::kCUDA, memory_type_id);
+  auto updated_options = (memory_type == TRTSERVER_MEMORY_CPU)
+                             ? options.device(torch::kCPU)
+                             : options.device(torch::kCUDA, memory_type_id);
   torch::Tensor input_tensor =
       torch::from_blob(buffer, meta_data.shape_, updated_options);
 

--- a/src/backends/tensorflow/base_backend.cc
+++ b/src/backends/tensorflow/base_backend.cc
@@ -442,7 +442,7 @@ ReadStringOutputTensor(
       int64_t device_id;
       Status status = payload.response_provider_->AllocateOutputBuffer(
           output_name, &content, serialized.size(), shape,
-          preferred_memory_type, &actual_memory_type, &device_id);
+          preferred_memory_type, 0, &actual_memory_type, &device_id);
       if (status.IsOk()) {
         if (actual_memory_type == TRTSERVER_MEMORY_GPU) {
 #ifdef TRTIS_ENABLE_GPU

--- a/src/backends/tensorflow/base_backend.cc
+++ b/src/backends/tensorflow/base_backend.cc
@@ -437,8 +437,11 @@ ReadStringOutputTensor(
       }
 
       void* content;
+      TRTSERVER_Memory_Type preferred_memory_type = TRTSERVER_MEMORY_CPU;
+      TRTSERVER_Memory_Type actual_memory_type;
+      int64_t device_id;
       Status status = payload.response_provider_->AllocateOutputBuffer(
-          output_name, &content, serialized.size(), shape);
+          output_name, &content, serialized.size(), shape, preferred_memory_type, &actual_memory_type, &device_id);
       if (status.IsOk()) {
         memcpy(
             content, reinterpret_cast<const void*>(serialized.c_str()),

--- a/src/backends/tensorflow/base_backend.cc
+++ b/src/backends/tensorflow/base_backend.cc
@@ -410,6 +410,16 @@ ReadStringOutputTensor(
 {
   size_t tensor_element_idx = 0;
 
+#ifdef TRTIS_ENABLE_GPU
+  bool cuda_copy = false;
+  cudaStream_t stream;
+  cudaError_t cuerr = cudaStreamCreate(&stream);
+  if (cuerr != cudaSuccess) {
+    LOG_VERBOSE(1) << "unable to create stream for " << output_name << ": "
+                   << cudaGetErrorString(cuerr);
+  }
+#endif  // TRTIS_ENABLE_GPU
+
   for (auto& payload : *payloads) {
     const InferRequestHeader& request_header =
         payload.request_provider_->RequestHeader();
@@ -439,14 +449,14 @@ ReadStringOutputTensor(
       void* content;
       TRTSERVER_Memory_Type preferred_memory_type = TRTSERVER_MEMORY_CPU;
       TRTSERVER_Memory_Type actual_memory_type;
-      int64_t device_id;
+      int64_t actual_memory_type_id;
       Status status = payload.response_provider_->AllocateOutputBuffer(
           output_name, &content, serialized.size(), shape,
-          preferred_memory_type, 0, &actual_memory_type, &device_id);
+          preferred_memory_type, 0 /* preferred_memory_type_id */,
+          &actual_memory_type, &actual_memory_type_id);
       if (status.IsOk()) {
         if (actual_memory_type == TRTSERVER_MEMORY_GPU) {
 #ifdef TRTIS_ENABLE_GPU
-          cudaStream_t stream = nullptr;
           cudaError_t err = cudaMemcpyAsync(
               content, reinterpret_cast<const void*>(serialized.c_str()),
               serialized.size(), cudaMemcpyDeviceToHost, stream);
@@ -458,7 +468,7 @@ ReadStringOutputTensor(
                     " CUDA copy from CPU memory to get String output data: " +
                     std::string(cudaGetErrorString(err)));
           } else {
-            cudaStreamSynchronize(stream);
+            cuda_copy = true;
           }
 #endif  // TRTIS_ENABLE_GPU
         } else {
@@ -473,6 +483,12 @@ ReadStringOutputTensor(
 
     tensor_element_idx += expected_element_cnt;
   }
+
+#ifdef TRTIS_ENABLE_GPU
+  if (cuda_copy) {
+    cudaStreamSynchronize(stream);
+  }
+#endif  // TRTIS_ENABLE_GPU
 }
 
 }  // namespace

--- a/src/backends/tensorflow/base_backend.cc
+++ b/src/backends/tensorflow/base_backend.cc
@@ -488,6 +488,13 @@ ReadStringOutputTensor(
   if (cuda_copy) {
     cudaStreamSynchronize(stream);
   }
+  if (stream != nullptr) {
+    cudaError_t err = cudaStreamDestroy(stream);
+    if (err != cudaSuccess) {
+      LOG_ERROR << "Failed to destroy cuda stream: " << cudaGetErrorString(err);
+    }
+    stream = nullptr;
+  }
 #endif  // TRTIS_ENABLE_GPU
 }
 

--- a/src/core/backend_context.cc
+++ b/src/core/backend_context.cc
@@ -165,12 +165,13 @@ BackendContext::SetFixedSizeOutputBuffer(
     if (payload.status_.IsOk() && (payload.response_provider_ != nullptr) &&
         payload.response_provider_->RequiresOutput(name)) {
       auto dst_memory_type = src_memory_type;
+      int64_t dst_device_id;
       void* buffer = nullptr;
 
       // try to get buffer with the same memory type as the output tensor
       Status status = payload.response_provider_->AllocateOutputBuffer(
           name, &buffer, expected_byte_size, content_shape, src_memory_type,
-          src_memory_type_id, &dst_memory_type);
+          src_memory_type_id, &dst_memory_type, , &dst_device_id);
 
       if (status.IsOk() && (expected_byte_size != 0)) {
         if (buffer == nullptr) {

--- a/src/core/backend_context.cc
+++ b/src/core/backend_context.cc
@@ -171,7 +171,7 @@ BackendContext::SetFixedSizeOutputBuffer(
       // try to get buffer with the same memory type as the output tensor
       Status status = payload.response_provider_->AllocateOutputBuffer(
           name, &buffer, expected_byte_size, content_shape, src_memory_type,
-          src_memory_type_id, &dst_memory_type, , &dst_device_id);
+          src_memory_type_id, &dst_memory_type, &dst_device_id);
 
       if (status.IsOk() && (expected_byte_size != 0)) {
         if (buffer == nullptr) {

--- a/src/core/backend_context.cc
+++ b/src/core/backend_context.cc
@@ -211,8 +211,6 @@ BackendContext::CopyBuffer(
     memcpy(dst, src, byte_size);
   } else {
 #ifdef TRTIS_ENABLE_GPU
-    // [TODO] Add check for Peer Access between two GPUs and use
-    // when possible
     // [TODO] use cudaMemcpyDefault if UVM is supported for the device
     auto copy_kind = cudaMemcpyDeviceToDevice;
     if (src_memory_type == TRTSERVER_MEMORY_CPU) {

--- a/src/core/backend_context.cc
+++ b/src/core/backend_context.cc
@@ -122,8 +122,8 @@ BackendContext::SetInputBuffer(
       if (content_byte_size > 0) {
         bool cuda_used = false;
         payload.status_ = CopyBuffer(
-            name, src_memory_type, (int)src_memory_type_id, dst_memory_type,
-            (int)dst_memory_type_id, content_byte_size, content,
+            name, src_memory_type, src_memory_type_id, dst_memory_type,
+            dst_memory_type_id, content_byte_size, content,
             input_buffer + buffer_copy_offset + copied_byte_size, &cuda_used);
         cuda_copy |= cuda_used;
       }
@@ -181,9 +181,9 @@ BackendContext::SetFixedSizeOutputBuffer(
         } else {
           bool cuda_used = false;
           status = CopyBuffer(
-              name, src_memory_type, (int)src_memory_type_id, dst_memory_type,
-              (int)dst_memory_type_id, expected_byte_size,
-              content + content_offset, buffer, &cuda_used);
+              name, src_memory_type, src_memory_type_id, dst_memory_type,
+              dst_memory_type_id, expected_byte_size, content + content_offset,
+              buffer, &cuda_used);
           cuda_copy |= cuda_used;
         }
       }
@@ -200,8 +200,9 @@ BackendContext::SetFixedSizeOutputBuffer(
 Status
 BackendContext::CopyBuffer(
     const std::string& name, const TRTSERVER_Memory_Type src_memory_type,
-    const int src_memory_type_id, const TRTSERVER_Memory_Type dst_memory_type,
-    const int dst_memory_type_id, const size_t byte_size, const void* src,
+    const int64_t src_memory_type_id,
+    const TRTSERVER_Memory_Type dst_memory_type,
+    const int64_t dst_memory_type_id, const size_t byte_size, const void* src,
     void* dst, bool* cuda_used)
 {
   *cuda_used = false;

--- a/src/core/backend_context.cc
+++ b/src/core/backend_context.cc
@@ -165,20 +165,18 @@ BackendContext::SetFixedSizeOutputBuffer(
     if (payload.status_.IsOk() && (payload.response_provider_ != nullptr) &&
         payload.response_provider_->RequiresOutput(name)) {
       auto dst_memory_type = src_memory_type;
-      int64_t dst_device_id;
+      int64_t dst_memory_type_id;
       void* buffer = nullptr;
 
       // try to get buffer with the same memory type as the output tensor
       Status status = payload.response_provider_->AllocateOutputBuffer(
           name, &buffer, expected_byte_size, content_shape, src_memory_type,
-          src_memory_type_id, &dst_memory_type, &dst_device_id);
-
+          src_memory_type_id, &dst_memory_type, &dst_memory_type_id);
       if (status.IsOk() && (expected_byte_size != 0)) {
         if (buffer == nullptr) {
           status = Status(
               RequestStatusCode::INTERNAL,
-              "all attempts to allocate buffer for output '" + name +
-                  "' failed");
+              "failed to allocate buffer for output '" + name + "'");
         } else {
           bool cuda_used = false;
           status = CopyBuffer(

--- a/src/core/backend_context.cc
+++ b/src/core/backend_context.cc
@@ -211,8 +211,8 @@ BackendContext::CopyBuffer(
     memcpy(dst, src, byte_size);
   } else {
 #ifdef TRTIS_ENABLE_GPU
-    // [TODO] Add check for Peer Access between two GPUs before using
-    // cudaMemcpyPeerAsync and use DeviceToHost + HostToDevice otherwise
+    // [TODO] Add check for Peer Access between two GPUs and use
+    // when possible
     // [TODO] use cudaMemcpyDefault if UVM is supported for the device
     auto copy_kind = cudaMemcpyDeviceToDevice;
     if (src_memory_type == TRTSERVER_MEMORY_CPU) {

--- a/src/core/backend_context.h
+++ b/src/core/backend_context.h
@@ -76,8 +76,9 @@ struct BackendContext {
 
   Status CopyBuffer(
       const std::string& name, const TRTSERVER_Memory_Type src_memory_type,
-      const int src_memory_type_id, const TRTSERVER_Memory_Type dst_memory_type,
-      const int dst_memory_type_id, const size_t byte_size, const void* src,
+      const int64_t src_memory_type_id,
+      const TRTSERVER_Memory_Type dst_memory_type,
+      const int64_t dst_memory_type_id, const size_t byte_size, const void* src,
       void* dst, bool* cuda_used);
 
   // Name of the model instance

--- a/src/core/backend_context.h
+++ b/src/core/backend_context.h
@@ -76,8 +76,9 @@ struct BackendContext {
 
   Status CopyBuffer(
       const std::string& name, const TRTSERVER_Memory_Type src_memory_type,
-      const TRTSERVER_Memory_Type dst_memory_type, const size_t byte_size,
-      const void* src, void* dst, bool* cuda_used);
+      const int src_memory_type_id, const TRTSERVER_Memory_Type dst_memory_type,
+      const int dst_memory_type_id, const size_t byte_size, const void* src,
+      void* dst, bool* cuda_used);
 
   // Name of the model instance
   std::string name_;

--- a/src/core/ensemble_scheduler.cc
+++ b/src/core/ensemble_scheduler.cc
@@ -82,7 +82,7 @@ class EnsembleContext {
       TRTSERVER_ResponseAllocator* allocator, void** buffer,
       void** buffer_userp, const char* tensor_name, size_t byte_size,
       TRTSERVER_Memory_Type memory_type, int64_t memory_type_id, void* userp,
-      TRTSERVER_Memory_Type* allocated_memory_type);
+      TRTSERVER_Memory_Type* actual_memory_type, int64_t* actual_device_id);
   static TRTSERVER_Error* ResponseRelease(
       TRTSERVER_ResponseAllocator* allocator, void* buffer, void* buffer_userp,
       size_t byte_size, TRTSERVER_Memory_Type memory_type,
@@ -318,7 +318,7 @@ EnsembleContext::ResponseAlloc(
     TRTSERVER_ResponseAllocator* allocator, void** buffer, void** buffer_userp,
     const char* tensor_name, size_t byte_size,
     TRTSERVER_Memory_Type memory_type, int64_t memory_type_id, void* userp,
-    TRTSERVER_Memory_Type* allocated_memory_type)
+    TRTSERVER_Memory_Type* actual_memory_type, int64_t* actual_device_id)
 {
   auto tensor_data_map = reinterpret_cast<
       std::unordered_map<std::string, std::shared_ptr<AllocatedSystemMemory>>*>(

--- a/src/core/ensemble_scheduler.cc
+++ b/src/core/ensemble_scheduler.cc
@@ -666,10 +666,10 @@ EnsembleContext::CheckAndSetEnsembleOutput()
     memory_block->BufferAt(0, &content_size, &dst_memory_type, &memory_type_id);
 
     void* buffer;
-    int64_t device_id;
+    int64_t allocated_memory_type_id;
     RETURN_IF_ERROR(response_provider_->AllocateOutputBuffer(
         output_pair.first, &buffer, expected_byte_size, shape, dst_memory_type,
-        memory_type_id, &allocated_memory_type, &device_id));
+        memory_type_id, &allocated_memory_type, &allocated_memory_type_id));
 
     // Done with this output if 'expected_byte_size' is 0
     if (expected_byte_size == 0) {
@@ -677,8 +677,7 @@ EnsembleContext::CheckAndSetEnsembleOutput()
     } else if (buffer == nullptr) {
       return Status(
           RequestStatusCode::INTERNAL,
-          "all attempts to allocate buffer for output '" + output_pair.first +
-              "' failed");
+          "failed to allocate buffer for output '" + output_pair.first + "'");
     }
 
     size_t content_offset = 0;

--- a/src/core/ensemble_scheduler.cc
+++ b/src/core/ensemble_scheduler.cc
@@ -688,7 +688,7 @@ EnsembleContext::CheckAndSetEnsembleOutput()
         content_idx, &content_size, &src_memory_type, &memory_type_id);
     while (content != nullptr) {
       if ((src_memory_type == TRTSERVER_MEMORY_CPU) &&
-          (dst_memory_type == TRTSERVER_MEMORY_CPU)) {
+          (allocated_memory_type == TRTSERVER_MEMORY_CPU)) {
         memcpy(((char*)buffer) + content_offset, content, content_size);
       } else {
 #ifdef TRTIS_ENABLE_GPU

--- a/src/core/ensemble_scheduler.cc
+++ b/src/core/ensemble_scheduler.cc
@@ -665,13 +665,10 @@ EnsembleContext::CheckAndSetEnsembleOutput()
     memory_block->BufferAt(0, &content_size, &dst_memory_type, &memory_type_id);
 
     void* buffer;
-    // Don't return on error if we haven't try all types
-    auto status = response_provider_->AllocateOutputBuffer(
+    int64_t device_id;
+    RETURN_IF_ERROR(response_provider_->AllocateOutputBuffer(
         output_pair.first, &buffer, expected_byte_size, shape, dst_memory_type,
-        memory_type_id, &actual_memory_type);
-    if (dst_memory_type == TRTSERVER_MEMORY_CPU) {
-      RETURN_IF_ERROR(status);
-    }
+        memory_type_id, &actual_memory_type, &device_id));
 
     // Done with this output if 'expected_byte_size' is 0
     if (expected_byte_size == 0) {

--- a/src/core/ensemble_scheduler.cc
+++ b/src/core/ensemble_scheduler.cc
@@ -79,10 +79,10 @@ class EnsembleContext {
 
  private:
   static TRTSERVER_Error* ResponseAlloc(
-      TRTSERVER_ResponseAllocator* allocator, void** buffer,
-      void** buffer_userp, const char* tensor_name, size_t byte_size,
-      TRTSERVER_Memory_Type memory_type, int64_t memory_type_id, void* userp,
-      TRTSERVER_Memory_Type* allocated_memory_type,
+      TRTSERVER_ResponseAllocator* allocator, const char* tensor_name,
+      size_t byte_size, TRTSERVER_Memory_Type preferred_memory_type,
+      int64_t preferred_memory_type_id, void* userp, void** buffer,
+      void** buffer_userp, TRTSERVER_Memory_Type* allocated_memory_type,
       int64_t* allocated_memory_type_id);
   static TRTSERVER_Error* ResponseRelease(
       TRTSERVER_ResponseAllocator* allocator, void* buffer, void* buffer_userp,
@@ -316,10 +316,10 @@ EnsembleContext::EnsembleContext(
 
 TRTSERVER_Error*
 EnsembleContext::ResponseAlloc(
-    TRTSERVER_ResponseAllocator* allocator, void** buffer, void** buffer_userp,
-    const char* tensor_name, size_t byte_size,
-    TRTSERVER_Memory_Type memory_type, int64_t memory_type_id, void* userp,
-    TRTSERVER_Memory_Type* allocated_memory_type,
+    TRTSERVER_ResponseAllocator* allocator, const char* tensor_name,
+    size_t byte_size, TRTSERVER_Memory_Type preferred_memory_type,
+    int64_t preferred_memory_type_id, void* userp, void** buffer,
+    void** buffer_userp, TRTSERVER_Memory_Type* allocated_memory_type,
     int64_t* allocated_memory_type_id)
 {
   auto tensor_data_map = reinterpret_cast<
@@ -330,7 +330,7 @@ EnsembleContext::ResponseAlloc(
   *buffer_userp = nullptr;
 
   auto allocated_buffer = std::make_shared<AllocatedSystemMemory>(
-      byte_size, memory_type, memory_type_id);
+      byte_size, preferred_memory_type, preferred_memory_type_id);
 
   auto mutable_buffer = allocated_buffer->MutableBuffer(
       allocated_memory_type, allocated_memory_type_id);

--- a/src/core/provider.cc
+++ b/src/core/provider.cc
@@ -704,8 +704,10 @@ InferResponseProvider::MutableResponseHeader()
 Status
 InferResponseProvider::AllocateOutputBuffer(
     const std::string& name, void** content, size_t content_byte_size,
-    const std::vector<int64_t>& content_shape, const TRTSERVER_Memory_Type preferred_memory_type, int64_t preferred_memory_type_id,
-    TRTSERVER_Memory_Type* actual_memory_type, int64_t* actual_device_id)
+    const std::vector<int64_t>& content_shape,
+    const TRTSERVER_Memory_Type preferred_memory_type,
+    int64_t preferred_memory_type_id, TRTSERVER_Memory_Type* actual_memory_type,
+    int64_t* actual_device_id)
 {
   *content = nullptr;
 
@@ -778,7 +780,8 @@ InferResponseProvider::AllocateOutputBuffer(
 #endif  // TRTIS_ENABLE_GPU
   TRTSERVER_Error* err = alloc_fn_(
       allocator_, &buffer, &buffer_userp, name.c_str(), alloc_byte_size,
-      preferred_memory_type, preferred_memory_type_id, alloc_userp_, actual_memory_type, actual_device_id);
+      preferred_memory_type, preferred_memory_type_id, alloc_userp_,
+      actual_memory_type, actual_device_id);
   Status status;
 #ifdef TRTIS_ENABLE_GPU
   cuerr = cudaSetDevice(current_device);

--- a/src/core/provider.cc
+++ b/src/core/provider.cc
@@ -705,7 +705,7 @@ Status
 InferResponseProvider::AllocateOutputBuffer(
     const std::string& name, void** content, size_t content_byte_size,
     const std::vector<int64_t>& content_shape, const TRTSERVER_Memory_Type preferred_memory_type, int64_t preferred_memory_type_id,
-    TRTSERVER_Memory_Type* actual_memory_type)
+    TRTSERVER_Memory_Type* actual_memory_type, int64_t* actual_device_id)
 {
   *content = nullptr;
 
@@ -728,6 +728,7 @@ InferResponseProvider::AllocateOutputBuffer(
   loutput->byte_size_ = content_byte_size;
   loutput->memory_type_ = preferred_memory_type;
   loutput->memory_type_id_ = preferred_memory_type_id;
+  // *actual_memory_type = preferred_memory_type;
 
   // For cls result, the provider will be responsible for allocating
   // the requested memory. The user-provided allocator should only be invoked
@@ -777,7 +778,7 @@ InferResponseProvider::AllocateOutputBuffer(
 #endif  // TRTIS_ENABLE_GPU
   TRTSERVER_Error* err = alloc_fn_(
       allocator_, &buffer, &buffer_userp, name.c_str(), alloc_byte_size,
-      preferred_memory_type, preferred_memory_type_id, alloc_userp_, actual_memory_type);
+      preferred_memory_type, preferred_memory_type_id, alloc_userp_, actual_memory_type, actual_device_id);
   Status status;
 #ifdef TRTIS_ENABLE_GPU
   cuerr = cudaSetDevice(current_device);
@@ -806,6 +807,8 @@ InferResponseProvider::AllocateOutputBuffer(
 
   loutput->release_buffer_ = buffer;
   loutput->release_userp_ = buffer_userp;
+  loutput->memory_type_ = *actual_memory_type;
+  loutput->memory_type_id_ = *actual_device_id;
 
   return Status::Success;
 }

--- a/src/core/provider.cc
+++ b/src/core/provider.cc
@@ -756,8 +756,8 @@ InferResponseProvider::AllocateOutputBuffer(
 
   void* buffer = nullptr;
   void* buffer_userp = nullptr;
-  TRTSERVER_Memory_Type raw_actual_memory_type = preferred_memory_type;
-  int64_t raw_actual_memory_type_id = preferred_memory_type_id;
+  TRTSERVER_Memory_Type raw_actual_memory_type;
+  int64_t raw_actual_memory_type_id;
 #ifdef TRTIS_ENABLE_GPU
   int current_device;
   auto cuerr = cudaGetDevice(&current_device);

--- a/src/core/provider.cc
+++ b/src/core/provider.cc
@@ -756,8 +756,8 @@ InferResponseProvider::AllocateOutputBuffer(
 
   void* buffer = nullptr;
   void* buffer_userp = nullptr;
-  TRTSERVER_Memory_Type raw_actual_memory_type;
-  int64_t raw_actual_memory_type_id;
+  TRTSERVER_Memory_Type raw_actual_memory_type = preferred_memory_type;
+  int64_t raw_actual_memory_type_id = preferred_memory_type_id;
 #ifdef TRTIS_ENABLE_GPU
   int current_device;
   auto cuerr = cudaGetDevice(&current_device);

--- a/src/core/provider.cc
+++ b/src/core/provider.cc
@@ -771,8 +771,8 @@ InferResponseProvider::AllocateOutputBuffer(
   }
 #endif  // TRTIS_ENABLE_GPU
   TRTSERVER_Error* err = alloc_fn_(
-      allocator_, &buffer, &buffer_userp, name.c_str(), alloc_byte_size,
-      preferred_memory_type, preferred_memory_type_id, alloc_userp_,
+      allocator_, name.c_str(), alloc_byte_size, preferred_memory_type,
+      preferred_memory_type_id, alloc_userp_, &buffer, &buffer_userp,
       &raw_actual_memory_type, &raw_actual_memory_type_id);
   if (!is_class) {
     *content = buffer;

--- a/src/core/provider.h
+++ b/src/core/provider.h
@@ -297,10 +297,10 @@ class InferResponseProvider {
   Status AllocateOutputBuffer(
       const std::string& name, void** content, size_t content_byte_size,
       const std::vector<int64_t>& content_shape,
-      const TRTSERVER_Memory_Type preferred_memory_type = TRTSERVER_MEMORY_CPU,
-      int64_t preferred_memory_type_id = 0,
-      TRTSERVER_Memory_Type* actual_memory_type = nullptr,
-      int64_t* actual_device_id = nullptr);
+      const TRTSERVER_Memory_Type preferred_memory_type,
+      const int64_t preferred_memory_type_id,
+      TRTSERVER_Memory_Type* actual_memory_type,
+      int64_t* actual_memory_type_id);
 
   // Get the address and byte-size of an output buffer. Error is
   // returned if the buffer is not already allocated.

--- a/src/core/provider.h
+++ b/src/core/provider.h
@@ -297,8 +297,8 @@ class InferResponseProvider {
   Status AllocateOutputBuffer(
       const std::string& name, void** content, size_t content_byte_size,
       const std::vector<int64_t>& content_shape,
-      TRTSERVER_Memory_Type preferred_memory_type = TRTSERVER_MEMORY_CPU,
-      int64_t preferred_memory_type_id = 0);
+      const TRTSERVER_Memory_Type preferred_memory_type = TRTSERVER_MEMORY_CPU,
+      int64_t preferred_memory_type_id = 0, TRTSERVER_Memory_Type* actual_memory_type = nullptr);
 
   // Get the address and byte-size of an output buffer. Error is
   // returned if the buffer is not already allocated.

--- a/src/core/provider.h
+++ b/src/core/provider.h
@@ -298,7 +298,7 @@ class InferResponseProvider {
       const std::string& name, void** content, size_t content_byte_size,
       const std::vector<int64_t>& content_shape,
       const TRTSERVER_Memory_Type preferred_memory_type = TRTSERVER_MEMORY_CPU,
-      int64_t preferred_memory_type_id = 0, TRTSERVER_Memory_Type* actual_memory_type = nullptr);
+      int64_t preferred_memory_type_id = 0, TRTSERVER_Memory_Type* actual_memory_type = nullptr, int64_t* actual_device_id = nullptr);
 
   // Get the address and byte-size of an output buffer. Error is
   // returned if the buffer is not already allocated.

--- a/src/core/provider.h
+++ b/src/core/provider.h
@@ -298,7 +298,9 @@ class InferResponseProvider {
       const std::string& name, void** content, size_t content_byte_size,
       const std::vector<int64_t>& content_shape,
       const TRTSERVER_Memory_Type preferred_memory_type = TRTSERVER_MEMORY_CPU,
-      int64_t preferred_memory_type_id = 0, TRTSERVER_Memory_Type* actual_memory_type = nullptr, int64_t* actual_device_id = nullptr);
+      int64_t preferred_memory_type_id = 0,
+      TRTSERVER_Memory_Type* actual_memory_type = nullptr,
+      int64_t* actual_device_id = nullptr);
 
   // Get the address and byte-size of an output buffer. Error is
   // returned if the buffer is not already allocated.

--- a/src/core/trtserver.cc
+++ b/src/core/trtserver.cc
@@ -570,6 +570,18 @@ TRTSERVER_SharedMemoryBlockDelete(
   return nullptr;  // Success
 }
 
+TRTSERVER_Error*
+TRTSERVER_SharedMemoryBlockDevice(
+    TRTSERVER_SharedMemoryBlock* shared_memory_block,
+    TRTSERVER_Memory_Type* memory_type, int* device_id)
+{
+  TrtServerSharedMemoryBlock* lsmb =
+      reinterpret_cast<TrtServerSharedMemoryBlock*>(shared_memory_block);
+  *memory_type = lsmb->Type();
+  *device_id = lsmb->DeviceId();
+  return nullptr;  // Success
+}
+
 //
 // TRTSERVER_ResponseAllocator
 //

--- a/src/core/trtserver.cc
+++ b/src/core/trtserver.cc
@@ -571,17 +571,26 @@ TRTSERVER_SharedMemoryBlockDelete(
 }
 
 TRTSERVER_Error*
-TRTSERVER_SharedMemoryBlockDevice(
+TRTSERVER_SharedMemoryBlockMemoryType(
     TRTSERVER_SharedMemoryBlock* shared_memory_block,
-    TRTSERVER_Memory_Type* memory_type, int* device_id)
+    TRTSERVER_Memory_Type* memory_type)
 {
   TrtServerSharedMemoryBlock* lsmb =
       reinterpret_cast<TrtServerSharedMemoryBlock*>(shared_memory_block);
   *memory_type = lsmb->Type();
+  return nullptr;  // Success
+}
+
+TRTSERVER_Error*
+TRTSERVER_SharedMemoryBlockMemoryTypeId(
+    TRTSERVER_SharedMemoryBlock* shared_memory_block, int64_t* memory_type_id)
+{
+  TrtServerSharedMemoryBlock* lsmb =
+      reinterpret_cast<TrtServerSharedMemoryBlock*>(shared_memory_block);
 #ifdef TRTIS_ENABLE_GPU
-  *device_id = lsmb->DeviceId();
+  *memory_type_id = lsmb->DeviceId();
 #else
-  *device_id = 0;
+  *memory_type_id = 0;
 #endif             // TRTIS_ENABLE_GPU
   return nullptr;  // Success
 }

--- a/src/core/trtserver.cc
+++ b/src/core/trtserver.cc
@@ -578,7 +578,11 @@ TRTSERVER_SharedMemoryBlockDevice(
   TrtServerSharedMemoryBlock* lsmb =
       reinterpret_cast<TrtServerSharedMemoryBlock*>(shared_memory_block);
   *memory_type = lsmb->Type();
+#ifdef TRTIS_ENABLE_GPU
   *device_id = lsmb->DeviceId();
+#else
+  *device_id = 0;
+#endif             // TRTIS_ENABLE_GPU
   return nullptr;  // Success
 }
 

--- a/src/core/trtserver.cc
+++ b/src/core/trtserver.cc
@@ -585,9 +585,9 @@ TRTSERVER_Error*
 TRTSERVER_SharedMemoryBlockMemoryTypeId(
     TRTSERVER_SharedMemoryBlock* shared_memory_block, int64_t* memory_type_id)
 {
+#ifdef TRTIS_ENABLE_GPU
   TrtServerSharedMemoryBlock* lsmb =
       reinterpret_cast<TrtServerSharedMemoryBlock*>(shared_memory_block);
-#ifdef TRTIS_ENABLE_GPU
   *memory_type_id = lsmb->DeviceId();
 #else
   *memory_type_id = 0;

--- a/src/core/trtserver.h
+++ b/src/core/trtserver.h
@@ -169,6 +169,15 @@ TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_SharedMemoryBlockGpuNew(
 TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_SharedMemoryBlockDelete(
     TRTSERVER_SharedMemoryBlock* shared_memory_block);
 
+/// Get the memory type of a shared memory block object.
+/// \param shared_memory_block The object whose memory type is required.
+/// \param memory_type Returns the memory type of the shared memory block.
+/// \param device_id The CPU/GPU number the shared memory region is in.
+/// \return a TRTSERVER_Error indicating success or failure.
+TRTSERVER_Error* TRTSERVER_SharedMemoryBlockDevice(
+    TRTSERVER_SharedMemoryBlock* shared_memory_block,
+    TRTSERVER_Memory_Type* memory_type, int* device_id);
+
 /// TRTSERVER_ResponseAllocator
 ///
 /// Object representing a memory allocator for inference response
@@ -214,7 +223,7 @@ typedef TRTSERVER_Error* (*TRTSERVER_ResponseAllocatorAllocFn_t)(
     TRTSERVER_ResponseAllocator* allocator, void** buffer, void** buffer_userp,
     const char* tensor_name, size_t byte_size,
     TRTSERVER_Memory_Type memory_type, int64_t memory_type_id, void* userp,
-    TRTSERVER_Memory_Type* actual_memory_type);
+    TRTSERVER_Memory_Type* actual_memory_type, int64_t* actual_device_id);
 
 /// Type for function that is called when the server no longer holds
 /// any reference to a buffer allocated by

--- a/src/core/trtserver.h
+++ b/src/core/trtserver.h
@@ -197,9 +197,11 @@ TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_SharedMemoryBlockDelete(
 ///
 /// If the function is called with 'byte_size' non-zero but an
 /// allocation is not possible for the requested 'memory_type', the
-/// function should return success and set 'buffer' == nullptr to
-/// indicate that an allocation in the requested 'memory_type' is not
-/// possible. In this case the function may be called again for the
+/// function will try a different memory type and return that as the
+/// 'actual_memory_type'. If this too fails then it returns failure and
+/// sets 'buffer' == nullptr to indicate that an allocation in the requested
+/// 'memory_type' as well as the 'actual_memory_type' is not possible.
+/// In this case the function may be called again for the
 /// same 'tensor_name' but with a different 'memory_type'.
 ///
 /// The function should return a TRTSERVER_Error object if a failure
@@ -211,7 +213,8 @@ TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_SharedMemoryBlockDelete(
 typedef TRTSERVER_Error* (*TRTSERVER_ResponseAllocatorAllocFn_t)(
     TRTSERVER_ResponseAllocator* allocator, void** buffer, void** buffer_userp,
     const char* tensor_name, size_t byte_size,
-    TRTSERVER_Memory_Type memory_type, int64_t memory_type_id, void* userp);
+    TRTSERVER_Memory_Type memory_type, int64_t memory_type_id, void* userp,
+    TRTSERVER_Memory_Type* actual_memory_type);
 
 /// Type for function that is called when the server no longer holds
 /// any reference to a buffer allocated by

--- a/src/core/trtserver.h
+++ b/src/core/trtserver.h
@@ -172,11 +172,17 @@ TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_SharedMemoryBlockDelete(
 /// Get the memory type of a shared memory block object.
 /// \param shared_memory_block The object whose memory type is required.
 /// \param memory_type Returns the memory type of the shared memory block.
-/// \param device_id The CPU/GPU number the shared memory region is in.
 /// \return a TRTSERVER_Error indicating success or failure.
-TRTSERVER_Error* TRTSERVER_SharedMemoryBlockDevice(
+TRTSERVER_Error* TRTSERVER_SharedMemoryBlockMemoryType(
     TRTSERVER_SharedMemoryBlock* shared_memory_block,
-    TRTSERVER_Memory_Type* memory_type, int* device_id);
+    TRTSERVER_Memory_Type* memory_type);
+
+/// Get the memory type id of a shared memory block object.
+/// \param shared_memory_block The object whose memory type is required.
+/// \param memory_type_id The CPU/GPU number the shared memory region is in.
+/// \return a TRTSERVER_Error indicating success or failure.
+TRTSERVER_Error* TRTSERVER_SharedMemoryBlockMemoryTypeId(
+    TRTSERVER_SharedMemoryBlock* shared_memory_block, int64_t* memory_type_id);
 
 /// TRTSERVER_ResponseAllocator
 ///
@@ -204,26 +210,23 @@ TRTSERVER_Error* TRTSERVER_SharedMemoryBlockDevice(
 /// case the function should return success and set 'buffer' ==
 /// nullptr.
 ///
-/// If the function is called with 'byte_size' non-zero but an
-/// allocation is not possible for the requested 'memory_type', the
-/// function will try a different memory type and return that as the
-/// 'actual_memory_type'. If this too fails then it returns failure and
-/// sets 'buffer' == nullptr to indicate that an allocation in the requested
-/// 'memory_type' as well as the 'actual_memory_type' is not possible.
-/// In this case the function may be called again for the
-/// same 'tensor_name' but with a different 'memory_type'.
+/// If the function is called with 'byte_size' non-zero the function should
+/// allocate a contiguous buffer of the requested size. If possible the function
+/// should allocate the buffer in the requested 'memory_type' and
+/// 'memory_type_id', but the function is free to allocate the buffer in any
+/// memory. The function must return in 'actual_memory_type' and
+/// 'actual_memory_type_id' the memory where the buffer is allocated.
 ///
 /// The function should return a TRTSERVER_Error object if a failure
 /// occurs while attempting an allocation. If an error object is
-/// returned, or if 'buffer' == nullptr is returned on all attempts
-/// for a result tensor, the inference server will assume allocation
+/// returned for a result tensor, the inference server will assume allocation
 /// is not possible for the result buffer and will abort the inference
 /// request.
 typedef TRTSERVER_Error* (*TRTSERVER_ResponseAllocatorAllocFn_t)(
     TRTSERVER_ResponseAllocator* allocator, void** buffer, void** buffer_userp,
     const char* tensor_name, size_t byte_size,
     TRTSERVER_Memory_Type memory_type, int64_t memory_type_id, void* userp,
-    TRTSERVER_Memory_Type* actual_memory_type, int64_t* actual_device_id);
+    TRTSERVER_Memory_Type* actual_memory_type, int64_t* actual_memory_type_id);
 
 /// Type for function that is called when the server no longer holds
 /// any reference to a buffer allocated by

--- a/src/core/trtserver.h
+++ b/src/core/trtserver.h
@@ -223,9 +223,9 @@ TRTSERVER_Error* TRTSERVER_SharedMemoryBlockMemoryTypeId(
 /// is not possible for the result buffer and will abort the inference
 /// request.
 typedef TRTSERVER_Error* (*TRTSERVER_ResponseAllocatorAllocFn_t)(
-    TRTSERVER_ResponseAllocator* allocator, void** buffer, void** buffer_userp,
-    const char* tensor_name, size_t byte_size,
-    TRTSERVER_Memory_Type memory_type, int64_t memory_type_id, void* userp,
+    TRTSERVER_ResponseAllocator* allocator, const char* tensor_name,
+    size_t byte_size, TRTSERVER_Memory_Type memory_type, int64_t memory_type_id,
+    void* userp, void** buffer, void** buffer_userp,
     TRTSERVER_Memory_Type* actual_memory_type, int64_t* actual_memory_type_id);
 
 /// Type for function that is called when the server no longer holds

--- a/src/core/trtserver.h
+++ b/src/core/trtserver.h
@@ -179,7 +179,7 @@ TRTSERVER_Error* TRTSERVER_SharedMemoryBlockMemoryType(
 
 /// Get the memory type id of a shared memory block object.
 /// \param shared_memory_block The object whose memory type is required.
-/// \param memory_type_id The CPU/GPU number the shared memory region is in.
+/// \param memory_type_id The device ID if the region is in GPU shared memory.
 /// \return a TRTSERVER_Error indicating success or failure.
 TRTSERVER_Error* TRTSERVER_SharedMemoryBlockMemoryTypeId(
     TRTSERVER_SharedMemoryBlock* shared_memory_block, int64_t* memory_type_id);

--- a/src/custom/identity/identity.cc
+++ b/src/custom/identity/identity.cc
@@ -289,9 +289,17 @@ Context::Execute(
         if (copy_type == cudaMemcpyHostToHost) {
           memcpy(output_buffer + total_byte_size, content, content_byte_size);
         } else {
-          auto err = cudaMemcpyAsync(
-              output_buffer + total_byte_size, content, content_byte_size,
-              copy_type, stream_);
+          cudaError_t err;
+          if ((src_memory_type_id != dst_memory_type_id) &&
+              (copy_type == cudaMemcpyDeviceToDevice)) {
+            err = cudaMemcpyPeerAsync(
+                output_buffer + total_byte_size, dst_memory_type_id, content,
+                src_memory_type_id, content_byte_size, stream_);
+          } else {
+            err = cudaMemcpyAsync(
+                output_buffer + total_byte_size, content, content_byte_size,
+                copy_type, stream_);
+          }
           if (err != cudaSuccess) {
             payload.error_code = kCopyBuffer;
             break;

--- a/src/servers/grpc_server.cc
+++ b/src/servers/grpc_server.cc
@@ -635,7 +635,8 @@ TRTSERVER_Error*
 InferResponseAlloc(
     TRTSERVER_ResponseAllocator* allocator, void** buffer, void** buffer_userp,
     const char* tensor_name, size_t byte_size,
-    TRTSERVER_Memory_Type memory_type, int64_t memory_type_id, void* userp)
+    TRTSERVER_Memory_Type preferred_memory_type, int64_t memory_type_id,
+    void* userp, TRTSERVER_Memory_Type* actual_memory_type)
 {
   AllocPayload* payload = reinterpret_cast<AllocPayload*>(userp);
   InferResponse* response = payload->response_;
@@ -646,9 +647,9 @@ InferResponseAlloc(
 
   // Can't allocate for any memory type other than CPU. If byte size is 0,
   // proceed regardless of memory type as no allocation is required.
-  if ((memory_type != TRTSERVER_MEMORY_CPU) && (byte_size != 0)) {
-    LOG_VERBOSE(1) << "GRPC allocation failed for type " << memory_type
-                   << " for " << tensor_name;
+  if ((preferred_memory_type != TRTSERVER_MEMORY_CPU) && (byte_size != 0)) {
+    LOG_VERBOSE(1) << "GRPC allocation failed for type "
+                   << preferred_memory_type << " for " << tensor_name;
     return nullptr;
   }
 

--- a/src/servers/grpc_server.cc
+++ b/src/servers/grpc_server.cc
@@ -683,12 +683,13 @@ InferResponseAlloc(
     }
 
     if (!use_shm) {
-      // Can't allocate for any memory type other than CPU. If byte size is 0,
-      // proceed regardless of memory type as no allocation is required.
+      // Can't allocate for any memory type other than CPU. If asked to
+      // allocate on GPU memory then force allocation on CPu instead.
       if (*actual_memory_type != TRTSERVER_MEMORY_CPU) {
         LOG_VERBOSE(1) << "GRPC allocation failed for type "
-                       << *actual_memory_type << " for " << tensor_name;
-        return nullptr;
+                       << *actual_memory_type << " for " << tensor_name
+                       << ", will use type " << TRTSERVER_MEMORY_CPU;
+        *actual_memory_type = TRTSERVER_MEMORY_CPU;
       }
 
       raw_output->resize(byte_size);

--- a/src/servers/grpc_server.cc
+++ b/src/servers/grpc_server.cc
@@ -134,6 +134,8 @@ struct AllocPayload {
   struct ShmInfo {
     void* base_;
     size_t byte_size_;
+    TRTSERVER_Memory_Type memory_type_;
+    int64_t device_id_;
   };
 
   using TensorShmMap = std::unordered_map<std::string, ShmInfo>;
@@ -636,7 +638,8 @@ InferResponseAlloc(
     TRTSERVER_ResponseAllocator* allocator, void** buffer, void** buffer_userp,
     const char* tensor_name, size_t byte_size,
     TRTSERVER_Memory_Type preferred_memory_type, int64_t memory_type_id,
-    void* userp, TRTSERVER_Memory_Type* actual_memory_type)
+    void* userp, TRTSERVER_Memory_Type* actual_memory_type,
+    int64_t* actual_device_id)
 {
   AllocPayload* payload = reinterpret_cast<AllocPayload*>(userp);
   InferResponse* response = payload->response_;
@@ -644,14 +647,6 @@ InferResponseAlloc(
 
   *buffer = nullptr;
   *buffer_userp = nullptr;
-
-  // Can't allocate for any memory type other than CPU. If byte size is 0,
-  // proceed regardless of memory type as no allocation is required.
-  if ((preferred_memory_type != TRTSERVER_MEMORY_CPU) && (byte_size != 0)) {
-    LOG_VERBOSE(1) << "GRPC allocation failed for type "
-                   << preferred_memory_type << " for " << tensor_name;
-    return nullptr;
-  }
 
   // Called once for each result tensor in the inference request. Must
   // always add a raw output into the response's list of outputs so
@@ -678,6 +673,8 @@ InferResponseAlloc(
         }
 
         *buffer = const_cast<void*>(pr->second.base_);
+        *actual_memory_type = pr->second.memory_type_;
+        *actual_device_id = pr->second.device_id_;
         use_shm = true;
 
         LOG_VERBOSE(1) << "GRPC shared-memory: " << tensor_name << ", size "
@@ -686,6 +683,14 @@ InferResponseAlloc(
     }
 
     if (!use_shm) {
+      // Can't allocate for any memory type other than CPU. If byte size is 0,
+      // proceed regardless of memory type as no allocation is required.
+      if (*actual_memory_type != TRTSERVER_MEMORY_CPU) {
+        LOG_VERBOSE(1) << "GRPC allocation failed for type "
+                       << *actual_memory_type << " for " << tensor_name;
+        return nullptr;
+      }
+
       raw_output->resize(byte_size);
       *buffer = static_cast<void*>(&((*raw_output)[0]));
 
@@ -728,21 +733,24 @@ InferAllocatorPayload(
   // invoked.
   for (const auto& io : request_header.output()) {
     if (io.has_shared_memory()) {
-      TRTSERVER_SharedMemoryBlock* smb = nullptr;
-      RETURN_IF_ERR(smb_manager->Get(&smb, io.shared_memory().name()));
-
       if (alloc_payload->shm_map_ == nullptr) {
         alloc_payload->shm_map_ = new AllocPayload::TensorShmMap;
       }
 
       void* base;
+      TRTSERVER_SharedMemoryBlock* smb = nullptr;
+      RETURN_IF_ERR(smb_manager->Get(&smb, io.shared_memory().name()));
       RETURN_IF_ERR(TRTSERVER_ServerSharedMemoryAddress(
           trtserver.get(), smb, io.shared_memory().offset(),
           io.shared_memory().byte_size(), &base));
 
+      TRTSERVER_Memory_Type memory_type;
+      int device_id;
+      TRTSERVER_SharedMemoryBlockDevice(smb, &memory_type, &device_id);
+
       alloc_payload->shm_map_->emplace(
-          io.name(),
-          AllocPayload::ShmInfo{base, io.shared_memory().byte_size()});
+          io.name(), AllocPayload::ShmInfo{base, io.shared_memory().byte_size(),
+                                           memory_type, device_id});
     }
   }
 

--- a/src/servers/grpc_server.cc
+++ b/src/servers/grpc_server.cc
@@ -637,9 +637,9 @@ TRTSERVER_Error*
 InferResponseAlloc(
     TRTSERVER_ResponseAllocator* allocator, void** buffer, void** buffer_userp,
     const char* tensor_name, size_t byte_size,
-    TRTSERVER_Memory_Type preferred_memory_type, int64_t preferred_memory_type_id,
-    void* userp, TRTSERVER_Memory_Type* actual_memory_type,
-    int64_t* actual_memory_type_id)
+    TRTSERVER_Memory_Type preferred_memory_type,
+    int64_t preferred_memory_type_id, void* userp,
+    TRTSERVER_Memory_Type* actual_memory_type, int64_t* actual_memory_type_id)
 {
   AllocPayload* payload = reinterpret_cast<AllocPayload*>(userp);
   InferResponse* response = payload->response_;

--- a/src/servers/grpc_server.cc
+++ b/src/servers/grpc_server.cc
@@ -637,7 +637,7 @@ TRTSERVER_Error*
 InferResponseAlloc(
     TRTSERVER_ResponseAllocator* allocator, void** buffer, void** buffer_userp,
     const char* tensor_name, size_t byte_size,
-    TRTSERVER_Memory_Type preferred_memory_type, int64_t memory_type_id,
+    TRTSERVER_Memory_Type preferred_memory_type, int64_t preferred_memory_type_id,
     void* userp, TRTSERVER_Memory_Type* actual_memory_type,
     int64_t* actual_memory_type_id)
 {
@@ -647,6 +647,8 @@ InferResponseAlloc(
 
   *buffer = nullptr;
   *buffer_userp = nullptr;
+  *actual_memory_type = preferred_memory_type;
+  *actual_memory_type_id = preferred_memory_type_id;
 
   // Called once for each result tensor in the inference request. Must
   // always add a raw output into the response's list of outputs so

--- a/src/servers/grpc_server.cc
+++ b/src/servers/grpc_server.cc
@@ -635,11 +635,11 @@ StatusHandler::Process(Handler::State* state, bool rpc_ok)
 //
 TRTSERVER_Error*
 InferResponseAlloc(
-    TRTSERVER_ResponseAllocator* allocator, void** buffer, void** buffer_userp,
-    const char* tensor_name, size_t byte_size,
-    TRTSERVER_Memory_Type preferred_memory_type,
-    int64_t preferred_memory_type_id, void* userp,
-    TRTSERVER_Memory_Type* actual_memory_type, int64_t* actual_memory_type_id)
+    TRTSERVER_ResponseAllocator* allocator, const char* tensor_name,
+    size_t byte_size, TRTSERVER_Memory_Type preferred_memory_type,
+    int64_t preferred_memory_type_id, void* userp, void** buffer,
+    void** buffer_userp, TRTSERVER_Memory_Type* actual_memory_type,
+    int64_t* actual_memory_type_id)
 {
   AllocPayload* payload = reinterpret_cast<AllocPayload*>(userp);
   InferResponse* response = payload->response_;

--- a/src/servers/http_server.cc
+++ b/src/servers/http_server.cc
@@ -361,8 +361,9 @@ HTTPAPIServer::ResponseAlloc(
       // Can't allocate for any memory type other than CPU.
       if (*actual_memory_type != TRTSERVER_MEMORY_CPU) {
         LOG_VERBOSE(1) << "HTTP allocation failed for type "
-                       << *actual_memory_type << " for " << tensor_name;
-        return nullptr;
+                       << *actual_memory_type << " for " << tensor_name
+                       << ", will use type " << TRTSERVER_MEMORY_CPU;
+        *actual_memory_type = TRTSERVER_MEMORY_CPU;
       }
 
       // Reserve requested space in evbuffer...

--- a/src/servers/http_server.cc
+++ b/src/servers/http_server.cc
@@ -230,7 +230,9 @@ class HTTPAPIServer : public HTTPServerImpl {
 
   using EVBufferPair = std::pair<
       evbuffer*,
-      std::unordered_map<std::string, std::pair<const void*, size_t>>>;
+      std::unordered_map<
+          std::string,
+          std::tuple<const void*, size_t, TRTSERVER_Memory_Type, int>>>;
 
   // Class object associated to evhtp thread, requests received are bounded
   // with the thread that accepts it. Need to keep track of that and let the
@@ -268,7 +270,8 @@ class HTTPAPIServer : public HTTPServerImpl {
       TRTSERVER_ResponseAllocator* allocator, void** buffer,
       void** buffer_userp, const char* tensor_name, size_t byte_size,
       TRTSERVER_Memory_Type preferred_memory_type, int64_t memory_type_id,
-      void* userp, TRTSERVER_Memory_Type* actual_memory_type);
+      void* userp, TRTSERVER_Memory_Type* actual_memory_type,
+      int64_t* actual_device_id);
   static TRTSERVER_Error* ResponseRelease(
       TRTSERVER_ResponseAllocator* allocator, void* buffer, void* buffer_userp,
       size_t byte_size, TRTSERVER_Memory_Type memory_type,
@@ -291,7 +294,9 @@ class HTTPAPIServer : public HTTPServerImpl {
       const std::string& model_name, const InferRequestHeader& request_header,
       evbuffer* input_buffer,
       TRTSERVER_InferenceRequestProvider* request_provider,
-      std::unordered_map<std::string, std::pair<const void*, size_t>>&
+      std::unordered_map<
+          std::string,
+          std::tuple<const void*, size_t, TRTSERVER_Memory_Type, int>>&
           output_shm_map);
 
   static void OKReplyCallback(evthr_t* thr, void* arg, void* shared);
@@ -321,11 +326,13 @@ HTTPAPIServer::ResponseAlloc(
     TRTSERVER_ResponseAllocator* allocator, void** buffer, void** buffer_userp,
     const char* tensor_name, size_t byte_size,
     TRTSERVER_Memory_Type preferred_memory_type, int64_t memory_type_id,
-    void* userp, TRTSERVER_Memory_Type* actual_memory_type)
+    void* userp, TRTSERVER_Memory_Type* actual_memory_type,
+    int64_t* actual_device_id)
 {
   auto userp_pair = reinterpret_cast<EVBufferPair*>(userp);
   evbuffer* evhttp_buffer = reinterpret_cast<evbuffer*>(userp_pair->first);
-  const std::unordered_map<std::string, std::pair<const void*, size_t>>&
+  const std::unordered_map<
+      std::string, std::tuple<const void*, size_t, TRTSERVER_Memory_Type, int>>&
       output_shm_map = userp_pair->second;
 
   *buffer = nullptr;
@@ -333,29 +340,31 @@ HTTPAPIServer::ResponseAlloc(
 
   // Don't need to do anything if no memory was requested.
   if (byte_size > 0) {
-    // Can't allocate for any memory type other than CPU.
-    if (preferred_memory_type != TRTSERVER_MEMORY_CPU) {
-      LOG_VERBOSE(1) << "HTTP allocation failed for type "
-                     << preferred_memory_type << " for " << tensor_name;
-      return nullptr;
-    }
-
     auto pr = output_shm_map.find(tensor_name);
     if (pr != output_shm_map.end()) {
       // If the output is in shared memory then check that the expected buffer
       // size is at least the byte size of the output.
-      if (byte_size > pr->second.second) {
+      if (byte_size > std::get<1>(pr->second)) {
         return TRTSERVER_ErrorNew(
             TRTSERVER_ERROR_INTERNAL,
             std::string(
                 "expected buffer size to be at least " +
-                std::to_string(pr->second.second) + " bytes but gets " +
+                std::to_string(std::get<1>(pr->second)) + " bytes but gets " +
                 std::to_string(byte_size) + " bytes in output tensor")
                 .c_str());
       }
 
-      *buffer = const_cast<void*>(pr->second.first);
+      *buffer = const_cast<void*>(std::get<0>(pr->second));
+      *actual_memory_type = std::get<2>(pr->second);
+      *actual_device_id = (int64_t)std::get<3>(pr->second);
     } else {
+      // Can't allocate for any memory type other than CPU.
+      if (*actual_memory_type != TRTSERVER_MEMORY_CPU) {
+        LOG_VERBOSE(1) << "HTTP allocation failed for type "
+                       << *actual_memory_type << " for " << tensor_name;
+        return nullptr;
+      }
+
       // Reserve requested space in evbuffer...
       struct evbuffer_iovec output_iovec;
       if (evbuffer_reserve_space(evhttp_buffer, byte_size, &output_iovec, 1) !=
@@ -846,7 +855,9 @@ HTTPAPIServer::EVBufferToInput(
     const std::string& model_name, const InferRequestHeader& request_header,
     evbuffer* input_buffer,
     TRTSERVER_InferenceRequestProvider* request_provider,
-    std::unordered_map<std::string, std::pair<const void*, size_t>>&
+    std::unordered_map<
+        std::string,
+        std::tuple<const void*, size_t, TRTSERVER_Memory_Type, int>>&
         output_shm_map)
 {
   // Extract individual input data from HTTP body and register in
@@ -958,10 +969,15 @@ HTTPAPIServer::EVBufferToInput(
           server_.get(), smb, io.shared_memory().offset(),
           io.shared_memory().byte_size(), &base));
 
+      TRTSERVER_Memory_Type memory_type;
+      int device_id;
+      TRTSERVER_SharedMemoryBlockDevice(smb, &memory_type, &device_id);
+
       output_shm_map.emplace(
           io.name(),
-          std::make_pair(
-              static_cast<const void*>(base), io.shared_memory().byte_size()));
+          std::make_tuple(
+              static_cast<const void*>(base), io.shared_memory().byte_size(),
+              memory_type, device_id));
     }
   }
 

--- a/src/servers/http_server.cc
+++ b/src/servers/http_server.cc
@@ -267,10 +267,10 @@ class HTTPAPIServer : public HTTPServerImpl {
 
  private:
   static TRTSERVER_Error* ResponseAlloc(
-      TRTSERVER_ResponseAllocator* allocator, void** buffer,
-      void** buffer_userp, const char* tensor_name, size_t byte_size,
-      TRTSERVER_Memory_Type preferred_memory_type, int64_t memory_type_id,
-      void* userp, TRTSERVER_Memory_Type* actual_memory_type,
+      TRTSERVER_ResponseAllocator* allocator, const char* tensor_name,
+      size_t byte_size, TRTSERVER_Memory_Type preferred_memory_type,
+      int64_t preferred_memory_type_id, void* userp, void** buffer,
+      void** buffer_userp, TRTSERVER_Memory_Type* actual_memory_type,
       int64_t* actual_memory_type_id);
   static TRTSERVER_Error* ResponseRelease(
       TRTSERVER_ResponseAllocator* allocator, void* buffer, void* buffer_userp,
@@ -323,11 +323,11 @@ class HTTPAPIServer : public HTTPServerImpl {
 
 TRTSERVER_Error*
 HTTPAPIServer::ResponseAlloc(
-    TRTSERVER_ResponseAllocator* allocator, void** buffer, void** buffer_userp,
-    const char* tensor_name, size_t byte_size,
-    TRTSERVER_Memory_Type preferred_memory_type,
-    int64_t preferred_memory_type_id, void* userp,
-    TRTSERVER_Memory_Type* actual_memory_type, int64_t* actual_memory_type_id)
+    TRTSERVER_ResponseAllocator* allocator, const char* tensor_name,
+    size_t byte_size, TRTSERVER_Memory_Type preferred_memory_type,
+    int64_t preferred_memory_type_id, void* userp, void** buffer,
+    void** buffer_userp, TRTSERVER_Memory_Type* actual_memory_type,
+    int64_t* actual_memory_type_id)
 {
   auto userp_pair = reinterpret_cast<EVBufferPair*>(userp);
   evbuffer* evhttp_buffer = reinterpret_cast<evbuffer*>(userp_pair->first);

--- a/src/servers/http_server.cc
+++ b/src/servers/http_server.cc
@@ -325,7 +325,7 @@ TRTSERVER_Error*
 HTTPAPIServer::ResponseAlloc(
     TRTSERVER_ResponseAllocator* allocator, void** buffer, void** buffer_userp,
     const char* tensor_name, size_t byte_size,
-    TRTSERVER_Memory_Type preferred_memory_type, int64_t memory_type_id,
+    TRTSERVER_Memory_Type preferred_memory_type, int64_t preferred_memory_type_id,
     void* userp, TRTSERVER_Memory_Type* actual_memory_type,
     int64_t* actual_memory_type_id)
 {
@@ -338,6 +338,8 @@ HTTPAPIServer::ResponseAlloc(
 
   *buffer = nullptr;
   *buffer_userp = nullptr;
+  *actual_memory_type = preferred_memory_type;
+  *actual_memory_type_id = preferred_memory_type_id;
 
   // Don't need to do anything if no memory was requested.
   if (byte_size > 0) {

--- a/src/servers/http_server.cc
+++ b/src/servers/http_server.cc
@@ -976,7 +976,6 @@ HTTPAPIServer::EVBufferToInput(
       int64_t memory_type_id;
       TRTSERVER_SharedMemoryBlockMemoryType(smb, &memory_type);
       TRTSERVER_SharedMemoryBlockMemoryTypeId(smb, &memory_type_id);
-
       output_shm_map.emplace(
           io.name(),
           std::make_tuple(

--- a/src/servers/http_server.cc
+++ b/src/servers/http_server.cc
@@ -325,9 +325,9 @@ TRTSERVER_Error*
 HTTPAPIServer::ResponseAlloc(
     TRTSERVER_ResponseAllocator* allocator, void** buffer, void** buffer_userp,
     const char* tensor_name, size_t byte_size,
-    TRTSERVER_Memory_Type preferred_memory_type, int64_t preferred_memory_type_id,
-    void* userp, TRTSERVER_Memory_Type* actual_memory_type,
-    int64_t* actual_memory_type_id)
+    TRTSERVER_Memory_Type preferred_memory_type,
+    int64_t preferred_memory_type_id, void* userp,
+    TRTSERVER_Memory_Type* actual_memory_type, int64_t* actual_memory_type_id)
 {
   auto userp_pair = reinterpret_cast<EVBufferPair*>(userp);
   evbuffer* evhttp_buffer = reinterpret_cast<evbuffer*>(userp_pair->first);

--- a/src/servers/memory_alloc.cc
+++ b/src/servers/memory_alloc.cc
@@ -99,11 +99,11 @@ MemoryTypeString(TRTSERVER_Memory_Type memory_type)
 
 TRTSERVER_Error*
 ResponseAlloc(
-    TRTSERVER_ResponseAllocator* allocator, void** buffer, void** buffer_userp,
-    const char* tensor_name, size_t byte_size,
-    TRTSERVER_Memory_Type preferred_memory_type,
-    int64_t preferred_memory_type_id, void* userp,
-    TRTSERVER_Memory_Type* actual_memory_type, int64_t* actual_memory_type_id)
+    TRTSERVER_ResponseAllocator* allocator, const char* tensor_name,
+    size_t byte_size, TRTSERVER_Memory_Type preferred_memory_type,
+    int64_t preferred_memory_type_id, void* userp, void** buffer,
+    void** buffer_userp, TRTSERVER_Memory_Type* actual_memory_type,
+    int64_t* actual_memory_type_id)
 {
   // Pass the tensor name with buffer_userp so we can show it when
   // releasing the buffer.

--- a/src/servers/memory_alloc.cc
+++ b/src/servers/memory_alloc.cc
@@ -101,7 +101,9 @@ TRTSERVER_Error*
 ResponseAlloc(
     TRTSERVER_ResponseAllocator* allocator, void** buffer, void** buffer_userp,
     const char* tensor_name, size_t byte_size,
-    TRTSERVER_Memory_Type memory_type, int64_t memory_type_id, void* userp)
+    TRTSERVER_Memory_Type preferred_memory_type,
+    int64_t preferred_memory_type_id, void* userp,
+    TRTSERVER_Memory_Type* actual_memory_type, int64_t* actual_memory_type_id)
 {
   // Pass the tensor name with buffer_userp so we can show it when
   // releasing the buffer.
@@ -115,10 +117,10 @@ ResponseAlloc(
              << tensor_name;
   } else {
     void* allocated_ptr = nullptr;
-    if (memory_type == TRTSERVER_MEMORY_CPU) {
+    if (preferred_memory_type == TRTSERVER_MEMORY_CPU) {
       allocated_ptr = malloc(byte_size);
     } else if (io_spec.output_type_ == TRTSERVER_MEMORY_GPU) {
-      auto err = cudaSetDevice(memory_type_id);
+      auto err = cudaSetDevice(preferred_memory_type_id);
       if (err == cudaSuccess) {
         err = cudaMalloc(&allocated_ptr, byte_size);
       }
@@ -136,7 +138,7 @@ ResponseAlloc(
           TRTSERVER_ERROR_INTERNAL,
           std::string(
               "failed to allocate " + std::to_string(byte_size) + " bytes in " +
-              MemoryTypeString(memory_type) + " for result tensor " +
+              MemoryTypeString(preferred_memory_type) + " for result tensor " +
               tensor_name)
               .c_str());
     }
@@ -144,10 +146,12 @@ ResponseAlloc(
     *buffer = allocated_ptr;
     *buffer_userp = new std::string(tensor_name);
     LOG_INFO << "allocated " << byte_size << " bytes in "
-             << MemoryTypeString(memory_type) << " for result tensor "
+             << MemoryTypeString(preferred_memory_type) << " for result tensor "
              << tensor_name;
   }
 
+  *actual_memory_type = preferred_memory_type;
+  *actual_memory_type_id = preferred_memory_type_id;
   return nullptr;  // Success
 }
 

--- a/src/servers/simple.cc
+++ b/src/servers/simple.cc
@@ -111,18 +111,24 @@ ResponseAlloc(
     if (memory_type == TRTSERVER_MEMORY_CPU) {
       allocated_ptr = malloc(byte_size);
       *actual_memory_type = TRTSERVER_MEMORY_CPU;
-#ifdef TRTIS_ENABLE_GPU
+      *actual_device_id = 0;
     } else if (use_gpu_memory) {
+#ifdef TRTIS_ENABLE_GPU
       auto err = cudaSetDevice(memory_type_id);
       if (err == cudaSuccess) {
         err = cudaMalloc(&allocated_ptr, byte_size);
       }
+
       if (err != cudaSuccess) {
         LOG_INFO << "cudaMalloc failed: " << cudaGetErrorString(err);
         allocated_ptr = nullptr;
         *actual_memory_type = TRTSERVER_MEMORY_GPU;
       }
 #endif  // TRTIS_ENABLE_GPU
+    } else {
+      allocated_ptr = malloc(byte_size);
+      *actual_memory_type = TRTSERVER_MEMORY_CPU;
+      *actual_device_id = 0;
     }
 
     if (allocated_ptr != nullptr) {

--- a/src/servers/simple.cc
+++ b/src/servers/simple.cc
@@ -94,7 +94,7 @@ ResponseAlloc(
     TRTSERVER_ResponseAllocator* allocator, void** buffer, void** buffer_userp,
     const char* tensor_name, size_t byte_size,
     TRTSERVER_Memory_Type memory_type, int64_t memory_type_id, void* userp,
-    TRTSERVER_Memory_Type* allocated_memory_type)
+    TRTSERVER_Memory_Type* actual_memory_type, int64_t* actual_device_id)
 {
   // Pass the tensor name with buffer_userp so we can show it when
   // releasing the buffer.
@@ -110,7 +110,7 @@ ResponseAlloc(
     void* allocated_ptr = nullptr;
     if (memory_type == TRTSERVER_MEMORY_CPU) {
       allocated_ptr = malloc(byte_size);
-      *allocated_memory_type = TRTSERVER_MEMORY_CPU;
+      *actual_memory_type = TRTSERVER_MEMORY_CPU;
 #ifdef TRTIS_ENABLE_GPU
     } else if (use_gpu_memory) {
       auto err = cudaSetDevice(memory_type_id);
@@ -120,7 +120,7 @@ ResponseAlloc(
       if (err != cudaSuccess) {
         LOG_INFO << "cudaMalloc failed: " << cudaGetErrorString(err);
         allocated_ptr = nullptr;
-        *allocated_memory_type = TRTSERVER_MEMORY_GPU;
+        *actual_memory_type = TRTSERVER_MEMORY_GPU;
       }
 #endif  // TRTIS_ENABLE_GPU
     }
@@ -129,8 +129,8 @@ ResponseAlloc(
       *buffer = allocated_ptr;
       *buffer_userp = new std::string(tensor_name);
       LOG_INFO << "allocated " << byte_size << " bytes in "
-               << MemoryTypeString(*allocated_memory_type)
-               << " for result tensor " << tensor_name;
+               << MemoryTypeString(*actual_memory_type) << " for result tensor "
+               << tensor_name;
     }
   }
 

--- a/src/servers/simple.cc
+++ b/src/servers/simple.cc
@@ -93,7 +93,8 @@ TRTSERVER_Error*
 ResponseAlloc(
     TRTSERVER_ResponseAllocator* allocator, void** buffer, void** buffer_userp,
     const char* tensor_name, size_t byte_size,
-    TRTSERVER_Memory_Type memory_type, int64_t memory_type_id, void* userp)
+    TRTSERVER_Memory_Type memory_type, int64_t memory_type_id, void* userp,
+    TRTSERVER_Memory_Type* allocated_memory_type)
 {
   // Pass the tensor name with buffer_userp so we can show it when
   // releasing the buffer.
@@ -109,6 +110,7 @@ ResponseAlloc(
     void* allocated_ptr = nullptr;
     if (memory_type == TRTSERVER_MEMORY_CPU) {
       allocated_ptr = malloc(byte_size);
+      *allocated_memory_type = TRTSERVER_MEMORY_CPU;
 #ifdef TRTIS_ENABLE_GPU
     } else if (use_gpu_memory) {
       auto err = cudaSetDevice(memory_type_id);
@@ -118,6 +120,7 @@ ResponseAlloc(
       if (err != cudaSuccess) {
         LOG_INFO << "cudaMalloc failed: " << cudaGetErrorString(err);
         allocated_ptr = nullptr;
+        *allocated_memory_type = TRTSERVER_MEMORY_GPU;
       }
 #endif  // TRTIS_ENABLE_GPU
     }
@@ -126,8 +129,8 @@ ResponseAlloc(
       *buffer = allocated_ptr;
       *buffer_userp = new std::string(tensor_name);
       LOG_INFO << "allocated " << byte_size << " bytes in "
-               << MemoryTypeString(memory_type) << " for result tensor "
-               << tensor_name;
+               << MemoryTypeString(*allocated_memory_type)
+               << " for result tensor " << tensor_name;
     }
   }
 

--- a/src/servers/simple.cc
+++ b/src/servers/simple.cc
@@ -91,11 +91,11 @@ MemoryTypeString(TRTSERVER_Memory_Type memory_type)
 
 TRTSERVER_Error*
 ResponseAlloc(
-    TRTSERVER_ResponseAllocator* allocator, void** buffer, void** buffer_userp,
-    const char* tensor_name, size_t byte_size,
-    TRTSERVER_Memory_Type preferred_memory_type,
-    int64_t preferred_memory_type_id, void* userp,
-    TRTSERVER_Memory_Type* actual_memory_type, int64_t* actual_memory_type_id)
+    TRTSERVER_ResponseAllocator* allocator, const char* tensor_name,
+    size_t byte_size, TRTSERVER_Memory_Type preferred_memory_type,
+    int64_t preferred_memory_type_id, void* userp, void** buffer,
+    void** buffer_userp, TRTSERVER_Memory_Type* actual_memory_type,
+    int64_t* actual_memory_type_id)
 {
   // Pass the tensor name with buffer_userp so we can show it when
   // releasing the buffer.

--- a/src/servers/simple.cc
+++ b/src/servers/simple.cc
@@ -112,7 +112,7 @@ ResponseAlloc(
       allocated_ptr = malloc(byte_size);
       *actual_memory_type = TRTSERVER_MEMORY_CPU;
       *actual_memory_type_id = 0;
-    } else if (use_gpu_memory) {
+    } else {
 #ifdef TRTIS_ENABLE_GPU
       auto err = cudaSetDevice(memory_type_id);
       if ((err != cudaSuccess) && (err != cudaErrorNoDevice) &&
@@ -123,25 +123,17 @@ ResponseAlloc(
                 "unable to recover current CUDA device: " +
                 std::string(cudaGetErrorString(err)))
                 .c_str());
-      } else if (err == cudaSuccess) {
-        err = cudaMalloc(&allocated_ptr, byte_size);
       }
 
+      err = cudaMalloc(&allocated_ptr, byte_size);
       if (err != cudaSuccess) {
         return TRTSERVER_ErrorNew(
             TRTSERVER_ERROR_INTERNAL,
             std::string(
                 "cudaMalloc failed: " + std::string(cudaGetErrorString(err)))
                 .c_str());
-        allocated_ptr = nullptr;
-        *actual_memory_type = TRTSERVER_MEMORY_GPU;
-        *actual_memory_type_id = 0;
       }
 #endif  // TRTIS_ENABLE_GPU
-    } else {
-      allocated_ptr = malloc(byte_size);
-      *actual_memory_type = TRTSERVER_MEMORY_CPU;
-      *actual_memory_type_id = 0;
     }
 
     if (allocated_ptr != nullptr) {

--- a/src/servers/simple.cc
+++ b/src/servers/simple.cc
@@ -93,7 +93,8 @@ TRTSERVER_Error*
 ResponseAlloc(
     TRTSERVER_ResponseAllocator* allocator, void** buffer, void** buffer_userp,
     const char* tensor_name, size_t byte_size,
-    TRTSERVER_Memory_Type preferred_memory_type, int64_t preferred_memory_type_id, void* userp,
+    TRTSERVER_Memory_Type preferred_memory_type,
+    int64_t preferred_memory_type_id, void* userp,
     TRTSERVER_Memory_Type* actual_memory_type, int64_t* actual_memory_type_id)
 {
   // Pass the tensor name with buffer_userp so we can show it when


### PR DESCRIPTION
- [x] keep track of memory type for output shared memory 
- [x] Call response allocation only once and return actual_memory_type (and actual_device_id) of where the output was finally allocated/resides.

- [x] Temporarily remove custom plugin from test due to unexpected behavior.