### PR TITLE
Fix client/server builds by keeping functions in header files for non-GPU build

### DIFF
--- a/src/clients/c++/library/request.h.in
+++ b/src/clients/c++/library/request.h.in
@@ -54,6 +54,8 @@
 
 #if TRTIS_ENABLE_GPU
 #include <cuda_runtime_api.h>
+#else
+struct cudaIpcMemHandle_t{};
 #endif  // TRTIS_ENABLE_GPU
 
 namespace nvidia { namespace inferenceserver {
@@ -693,10 +695,10 @@ class InferContext {
   /// call to SetRunOptions().
   /// Once the request is completed, the InferContext pointer and the Request
   /// object will be passed to the provided 'callback' function. Upon the
-  /// invocation of callback function, the ownership of Request object is 
-  /// transfered to the function caller. It is then the caller's choice on 
+  /// invocation of callback function, the ownership of Request object is
+  /// transfered to the function caller. It is then the caller's choice on
   /// either retrieving the results inside the callback function or deferring
-  /// it to a different thread so that the InferContext is unblocked. See 
+  /// it to a different thread so that the InferContext is unblocked. See
   /// GetAsyncRunResults().
   /// \param callback The callback function to be invoked on request completion
   /// \return Error object indicating success or failure.
@@ -798,7 +800,6 @@ class SharedMemoryControlContext {
       const std::string& name, const std::string& shm_key, size_t offset,
       size_t byte_size) = 0;
 
-#if TRTIS_ENABLE_GPU
   /// Register a CUDA shared memory region on the inference server. If the
   /// shared memory region is already registered, it will return error
   /// 'TRTSERVER_ERROR_ALEADY_EXISTS'.
@@ -812,7 +813,6 @@ class SharedMemoryControlContext {
   virtual Error RegisterCudaSharedMemory(
       const std::string& name, const cudaIpcMemHandle_t& cuda_shm_handle,
       size_t byte_size, int device_id) = 0;
-#endif  // TRTIS_ENABLE_GPU
 
   /// Unregister a registered shared memory region on the inference server. If
   /// the shared memory region is not registered, do nothing and return success.

--- a/src/core/trtserver.cc
+++ b/src/core/trtserver.cc
@@ -546,19 +546,23 @@ TRTSERVER_SharedMemoryBlockCpuNew(
   return nullptr;  // Success
 }
 
-#ifdef TRTIS_ENABLE_GPU
 TRTSERVER_Error*
 TRTSERVER_SharedMemoryBlockGpuNew(
     TRTSERVER_SharedMemoryBlock** shared_memory_block, const char* name,
     const cudaIpcMemHandle_t* cuda_shm_handle, const size_t byte_size,
     const int device_id)
 {
+#ifdef TRTIS_ENABLE_GPU
   *shared_memory_block = reinterpret_cast<TRTSERVER_SharedMemoryBlock*>(
       new TrtServerSharedMemoryBlock(
           TRTSERVER_MEMORY_GPU, name, cuda_shm_handle, device_id, byte_size));
   return nullptr;  // Success
-}
+#else
+  return TRTSERVER_ErrorNew(
+      TRTSERVER_ERROR_UNSUPPORTED,
+      "CUDA shared memory not supported when TRTIS_ENABLE_GPU=0");
 #endif  // TRTIS_ENABLE_GPU
+}
 
 TRTSERVER_Error*
 TRTSERVER_SharedMemoryBlockDelete(

--- a/src/core/trtserver.h
+++ b/src/core/trtserver.h
@@ -45,6 +45,8 @@ extern "C" {
 
 #if TRTIS_ENABLE_GPU
 #include <cuda_runtime_api.h>
+#else
+typedef void cudaIpcMemHandle_t;
 #endif  // TRTIS_ENABLE_GPU
 
 struct TRTSERVER_Error;
@@ -155,12 +157,10 @@ TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_SharedMemoryBlockCpuNew(
 /// \param byte_size The size, in bytes of the block.
 /// \param device_id The GPU number the CUDA shared memory region is in.
 /// \return a TRTSERVER_Error indicating success or failure.
-#ifdef TRTIS_ENABLE_GPU
 TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_SharedMemoryBlockGpuNew(
     TRTSERVER_SharedMemoryBlock** shared_memory_block, const char* name,
     const cudaIpcMemHandle_t* cuda_shm_handle, const size_t byte_size,
     const int device_id);
-#endif  // TRTIS_ENABLE_GPU
 
 /// Delete a shared memory block object.
 /// \param shared_memory_block The object to delete.


### PR DESCRIPTION
Impacted functions: RegisterCudaSharedMemory and TRTSERVER_SharedMemoryBlockGpuNew
They return error when called with TRTIS_ENABLE_GPU=OFF