### PR TITLE
Enable peer access for all device pairs at server initialization

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -125,6 +125,7 @@ set(
   autofill.cc
   backend.cc
   backend_context.cc
+  cuda_utils.cc
   dynamic_batch_scheduler.cc
   ensemble_scheduler.cc
   ensemble_utils.cc
@@ -153,6 +154,7 @@ set(
   backend.h
   backend_context.h
   constants.h
+  cuda_utils.h
   dynamic_batch_scheduler.h
   ensemble_scheduler.h
   ensemble_utils.h

--- a/src/core/cuda_utils.cc
+++ b/src/core/cuda_utils.cc
@@ -1,0 +1,77 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "src/core/cuda_utils.h"
+
+#include "src/core/model_config_utils.h"
+#include "src/core/request_status.pb.h"
+
+#ifdef TRTIS_ENABLE_GPU
+#include <cuda_runtime_api.h>
+#endif  // TRTIS_ENABLE_GPU
+
+namespace nvidia { namespace inferenceserver {
+
+Status
+EnablePeerAccess()
+{
+#ifdef TRTIS_ENABLE_GPU
+  // If we can't enable peer access for one device pair, the best we can
+  // do is skipping it...
+  std::set<int> supported_gpus;
+  bool all_enabled = false;
+  if (GetSupportedGPUs(supported_gpus).IsOk()) {
+    all_enabled = true;
+    int can_access_peer = false;
+    for (const auto& host : supported_gpus) {
+      auto cuerr = cudaSetDevice(host);
+
+      if (cuerr == cudaSuccess) {
+        for (const auto& peer : supported_gpus) {
+          if (host == peer) {
+            continue;
+          }
+
+          cuerr = cudaDeviceCanAccessPeer(&can_access_peer, host, peer);
+          if ((cuerr == cudaSuccess) && (can_access_peer == 1)) {
+            cuerr = cudaDeviceEnablePeerAccess(peer, 0);
+          }
+
+          all_enabled &= ((cuerr == cudaSuccess) && (can_access_peer == 1));
+        }
+      }
+    }
+  }
+  if (!all_enabled) {
+    return Status(
+        RequestStatusCode::UNSUPPORTED,
+        "failed to enable peer access for some device pairs");
+  }
+#endif  // TRTIS_ENABLE_GPU
+  return Status::Success;
+}
+
+}}  // namespace nvidia::inferenceserver

--- a/src/core/cuda_utils.h
+++ b/src/core/cuda_utils.h
@@ -1,0 +1,36 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include "src/core/status.h"
+
+namespace nvidia { namespace inferenceserver {
+
+/// Enable peer access for all GPU device pairs
+/// \return The error status. A non-OK status means not all pairs are enabled
+Status EnablePeerAccess();
+
+}}  // namespace nvidia::inferenceserver

--- a/src/core/server.cc
+++ b/src/core/server.cc
@@ -39,6 +39,7 @@
 #include "src/core/api.pb.h"
 #include "src/core/backend.h"
 #include "src/core/constants.h"
+#include "src/core/cuda_utils.h"
 #include "src/core/logging.h"
 #include "src/core/model_config.h"
 #include "src/core/model_config.pb.h"
@@ -130,6 +131,12 @@ InferenceServer::Init()
   if (!status.IsOk()) {
     ready_state_ = ServerReadyState::SERVER_FAILED_TO_INITIALIZE;
     return status;
+  }
+
+  status = EnablePeerAccess();
+  if (!status.IsOk()) {
+    // failed to enable peer access is not critical, just inefficient.
+    LOG_ERROR << status.Message();
   }
 
   // Create the model manager for the repository. Unless model control


### PR DESCRIPTION
It turns out that peer access needs to be enabled so that peer-to-peer copy will behave as expected. If not enabled, the copy will be staged through the host (i.e. device 0 -> host -> device 1, see [programming guide](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#peer-to-peer-memory-copy)).