### PR TITLE
Clean up InferenceBackend

### DIFF
--- a/src/backends/caffe2/netdef_backend.cc
+++ b/src/backends/caffe2/netdef_backend.cc
@@ -96,15 +96,6 @@ NetDefBackend::Context::~Context()
 }
 
 Status
-NetDefBackend::Init(const std::string& path, const ModelConfig& config)
-{
-  RETURN_IF_ERROR(ValidateModelConfig(config, kCaffe2NetDefPlatform));
-  RETURN_IF_ERROR(SetModelConfig(path, config));
-
-  return Status::Success;
-}
-
-Status
 NetDefBackend::CreateExecutionContexts(
     const std::unordered_map<std::string, std::vector<char>>& models)
 {

--- a/src/backends/caffe2/netdef_backend.cc
+++ b/src/backends/caffe2/netdef_backend.cc
@@ -215,7 +215,7 @@ NetDefBackend::CreateExecutionContext(
                                                    : Config().max_batch_size();
 
   contexts_.emplace_back(new Context(instance_name, gpu_device, mbs));
-  const std::unique_ptr<Context>& context = contexts_.back();
+  Context* context = static_cast<Context*>(contexts_.back().get());
 
   RETURN_IF_ERROR(context->CreateCudaStream());
 
@@ -322,43 +322,6 @@ NetDefBackend::Context::ValidateOutputs(
   }
 
   return Status::Success;
-}
-
-void
-NetDefBackend::Run(
-    uint32_t runner_idx, std::vector<Scheduler::Payload>* payloads,
-    std::function<void(Status)> OnCompleteQueuedPayloads)
-{
-  // Each runner executes using the corresponding context...
-  if (runner_idx >= contexts_.size()) {
-    OnCompleteQueuedPayloads(Status(
-        RequestStatusCode::INTERNAL,
-        "unexpected runner index" + std::to_string(runner_idx) +
-            ", max allowed " + std::to_string(contexts_.size())));
-    return;
-  }
-
-  // Stop queue timer and start compute timer when the payload is
-  // scheduled to run
-  for (auto& payload : *payloads) {
-    if (payload.stats_ != nullptr) {
-      payload.stats_->CaptureTimestamp(
-          ModelInferStats::TimestampKind::kComputeStart);
-      payload.stats_->SetGPUDevice(contexts_[runner_idx]->gpu_device_);
-    }
-  }
-
-  Status status = contexts_[runner_idx]->Run(this, payloads);
-
-  // Stop compute timers.
-  for (auto& payload : *payloads) {
-    if (payload.stats_ != nullptr) {
-      payload.stats_->CaptureTimestamp(
-          ModelInferStats::TimestampKind::kComputeEnd);
-    }
-  }
-
-  OnCompleteQueuedPayloads(status);
 }
 
 Status
@@ -489,7 +452,7 @@ NetDefBackend::Context::SetInput(
 
 Status
 NetDefBackend::Context::Run(
-    const NetDefBackend* base, std::vector<Scheduler::Payload>* payloads)
+    const InferenceBackend* base, std::vector<Scheduler::Payload>* payloads)
 {
   LOG_VERBOSE(1) << "Running " << name_ << " with " << payloads->size()
                  << " request payloads";

--- a/src/backends/caffe2/netdef_backend.h
+++ b/src/backends/caffe2/netdef_backend.h
@@ -54,12 +54,6 @@ class NetDefBackend : public InferenceBackend {
       const ModelSequenceBatching::Control::Kind control_kind,
       std::vector<std::string>* input_names);
 
-  // Run model on the context associated with 'runner_idx' to
-  // execute for one or more requests.
-  void Run(
-      uint32_t runner_idx, std::vector<Scheduler::Payload>* payloads,
-      std::function<void(Status)> OnCompleteQueuedPayloads);
-
  private:
   DISALLOW_COPY_AND_ASSIGN(NetDefBackend);
   friend std::ostream& operator<<(std::ostream&, const NetDefBackend&);
@@ -86,14 +80,10 @@ class NetDefBackend : public InferenceBackend {
         std::vector<Scheduler::Payload>* payloads,
         std::vector<std::unique_ptr<char[]>>* input_buffers, bool* cuda_copy);
 
-    // Run model to execute for one or more requests. This function
-    // assumes that it is only called by the single runner thread that
-    // is assigned to this context. A non-OK return status indicates
-    // an internal error that prevents any of the of requests from
-    // completing. If an error is isolate to a single request payload
-    // it will be reported in that payload.
+    // See BackendContext::Run()
     Status Run(
-        const NetDefBackend* base, std::vector<Scheduler::Payload>* payloads);
+        const InferenceBackend* base,
+        std::vector<Scheduler::Payload>* payloads) override;
 
     // Set an input tensor from one or more payloads.
     Status SetFixedSizedInputTensor(
@@ -112,8 +102,6 @@ class NetDefBackend : public InferenceBackend {
     // Caffe2 workspace.
     std::unique_ptr<Caffe2Workspace> workspace_;
   };
-
-  std::vector<std::unique_ptr<Context>> contexts_;
 };
 
 std::ostream& operator<<(std::ostream& out, const NetDefBackend& pb);

--- a/src/backends/caffe2/netdef_backend.h
+++ b/src/backends/caffe2/netdef_backend.h
@@ -39,8 +39,6 @@ class NetDefBackend : public InferenceBackend {
   NetDefBackend() = default;
   NetDefBackend(NetDefBackend&&) = default;
 
-  Status Init(const std::string& path, const ModelConfig& config);
-
   // Create a context for execution for each instance for the
   // serialized netdefs specified in 'models'.
   Status CreateExecutionContexts(

--- a/src/backends/caffe2/netdef_backend_factory.cc
+++ b/src/backends/caffe2/netdef_backend_factory.cc
@@ -72,7 +72,8 @@ NetDefBackendFactory::CreateBackend(
   // Create the backend for the model and all the execution contexts
   // requested for this model.
   std::unique_ptr<NetDefBackend> local_backend(new NetDefBackend);
-  RETURN_IF_ERROR(local_backend->Init(path, model_config));
+  RETURN_IF_ERROR(
+      local_backend->Init(path, model_config, kCaffe2NetDefPlatform));
   RETURN_IF_ERROR(local_backend->CreateExecutionContexts(models));
 
   *backend = std::move(local_backend);

--- a/src/backends/custom/custom_backend.cc
+++ b/src/backends/custom/custom_backend.cc
@@ -100,11 +100,8 @@ CustomBackend::Init(
     const std::string& path, const std::vector<std::string>& server_params,
     const ModelConfig& config)
 {
-  RETURN_IF_ERROR(ValidateModelConfig(config, kCustomPlatform));
-  RETURN_IF_ERROR(SetModelConfig(path, config));
-
+  RETURN_IF_ERROR(InferenceBackend::Init(path, config, kCustomPlatform));
   server_params_ = server_params;
-
   return Status::Success;
 }
 

--- a/src/backends/custom/custom_backend.h
+++ b/src/backends/custom/custom_backend.h
@@ -55,12 +55,6 @@ class CustomBackend : public InferenceBackend {
   // Init model on the context associated with 'runner_idx'.
   Status InitBackend(uint32_t runner_idx);
 
-  // Run model on the context associated with 'runner_idx' to
-  // execute for one or more requests.
-  void RunBackend(
-      uint32_t runner_idx, std::vector<Scheduler::Payload>* payloads,
-      std::function<void(Status)> OnCompleteQueuedPayloads);
-
  private:
   DISALLOW_COPY_AND_ASSIGN(CustomBackend);
   friend std::ostream& operator<<(std::ostream&, const CustomBackend&);
@@ -88,13 +82,10 @@ class CustomBackend : public InferenceBackend {
     // Return the shared library reported error string for 'err'.
     std::string LibraryErrorString(const int err);
 
-    // Run model to execute for one or more requests. This function
-    // assumes that it is only called by the single runner thread that
-    // is assigned to this context. A non-OK return status indicates
-    // an internal error that prevents any of the of requests from
-    // completing. If an error is isolate to a single request payload
-    // it will be reported in that payload.
-    Status Run(CustomBackend* base, std::vector<Scheduler::Payload>* payloads);
+    // See BackendContext::Run()
+    Status Run(
+        const InferenceBackend* base,
+        std::vector<Scheduler::Payload>* payloads) override;
 
     struct GetInputOutputContext {
       GetInputOutputContext(
@@ -158,7 +149,6 @@ class CustomBackend : public InferenceBackend {
   };
 
   std::vector<std::string> server_params_;
-  std::vector<std::unique_ptr<Context>> contexts_;
 };
 
 std::ostream& operator<<(std::ostream& out, const CustomBackend& pb);

--- a/src/backends/ensemble/ensemble_backend.cc
+++ b/src/backends/ensemble/ensemble_backend.cc
@@ -40,8 +40,7 @@ EnsembleBackend::Init(
     InferenceServer* const server, const std::string& path,
     const ModelConfig& config)
 {
-  RETURN_IF_ERROR(ValidateModelConfig(config, kEnsemblePlatform));
-  RETURN_IF_ERROR(SetModelConfig(path, config));
+  RETURN_IF_ERROR(InferenceBackend::Init(path, config, kEnsemblePlatform));
 
   std::unique_ptr<Scheduler> scheduler;
   RETURN_IF_ERROR(EnsembleScheduler::Create(server, config, &scheduler));

--- a/src/backends/ensemble/ensemble_backend.h
+++ b/src/backends/ensemble/ensemble_backend.h
@@ -42,11 +42,11 @@ class EnsembleBackend : public InferenceBackend {
       const ModelConfig& config);
 
  private:
-  // Run model on the context associated with 'runner_idx' to
-  // execute for one or more requests.
+  // Override InferenceBackend::Run() to return proper error if
+  // Run() is called for ensemble model.
   void Run(
       uint32_t runner_idx, std::vector<Scheduler::Payload>* payloads,
-      std::function<void(Status)> OnCompleteQueuedPayloads);
+      std::function<void(Status)> OnCompleteQueuedPayloads) override;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(EnsembleBackend);

--- a/src/backends/onnx/onnx_backend.cc
+++ b/src/backends/onnx/onnx_backend.cc
@@ -68,15 +68,6 @@ OnnxBackend::Context::~Context()
 }
 
 Status
-OnnxBackend::Init(const std::string& path, const ModelConfig& config)
-{
-  RETURN_IF_ERROR(ValidateModelConfig(config, kOnnxRuntimeOnnxPlatform));
-  RETURN_IF_ERROR(SetModelConfig(path, config));
-
-  return Status::Success;
-}
-
-Status
 OnnxBackend::CreateExecutionContexts(
     const std::unordered_map<std::string, std::string>& models)
 {

--- a/src/backends/onnx/onnx_backend.h
+++ b/src/backends/onnx/onnx_backend.h
@@ -39,8 +39,6 @@ class OnnxBackend : public InferenceBackend {
   OnnxBackend() = default;
   OnnxBackend(OnnxBackend&&) = default;
 
-  Status Init(const std::string& path, const ModelConfig& config);
-
   // Create a context for execution for each instance for the
   // serialized plans specified in 'models'.
   Status CreateExecutionContexts(

--- a/src/backends/onnx/onnx_backend.h
+++ b/src/backends/onnx/onnx_backend.h
@@ -57,16 +57,6 @@ class OnnxBackend : public InferenceBackend {
       OrtSessionOptions* session_options,
       const std::unordered_map<std::string, std::string>& paths);
 
-  // [TODO] need to override Run() because it needs to clean up run-wise
-  // variables, but should just move the clean up inside Context::Run(),
-  // and make this non-virtual.
-  //
-  // Run model on the context associated with 'runner_idx' to
-  // execute for one or more requests.
-  void Run(
-      uint32_t runner_idx, std::vector<Scheduler::Payload>* payloads,
-      std::function<void(Status)> OnCompleteQueuedPayloads) override;
-
  private:
   DISALLOW_COPY_AND_ASSIGN(OnnxBackend);
   friend std::ostream& operator<<(std::ostream&, const OnnxBackend&);
@@ -94,7 +84,8 @@ class OnnxBackend : public InferenceBackend {
 
     // See BackendContext::Run()
     Status Run(
-        const InferenceBackend* base, std::vector<Scheduler::Payload>* payloads);
+        const InferenceBackend* base,
+        std::vector<Scheduler::Payload>* payloads);
 
     // Set an input tensor from one or more payloads.
     Status SetInputTensor(

--- a/src/backends/onnx/onnx_backend.h
+++ b/src/backends/onnx/onnx_backend.h
@@ -57,11 +57,15 @@ class OnnxBackend : public InferenceBackend {
       OrtSessionOptions* session_options,
       const std::unordered_map<std::string, std::string>& paths);
 
+  // [TODO] need to override Run() because it needs to clean up run-wise
+  // variables, but should just move the clean up inside Context::Run(),
+  // and make this non-virtual.
+  //
   // Run model on the context associated with 'runner_idx' to
   // execute for one or more requests.
   void Run(
       uint32_t runner_idx, std::vector<Scheduler::Payload>* payloads,
-      std::function<void(Status)> OnCompleteQueuedPayloads);
+      std::function<void(Status)> OnCompleteQueuedPayloads) override;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(OnnxBackend);
@@ -88,14 +92,9 @@ class OnnxBackend : public InferenceBackend {
         const std::string& model_name, const ModelSequenceBatching& batcher,
         const ModelSequenceBatching::Control::Kind control_kind);
 
-    // Run model to execute for one or more requests. This function
-    // assumes that it is only called by the single runner thread that
-    // is assigned to this context. A non-OK return status indicates
-    // an internal error that prevents any of the of requests from
-    // completing. If an error is isolate to a single request payload
-    // it will be reported in that payload.
+    // See BackendContext::Run()
     Status Run(
-        const OnnxBackend* base, std::vector<Scheduler::Payload>* payloads);
+        const InferenceBackend* base, std::vector<Scheduler::Payload>* payloads);
 
     // Set an input tensor from one or more payloads.
     Status SetInputTensor(
@@ -117,7 +116,7 @@ class OnnxBackend : public InferenceBackend {
 
     // Read output tensors into one or more payloads accordingly.
     Status ReadOutputTensors(
-        const OnnxBackend* base, const size_t total_batch_size,
+        const InferenceBackend* base, const size_t total_batch_size,
         const std::vector<const char*>& output_names,
         std::vector<Scheduler::Payload>* payloads);
 
@@ -140,8 +139,6 @@ class OnnxBackend : public InferenceBackend {
     std::vector<OrtValue*> input_tensors_;
     std::vector<OrtValue*> output_tensors_;
   };
-
-  std::vector<std::unique_ptr<Context>> contexts_;
 };
 
 std::ostream& operator<<(std::ostream& out, const OnnxBackend& pb);

--- a/src/backends/onnx/onnx_backend_factory.cc
+++ b/src/backends/onnx/onnx_backend_factory.cc
@@ -84,7 +84,8 @@ OnnxBackendFactory::CreateBackend(
   // Create the backend for the model and all the execution contexts
   // requested for this model.
   std::unique_ptr<OnnxBackend> local_backend(new OnnxBackend);
-  RETURN_IF_ERROR(local_backend->Init(path, model_config));
+  RETURN_IF_ERROR(
+      local_backend->Init(path, model_config, kOnnxRuntimeOnnxPlatform));
   RETURN_IF_ERROR(local_backend->CreateExecutionContexts(models));
 
   *backend = std::move(local_backend);

--- a/src/backends/pytorch/libtorch_backend.cc
+++ b/src/backends/pytorch/libtorch_backend.cc
@@ -137,15 +137,6 @@ ConvertTorchTypeToDataType(const torch::ScalarType& ttype)
 }
 
 Status
-LibTorchBackend::Init(const std::string& path, const ModelConfig& config)
-{
-  RETURN_IF_ERROR(ValidateModelConfig(config, kPyTorchLibTorchPlatform));
-  RETURN_IF_ERROR(SetModelConfig(path, config));
-
-  return Status::Success;
-}
-
-Status
 LibTorchBackend::CreateExecutionContexts(
     const std::unordered_map<std::string, std::string>& models)
 {

--- a/src/backends/pytorch/libtorch_backend.h
+++ b/src/backends/pytorch/libtorch_backend.h
@@ -57,12 +57,6 @@ class LibTorchBackend : public InferenceBackend {
       const std::unordered_map<std::string, std::string>& paths);
 
  private:
-  // Run model on the context associated with 'runner_idx' to
-  // execute for one or more requests.
-  void Run(
-      uint32_t runner_idx, std::vector<Scheduler::Payload>* payloads,
-      std::function<void(Status)> OnCompleteQueuedPayloads);
-
  private:
   DISALLOW_COPY_AND_ASSIGN(LibTorchBackend);
   friend std::ostream& operator<<(std::ostream&, const LibTorchBackend&);
@@ -91,14 +85,10 @@ class LibTorchBackend : public InferenceBackend {
         std::vector<Scheduler::Payload>* payloads, InputMetaData* meta_data,
         bool* cuda_copy);
 
-    // Run model to execute for one or more requests. This function
-    // assumes that it is only called by the single runner thread that
-    // is assigned to this context. A non-OK return status indicates
-    // an internal error that prevents any of the of requests from
-    // completing. If an error is isolate to a single request payload
-    // it will be reported in that payload.
+    // See BackendContext::Run()
     Status Run(
-        const LibTorchBackend* base, std::vector<Scheduler::Payload>* payloads);
+        const InferenceBackend* base,
+        std::vector<Scheduler::Payload>* payloads) override;
 
     // Helper function to set an input buffer from one or more payloads.
     Status SetFixedSizedInputBuffer(
@@ -131,8 +121,6 @@ class LibTorchBackend : public InferenceBackend {
     std::unordered_map<std::string, int> input_index_map_;
     std::unordered_map<std::string, int> output_index_map_;
   };
-
-  std::vector<std::unique_ptr<Context>> contexts_;
 };
 
 std::ostream& operator<<(std::ostream& out, const LibTorchBackend& pb);

--- a/src/backends/pytorch/libtorch_backend.h
+++ b/src/backends/pytorch/libtorch_backend.h
@@ -46,8 +46,6 @@ class LibTorchBackend : public InferenceBackend {
   LibTorchBackend() = default;
   LibTorchBackend(LibTorchBackend&&) = default;
 
-  Status Init(const std::string& path, const ModelConfig& config);
-
   // Create a context for execution for each instance for the
   // serialized .pt models specified in 'paths'.
   Status CreateExecutionContexts(

--- a/src/backends/pytorch/libtorch_backend_factory.cc
+++ b/src/backends/pytorch/libtorch_backend_factory.cc
@@ -71,7 +71,8 @@ LibTorchBackendFactory::CreateBackend(
   // Create the backend for the model and all the execution contexts
   // requested for this model.
   std::unique_ptr<LibTorchBackend> local_backend(new LibTorchBackend);
-  RETURN_IF_ERROR(local_backend->Init(path, model_config));
+  RETURN_IF_ERROR(
+      local_backend->Init(path, model_config, kPyTorchLibTorchPlatform));
   RETURN_IF_ERROR(local_backend->CreateExecutionContexts(torch_models));
 
   *backend = std::move(local_backend);

--- a/src/backends/tensorflow/base_backend.h
+++ b/src/backends/tensorflow/base_backend.h
@@ -41,17 +41,18 @@ class BaseBackend : public InferenceBackend {
   BaseBackend() = default;
   BaseBackend(BaseBackend&&) = default;
 
-  Status Init(const std::string& path, const ModelConfig& config);
+  Status Init(
+      const std::string& path, const ModelConfig& model_config,
+      const GraphDefBackendFactory::Config* backend_config,
+      const std::string& platform);
 
   // Create a context for execution for each instance of the
   // tensorflow model specified in 'paths'. The model can be either a
   // graphdef or savedmodel
   Status CreateExecutionContexts(
-      const std::shared_ptr<GraphDefBackendFactory::Config>& backend_config,
       const std::unordered_map<std::string, std::string>& paths);
   Status CreateExecutionContext(
       const std::string& instance_name, const int gpu_device,
-      const std::shared_ptr<GraphDefBackendFactory::Config>& backend_config,
       const std::unordered_map<std::string, std::string>& paths);
 
  protected:
@@ -61,7 +62,7 @@ class BaseBackend : public InferenceBackend {
 
   // Load model and create a corresponding TRTISTF model object.
   virtual Status CreateTRTISTFModel(
-      const std::shared_ptr<GraphDefBackendFactory::Config>& backend_config,
+      const GraphDefBackendFactory::Config* backend_config,
       const int gpu_device, const bool has_graph_level, const int graph_level,
       const std::string& model_path, TRTISTFModelHandle* trtistf_model,
       IONameMap* input_name_map, IONameMap* output_name_map,
@@ -146,6 +147,8 @@ class BaseBackend : public InferenceBackend {
  private:
   DISALLOW_COPY_AND_ASSIGN(BaseBackend);
   friend std::ostream& operator<<(std::ostream&, const BaseBackend&);
+
+  const GraphDefBackendFactory::Config* backend_config_;
 };
 
 std::ostream& operator<<(std::ostream& out, const BaseBackend& pb);

--- a/src/backends/tensorflow/base_backend.h
+++ b/src/backends/tensorflow/base_backend.h
@@ -123,8 +123,10 @@ class BaseBackend : public InferenceBackend {
     // an internal error that prevents any of the of requests from
     // completing. If an error is isolate to a single request payload
     // it will be reported in that payload.
+    // See BackendContext::Run()
     Status Run(
-        const BaseBackend* base, std::vector<Scheduler::Payload>* payloads);
+        const InferenceBackend* base,
+        std::vector<Scheduler::Payload>* payloads) override;
 
     // Map from configuration name for an input to tensor name for
     // that input in the model.
@@ -142,18 +144,8 @@ class BaseBackend : public InferenceBackend {
   };
 
  private:
-  // Run model on the context associated with 'runner_idx' to
-  // execute for one or more requests.
-  void Run(
-      uint32_t runner_idx, std::vector<Scheduler::Payload>* payloads,
-      std::function<void(Status)> OnCompleteQueuedPayloads);
-
- private:
   DISALLOW_COPY_AND_ASSIGN(BaseBackend);
   friend std::ostream& operator<<(std::ostream&, const BaseBackend&);
-
-  // The contexts for this backend.
-  std::vector<std::unique_ptr<Context>> contexts_;
 };
 
 std::ostream& operator<<(std::ostream& out, const BaseBackend& pb);

--- a/src/backends/tensorflow/graphdef_backend.cc
+++ b/src/backends/tensorflow/graphdef_backend.cc
@@ -37,17 +37,9 @@
 namespace nvidia { namespace inferenceserver {
 
 Status
-GraphDefBackend::Init(const std::string& path, const ModelConfig& config)
-{
-  RETURN_IF_ERROR(ValidateModelConfig(config, kTensorFlowGraphDefPlatform));
-  RETURN_IF_ERROR(BaseBackend::Init(path, config));
-  return Status::Success;
-}
-
-Status
 GraphDefBackend::CreateTRTISTFModel(
-    const std::shared_ptr<GraphDefBackendFactory::Config>& backend_config,
-    const int device_id, const bool has_graph_level, const int graph_level,
+    const GraphDefBackendFactory::Config* backend_config, const int device_id,
+    const bool has_graph_level, const int graph_level,
     const std::string& model_path, TRTISTFModelHandle* trtistf_model,
     IONameMap* input_name_map, IONameMap* output_name_map,
     const TRTISTF_TFTRTConfig* tftrt_config)

--- a/src/backends/tensorflow/graphdef_backend.h
+++ b/src/backends/tensorflow/graphdef_backend.h
@@ -35,11 +35,9 @@ class GraphDefBackend : public BaseBackend {
   GraphDefBackend() = default;
   GraphDefBackend(GraphDefBackend&&) = default;
 
-  Status Init(const std::string& path, const ModelConfig& config);
-
   Status CreateTRTISTFModel(
-      const std::shared_ptr<GraphDefBackendFactory::Config>& backend_config,
-      const int device_id, const bool has_graph_level, const int graph_level,
+      const GraphDefBackendFactory::Config* backend_config, const int device_id,
+      const bool has_graph_level, const int graph_level,
       const std::string& model_path, TRTISTFModelHandle* trtistf_model,
       IONameMap* input_name_map, IONameMap* output_name_map,
       const TRTISTF_TFTRTConfig* tftrt_config) override;

--- a/src/backends/tensorflow/graphdef_backend_factory.cc
+++ b/src/backends/tensorflow/graphdef_backend_factory.cc
@@ -75,9 +75,9 @@ GraphDefBackendFactory::CreateBackend(
   }
 
   std::unique_ptr<GraphDefBackend> local_backend(new GraphDefBackend);
-  RETURN_IF_ERROR(local_backend->Init(path, model_config));
-  RETURN_IF_ERROR(
-      local_backend->CreateExecutionContexts(backend_config_, graphdef_paths));
+  RETURN_IF_ERROR(local_backend->Init(
+      path, model_config, backend_config_.get(), kTensorFlowGraphDefPlatform));
+  RETURN_IF_ERROR(local_backend->CreateExecutionContexts(graphdef_paths));
 
   *backend = std::move(local_backend);
   return Status::Success;

--- a/src/backends/tensorflow/savedmodel_backend.cc
+++ b/src/backends/tensorflow/savedmodel_backend.cc
@@ -54,18 +54,9 @@ FindIOByName(const TRTISTF_IOList* ios, const std::string& name)
 }  // namespace
 
 Status
-SavedModelBackend::Init(const std::string& path, const ModelConfig& config)
-{
-  RETURN_IF_ERROR(ValidateModelConfig(config, kTensorFlowSavedModelPlatform));
-  RETURN_IF_ERROR(BaseBackend::Init(path, config));
-
-  return Status::Success;
-}
-
-Status
 SavedModelBackend::CreateTRTISTFModel(
-    const std::shared_ptr<GraphDefBackendFactory::Config>& backend_config,
-    const int device_id, const bool has_graph_level, const int graph_level,
+    const GraphDefBackendFactory::Config* backend_config, const int device_id,
+    const bool has_graph_level, const int graph_level,
     const std::string& model_path, TRTISTFModelHandle* trtistf_model,
     IONameMap* input_name_map, IONameMap* output_name_map,
     const TRTISTF_TFTRTConfig* tftrt_config)

--- a/src/backends/tensorflow/savedmodel_backend.h
+++ b/src/backends/tensorflow/savedmodel_backend.h
@@ -35,11 +35,9 @@ class SavedModelBackend : public BaseBackend {
   SavedModelBackend() = default;
   SavedModelBackend(SavedModelBackend&&) = default;
 
-  Status Init(const std::string& path, const ModelConfig& config);
-
   Status CreateTRTISTFModel(
-      const std::shared_ptr<GraphDefBackendFactory::Config>& backend_config,
-      const int device_id, const bool has_graph_level, const int graph_level,
+      const GraphDefBackendFactory::Config* backend_config, const int device_id,
+      const bool has_graph_level, const int graph_level,
       const std::string& model_path, TRTISTFModelHandle* trtistf_model,
       IONameMap* input_name_map, IONameMap* output_name_map,
       const TRTISTF_TFTRTConfig* tftrt_config) override;

--- a/src/backends/tensorflow/savedmodel_backend_factory.cc
+++ b/src/backends/tensorflow/savedmodel_backend_factory.cc
@@ -75,9 +75,10 @@ SavedModelBackendFactory::CreateBackend(
   }
 
   std::unique_ptr<SavedModelBackend> local_backend(new SavedModelBackend);
-  RETURN_IF_ERROR(local_backend->Init(path, model_config));
-  RETURN_IF_ERROR(local_backend->CreateExecutionContexts(
-      backend_config_, savedmodel_paths));
+  RETURN_IF_ERROR(local_backend->Init(
+      path, model_config, backend_config_.get(),
+      kTensorFlowSavedModelPlatform));
+  RETURN_IF_ERROR(local_backend->CreateExecutionContexts(savedmodel_paths));
 
   *backend = std::move(local_backend);
   return Status::Success;

--- a/src/backends/tensorrt/plan_backend.cc
+++ b/src/backends/tensorrt/plan_backend.cc
@@ -127,15 +127,6 @@ PlanBackend::Context::~Context()
 }
 
 Status
-PlanBackend::Init(const std::string& path, const ModelConfig& config)
-{
-  RETURN_IF_ERROR(ValidateModelConfig(config, kTensorRTPlanPlatform));
-  RETURN_IF_ERROR(SetModelConfig(path, config));
-
-  return Status::Success;
-}
-
-Status
 PlanBackend::CreateExecutionContexts(
     const std::unordered_map<std::string, std::vector<char>>& models)
 {

--- a/src/backends/tensorrt/plan_backend.cc
+++ b/src/backends/tensorrt/plan_backend.cc
@@ -247,7 +247,7 @@ PlanBackend::CreateExecutionContext(
   const int profile_index = GetProfileIndex(profile_name);
   contexts_.emplace_back(
       new Context(instance_name, gpu_device, mbs, profile_index));
-  const std::unique_ptr<Context>& context = contexts_.back();
+  Context* context = static_cast<Context*>(contexts_.back().get());
 
   // Set the device before generating engine and context.
   cuerr = cudaSetDevice(gpu_device);
@@ -708,43 +708,6 @@ PlanBackend::Context::InitializeConfigOutputBindings(
   return Status::Success;
 }
 
-void
-PlanBackend::Run(
-    uint32_t runner_idx, std::vector<Scheduler::Payload>* payloads,
-    std::function<void(Status)> OnCompleteQueuedPayloads)
-{
-  // Each runner executes using the corresponding context...
-  if (runner_idx >= contexts_.size()) {
-    OnCompleteQueuedPayloads(Status(
-        RequestStatusCode::INTERNAL,
-        "unexpected runner index" + std::to_string(runner_idx) +
-            ", max allowed " + std::to_string(contexts_.size())));
-    return;
-  }
-
-  // Stop queue timer and start compute timer when the payload is
-  // scheduled to run
-  for (auto& payload : *payloads) {
-    if (payload.stats_ != nullptr) {
-      payload.stats_->CaptureTimestamp(
-          ModelInferStats::TimestampKind::kComputeStart);
-      payload.stats_->SetGPUDevice(contexts_[runner_idx]->gpu_device_);
-    }
-  }
-
-  Status status = contexts_[runner_idx]->Run(payloads);
-
-  // Stop compute timers.
-  for (auto& payload : *payloads) {
-    if (payload.stats_ != nullptr) {
-      payload.stats_->CaptureTimestamp(
-          ModelInferStats::TimestampKind::kComputeEnd);
-    }
-  }
-
-  OnCompleteQueuedPayloads(status);
-}
-
 // CUDA 10.1 starts to support CUDA graphs.
 #ifdef TRTIS_ENABLE_CUDA_GRAPH
 bool
@@ -796,7 +759,8 @@ PlanBackend::Context::BuildCudaGraph(const int batch_size)
 #endif
 
 Status
-PlanBackend::Context::Run(std::vector<Scheduler::Payload>* payloads)
+PlanBackend::Context::Run(
+    const InferenceBackend* base, std::vector<Scheduler::Payload>* payloads)
 {
   LOG_VERBOSE(1) << "Running " << name_ << " with " << payloads->size()
                  << " request payloads";
@@ -1033,7 +997,8 @@ operator<<(std::ostream& out, const PlanBackend& pb)
 {
   out << "name=" << pb.Name() << std::endl;
   out << "contexts:" << std::endl;
-  for (const auto& context : pb.contexts_) {
+  for (size_t idx = 0; idx < pb.contexts_.size(); idx++) {
+    auto context = static_cast<PlanBackend::Context*>(pb.contexts_[idx].get());
     out << "  name=" << context->name_ << ", gpu="
         << ((context->gpu_device_ == PlanBackend::Context::NO_GPU_DEVICE)
                 ? "<none>"

--- a/src/backends/tensorrt/plan_backend.h
+++ b/src/backends/tensorrt/plan_backend.h
@@ -40,8 +40,6 @@ class PlanBackend : public InferenceBackend {
   PlanBackend() = default;
   PlanBackend(PlanBackend&&) = default;
 
-  Status Init(const std::string& path, const ModelConfig& config);
-
   // Create a context for execution for each instance for the
   // serialized plans specified in 'models'.
   Status CreateExecutionContexts(

--- a/src/backends/tensorrt/plan_backend.h
+++ b/src/backends/tensorrt/plan_backend.h
@@ -52,13 +52,6 @@ class PlanBackend : public InferenceBackend {
       const std::string profile_index);
 
  private:
-  // Run model on the context associated with 'runner_idx' to
-  // execute for one or more requests.
-  void Run(
-      uint32_t runner_idx, std::vector<Scheduler::Payload>* payloads,
-      std::function<void(Status)> OnCompleteQueuedPayloads);
-
- private:
   DISALLOW_COPY_AND_ASSIGN(PlanBackend);
   friend std::ostream& operator<<(std::ostream&, const PlanBackend&);
 
@@ -93,13 +86,10 @@ class PlanBackend : public InferenceBackend {
 
     void InitProfile();
 
-    // Run model to execute for one or more requests. This function
-    // assumes that it is only called by the single runner thread that
-    // is assigned to this context. A non-OK return status indicates
-    // an internal error that prevents any of the of requests from
-    // completing. If an error is isolate to a single request payload
-    // it will be reported in that payload.
-    Status Run(std::vector<Scheduler::Payload>* payloads);
+    // See BackendContext::Run()
+    Status Run(
+        const InferenceBackend* base,
+        std::vector<Scheduler::Payload>* payloads) override;
 
     // TensorRT components for the model
     nvinfer1::IRuntime* runtime_;
@@ -140,8 +130,6 @@ class PlanBackend : public InferenceBackend {
     std::unordered_map<int, cudaGraph_t> cuda_graphs_;
     std::unordered_map<int, cudaGraphExec_t> cuda_graph_execs_;
   };
-
-  std::vector<std::unique_ptr<Context>> contexts_;
 };
 
 std::ostream& operator<<(std::ostream& out, const PlanBackend& pb);

--- a/src/backends/tensorrt/plan_backend_factory.cc
+++ b/src/backends/tensorrt/plan_backend_factory.cc
@@ -87,7 +87,8 @@ PlanBackendFactory::CreateBackend(
   // Create the backend for the model and all the execution contexts
   // requested for this model.
   std::unique_ptr<PlanBackend> local_backend(new PlanBackend);
-  RETURN_IF_ERROR(local_backend->Init(path, model_config));
+  RETURN_IF_ERROR(
+      local_backend->Init(path, model_config, kTensorRTPlanPlatform));
   RETURN_IF_ERROR(local_backend->CreateExecutionContexts(models));
 
   *backend = std::move(local_backend);

--- a/src/core/backend.cc
+++ b/src/core/backend.cc
@@ -141,4 +141,41 @@ InferenceBackend::Run(
       stats, request_provider, response_provider, OnCompleteHandleInfer);
 }
 
+void
+InferenceBackend::Run(
+    uint32_t runner_idx, std::vector<Scheduler::Payload>* payloads,
+    std::function<void(Status)> OnCompleteQueuedPayloads)
+{
+  // Each runner executes using the corresponding context...
+  if (runner_idx >= contexts_.size()) {
+    OnCompleteQueuedPayloads(Status(
+        RequestStatusCode::INTERNAL,
+        "unexpected runner index" + std::to_string(runner_idx) +
+            ", max allowed " + std::to_string(contexts_.size())));
+    return;
+  }
+
+  // Stop queue timer and start compute timer when the payload is
+  // scheduled to run
+  for (auto& payload : *payloads) {
+    if (payload.stats_ != nullptr) {
+      payload.stats_->CaptureTimestamp(
+          ModelInferStats::TimestampKind::kComputeStart);
+      payload.stats_->SetGPUDevice(contexts_[runner_idx]->gpu_device_);
+    }
+  }
+
+  Status status = contexts_[runner_idx]->Run(this, payloads);
+
+  // Stop compute timers.
+  for (auto& payload : *payloads) {
+    if (payload.stats_ != nullptr) {
+      payload.stats_->CaptureTimestamp(
+          ModelInferStats::TimestampKind::kComputeEnd);
+    }
+  }
+
+  OnCompleteQueuedPayloads(status);
+}
+
 }}  // namespace nvidia::inferenceserver

--- a/src/core/backend.cc
+++ b/src/core/backend.cc
@@ -130,6 +130,17 @@ InferenceBackend::SetConfiguredScheduler(
   return SetScheduler(std::move(scheduler));
 }
 
+Status
+InferenceBackend::Init(
+    const std::string& path, const ModelConfig& config,
+    const std::string& platform)
+{
+  RETURN_IF_ERROR(ValidateModelConfig(config, platform));
+  RETURN_IF_ERROR(SetModelConfig(path, config));
+
+  return Status::Success;
+}
+
 void
 InferenceBackend::Run(
     const std::shared_ptr<ModelInferStats>& stats,

--- a/src/core/backend.h
+++ b/src/core/backend.h
@@ -25,6 +25,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
+#include "src/core/backend_context.h"
 #include "src/core/label_provider.h"
 #include "src/core/model_config.pb.h"
 #include "src/core/scheduler.h"
@@ -81,6 +82,12 @@ class InferenceBackend {
       std::function<void(const Status&)> OnCompleteHandleInfer);
 
  protected:
+  // Run model on the context associated with 'runner_idx' to
+  // execute for one or more requests.
+  virtual void Run(
+      uint32_t runner_idx, std::vector<Scheduler::Payload>* payloads,
+      std::function<void(Status)> OnCompleteQueuedPayloads);
+
   // Set the configuration of the model being served.
   Status SetModelConfig(const std::string& path, const ModelConfig& config);
 
@@ -96,6 +103,8 @@ class InferenceBackend {
 
   // Get the raw pointer to the scheduler of this backend.
   Scheduler* BackendScheduler() { return scheduler_.get(); }
+
+  std::vector<std::unique_ptr<BackendContext>> contexts_;
 
  private:
   // Configuration of the model that this backend represents.

--- a/src/core/backend.h
+++ b/src/core/backend.h
@@ -84,7 +84,7 @@ class InferenceBackend {
  protected:
   // Run model on the context associated with 'runner_idx' to
   // execute for one or more requests.
-  void Run(
+  virtual void Run(
       uint32_t runner_idx, std::vector<Scheduler::Payload>* payloads,
       std::function<void(Status)> OnCompleteQueuedPayloads);
 

--- a/src/core/backend.h
+++ b/src/core/backend.h
@@ -72,6 +72,10 @@ class InferenceBackend {
     return label_provider_;
   }
 
+  Status Init(
+      const std::string& path, const ModelConfig& config,
+      const std::string& platform);
+
   // Run inference using the provided request to produce outputs in the provide
   // response. The inference will run asynchronously and "OnCompleteHandleInfer"
   // callback will be called once the inference is completed

--- a/src/core/backend.h
+++ b/src/core/backend.h
@@ -84,7 +84,7 @@ class InferenceBackend {
  protected:
   // Run model on the context associated with 'runner_idx' to
   // execute for one or more requests.
-  virtual void Run(
+  void Run(
       uint32_t runner_idx, std::vector<Scheduler::Payload>* payloads,
       std::function<void(Status)> OnCompleteQueuedPayloads);
 

--- a/src/core/backend_context.h
+++ b/src/core/backend_context.h
@@ -36,8 +36,10 @@
 namespace nvidia { namespace inferenceserver {
 
 class AllocatedSystemMemory;
+class InferenceBackend;
 
 struct BackendContext {
+ public:
   // GPU device number that indicates that no gpu is available for a
   // context (which is an invalid state since TensorRT requires a
   // GPU).
@@ -54,6 +56,16 @@ struct BackendContext {
   // Create the CUDA stream for data transfer operations. Have no effect
   // if GPU support is disabled.
   Status CreateCudaStream(const int cuda_stream_priority = 0);
+
+  // Run model to execute for one or more requests. This function
+  // assumes that it is only called by the single runner thread that
+  // is assigned to this context. A non-OK return status indicates
+  // an internal error that prevents any of the of requests from
+  // completing. If an error is isolate to a single request payload
+  // it will be reported in that payload.
+  virtual Status Run(
+      const InferenceBackend* base,
+      std::vector<Scheduler::Payload>* payloads) = 0;
 
   // Helper function to batch input data from payloads into 'input_buffer'.
   // 'input_buffer' must be a continuous block that can hold the sum of


### PR DESCRIPTION
This is part of adding warmup functionality, the main purpose is to expose `Run()` in base class so that warmup functionality can utilize it without knowing underlying backends, and to remove redundant code.