### PR TITLE
Fixing the simple perf client to work on async concurrency 8

### DIFF
--- a/qa/L0_simple_perf/test.sh
+++ b/qa/L0_simple_perf/test.sh
@@ -119,28 +119,25 @@ for BACKEND in $BACKENDS; do
                 RET=1
             fi
 
-            # FIXME bug with >1 concurrency in clients
-            if (( $CONCURRENCY == 1 )); then
 
-                echo -e "," >> ${BACKEND}.log
+            echo -e "," >> ${BACKEND}.log
 
-                # async HTTP API
-                $CLIENT -a -l"async" \
-                        -f${BACKEND} -m${MODEL_NAME} -c${CONCURRENCY} -s${TENSOR_SIZE} \
-                        -w${WARMUP_ITERS} -n${MEASURE_ITERS} >> ${BACKEND}.log 2>&1
-                if (( $? != 0 )); then
-                    RET=1
-                fi
+            # async HTTP API
+            $CLIENT -a -l"async" \
+                    -f${BACKEND} -m${MODEL_NAME} -c${CONCURRENCY} -s${TENSOR_SIZE} \
+                    -w${WARMUP_ITERS} -n${MEASURE_ITERS} >> ${BACKEND}.log 2>&1
+            if (( $? != 0 )); then
+                RET=1
+            fi
 
-                echo -e "," >> ${BACKEND}.log
+            echo -e "," >> ${BACKEND}.log
 
-                # async GRPC API
-                $CLIENT -a -l"async" -i grpc -u localhost:8001 \
-                        -f${BACKEND} -m${MODEL_NAME} -c${CONCURRENCY} -s${TENSOR_SIZE} \
-                        -w${WARMUP_ITERS} -n${MEASURE_ITERS} >> ${BACKEND}.log 2>&1
-                if (( $? != 0 )); then
-                    RET=1
-                fi
+            # async GRPC API
+            $CLIENT -a -l"async" -i grpc -u localhost:8001 \
+                    -f${BACKEND} -m${MODEL_NAME} -c${CONCURRENCY} -s${TENSOR_SIZE} \
+                    -w${WARMUP_ITERS} -n${MEASURE_ITERS} >> ${BACKEND}.log 2>&1
+            if (( $? != 0 )); then
+                RET=1
             fi
         done
         set -e

--- a/src/clients/c++/examples/simple_perf_client.cc
+++ b/src/clients/c++/examples/simple_perf_client.cc
@@ -263,7 +263,7 @@ void
 RunAsyncComplete(
     nic::InferContext* ctx,
     const std::shared_ptr<nic::InferContext::Request>& request, sem_t* sem,
-    uint64_t* ns)
+    std::vector<uint64_t>::iterator iter)
 {
   // We include getting the results in the timing since that is
   // included in the sync case as well.
@@ -276,12 +276,10 @@ RunAsyncComplete(
       results.size() != 1,
       "expected 1 result, got " + std::to_string(results.size()));
 
-  if (ns != nullptr) {
-    struct timespec end;
-    clock_gettime(CLOCK_MONOTONIC, &end);
-    uint64_t end_ns = TIMESPEC_TO_NANOS(end);
-    *ns = end_ns - *ns;
-  }
+  struct timespec end;
+  clock_gettime(CLOCK_MONOTONIC, &end);
+  uint64_t end_ns = TIMESPEC_TO_NANOS(end);
+  *iter = end_ns - *iter;
 
   sem_post(sem);
 }
@@ -301,26 +299,24 @@ RunAsyncConcurrent(
 
   struct timespec total_start;
   clock_gettime(CLOCK_MONOTONIC, &total_start);
+  request_duration_ns->resize(iters * concurrency);
 
-  for (uint32_t iter = 0; iter < (iters * concurrency); iter++) {
+  for (std::vector<uint64_t>::iterator iter = request_duration_ns->begin();
+       iter != request_duration_ns->end(); ++iter) {
     // Wait so that only 'concurrency' requests are in flight at any
     // given time.
     sem_wait(sem);
 
-    uint64_t* ns = nullptr;
-    if (request_duration_ns != nullptr) {
-      struct timespec start;
-      clock_gettime(CLOCK_MONOTONIC, &start);
-      request_duration_ns->push_back(TIMESPEC_TO_NANOS(start));
-      ns = &request_duration_ns->back();
-    }
+    struct timespec start;
+    clock_gettime(CLOCK_MONOTONIC, &start);
+    *iter = TIMESPEC_TO_NANOS(start);
 
     FAIL_IF_ERR(
         ctx->AsyncRun(
-            [sem, ns](
+            [sem, iter](
                 nic::InferContext* ctx,
                 const std::shared_ptr<nic::InferContext::Request>& request) {
-              RunAsyncComplete(ctx, request, sem, ns);
+              RunAsyncComplete(ctx, request, sem, iter);
             }),
         "unable to async run");
   }


### PR DESCRIPTION
The vector request_duration_ns was dynamically grown and the stale pointers forwarded to the callback functions of the request were causing the segmentation faults.
The problem is not present in the sync case because we already pre-allocate the vector memory.