### PR TITLE
Clarify why ONNX is not in L0_nullchar_string

### DIFF
--- a/qa/L0_nullchar_string/test.sh
+++ b/qa/L0_nullchar_string/test.sh
@@ -59,7 +59,9 @@ RET=0
 
 set +e
 
-# Add onnx_nobatch_zero_1_object once Onnx backend is fixed
+# Ignore ONNX backend because even though ONNX supports string data type,
+# strings that contain null character in the middle is not considered.
+# https://github.com/microsoft/onnxruntime/issues/2284
 for MODEL in graphdef_nobatch_zero_1_object savedmodel_nobatch_zero_1_object; do
   python $NULLCHAR_CLIENT_PY -m $MODEL -v >>$CLIENT_LOG 2>&1
   if [ $? -ne 0 ]; then

--- a/qa/L0_nullchar_string/test.sh
+++ b/qa/L0_nullchar_string/test.sh
@@ -60,7 +60,7 @@ RET=0
 set +e
 
 # Ignore ONNX backend because even though ONNX supports string data type,
-# strings that contain null character in the middle is not considered.
+# strings that contain null character in the middle is not allowed.
 # https://github.com/microsoft/onnxruntime/issues/2284
 for MODEL in graphdef_nobatch_zero_1_object savedmodel_nobatch_zero_1_object; do
   python $NULLCHAR_CLIENT_PY -m $MODEL -v >>$CLIENT_LOG 2>&1


### PR DESCRIPTION
Not going to run CI as it is just documentation change.