### PR TITLE
Fix dynamic and sequence batcher to handle unloaded backend case

### DIFF
--- a/Dockerfile.QA
+++ b/Dockerfile.QA
@@ -57,6 +57,8 @@ WORKDIR /workspace
 RUN mkdir -p qa/common && \
     mkdir qa/L0_simple_example/models && \
     cp -r docs/examples/model_repository/simple qa/L0_simple_example/models/. && \
+    mkdir qa/L0_backend_release/simple_models && \
+    cp -r docs/examples/model_repository/simple qa/L0_backend_release/simple_models/. && \
     mkdir qa/L0_simple_callback_example/models && \
     cp -r docs/examples/model_repository/simple qa/L0_simple_callback_example/models/. && \
     mkdir qa/L0_simple_string_example/models && \
@@ -112,6 +114,9 @@ RUN mkdir -p qa/L0_custom_param/models/param/1 && \
 RUN mkdir -p qa/L0_simple_sequence_example/models/simple_sequence/1 && \
     cp builddir/trtis-custom-backends/install/lib/libsequence.so \
         qa/L0_simple_sequence_example/models/simple_sequence/1/. && \
+    mkdir -p qa/L0_backend_release/simple_seq_models/simple_sequence/1 && \
+    cp builddir/trtis-custom-backends/install/lib/libsequence.so \
+        qa/L0_backend_release/simple_seq_models/simple_sequence/1/. && \
     mkdir -p qa/custom_models/custom_sequence_int32/1 && \
     cp builddir/trtis-custom-backends/install/lib/libsequence.so \
         qa/custom_models/custom_sequence_int32/1/.

--- a/qa/L0_backend_release/simple_seq_models/simple_sequence/config.pbtxt
+++ b/qa/L0_backend_release/simple_seq_models/simple_sequence/config.pbtxt
@@ -1,4 +1,3 @@
-#!/bin/bash
 # Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -25,41 +24,48 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-CLIENT_LOG="./client.log"
-SHM_TEST=shared_memory_test.py
-
-SERVER=/opt/tensorrtserver/bin/trtserver
-source ../common/util.sh
-
-RET=0
-
-SERVER_ARGS="--model-repository=`pwd`/models --log-verbose=1"
-SERVER_LOG="./inference_server.log"
-rm -f $SERVER_LOG
-rm -f $CLIENT_LOG
-run_server
-if [ "$SERVER_PID" == "0" ]; then
-    echo -e "\n***\n*** Failed to start $SERVER\n***"
-    cat $SERVER_LOG
-    exit 1
-fi
-
-set +e
-python $SHM_TEST >>$CLIENT_LOG 2>&1
-if [ $? -ne 0 ]; then
-    echo -e "\n***\n*** Test Failed\n***"
-    RET=1
-fi
-set -e
-
-kill $SERVER_PID
-wait $SERVER_PID
-
-if [ $RET -eq 0 ]; then
-    echo -e "\n***\n*** Test Passed\n***"
-else
-    cat $CLIENT_LOG
-    echo -e "\n***\n*** Test FAILED\n***"
-fi
-
-exit $RET
+name: "simple_sequence"
+platform: "custom"
+max_batch_size: 8
+default_model_filename: "libsequence.so"
+sequence_batching {
+  control_input [
+    {
+      name: "START"
+      control [
+        {
+          kind: CONTROL_SEQUENCE_START
+          int32_false_true: [ 0, 1 ]
+        }
+      ]
+    },
+    {
+      name: "READY"
+      control [
+        {
+          kind: CONTROL_SEQUENCE_READY
+          int32_false_true: [ 0, 1 ]
+        }
+      ]
+    }
+  ]
+}
+input [
+  {
+    name: "INPUT"
+    data_type: TYPE_INT32
+    dims: [ 1 ]
+  }
+]
+output [
+  {
+    name: "OUTPUT"
+    data_type: TYPE_INT32
+    dims: [ 1 ]
+  }
+]
+instance_group [
+  {
+    kind: KIND_CPU
+  }
+]

--- a/qa/L0_backend_release/test.sh
+++ b/qa/L0_backend_release/test.sh
@@ -1,0 +1,164 @@
+#!/bin/bash
+# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REPO_VERSION=${NVIDIA_TENSORRT_SERVER_VERSION}
+if [ "$#" -ge 1 ]; then
+    REPO_VERSION=$1
+fi
+if [ -z "$REPO_VERSION" ]; then
+    echo -e "Repository version must be specified"
+    echo -e "\n***\n*** Test Failed\n***"
+    exit 1
+fi
+
+SIMPLE_CLIENT=../clients/simple_client
+SIMPLE_SEQ_CLIENT=../clients/simple_sequence_client
+
+SERVER=/opt/tensorrtserver/bin/trtserver
+SERVER_ARGS=--model-repository=`pwd`/models
+source ../common/util.sh
+
+export CUDA_VISIBLE_DEVICES=0
+
+RET=0
+
+rm -fr *.log
+
+# This is a test of the schedulers to make sure they correctly release
+# their own backend so don't need to test across all frameworks.  Set
+# the delay, in milliseconds, that will cause the scheduler to be the
+# last holding the backend handle.
+export TRTSERVER_DELAY_SCHEDULER_BACKEND_RELEASE=5000
+
+# dynamic batcher - 1 instance
+rm -fr models && cp -r simple_models models
+(cd models/simple && echo "instance_group [{ count: 1 }]" >> config.pbtxt)
+
+SERVER_LOG="./inference_server_1.log"
+run_server
+if [ "$SERVER_PID" == "0" ]; then
+    echo -e "\n***\n*** Failed to start $SERVER\n***"
+    cat $SERVER_LOG
+    exit 1
+fi
+
+set +e
+
+$SIMPLE_CLIENT -v >> client_simple.log 2>&1
+if [ $? -ne 0 ]; then
+    RET=1
+fi
+
+set -e
+
+kill $SERVER_PID
+wait $SERVER_PID
+
+# dynamic batcher - 4 instance
+rm -fr models && cp -r simple_models models
+(cd models/simple && echo "instance_group [{ count: 4 }]" >> config.pbtxt)
+
+SERVER_LOG="./inference_server_4.log"
+run_server
+if [ "$SERVER_PID" == "0" ]; then
+    echo -e "\n***\n*** Failed to start $SERVER\n***"
+    cat $SERVER_LOG
+    exit 1
+fi
+
+set +e
+
+$SIMPLE_CLIENT -v >> client_simple.log 2>&1
+if [ $? -ne 0 ]; then
+    RET=1
+fi
+
+set -e
+
+kill $SERVER_PID
+wait $SERVER_PID
+
+# sequence batcher - 1 instance
+rm -fr models && cp -r simple_seq_models models
+(cd models/simple_sequence && \
+        sed -i "s/sequence_batching.*{.*/sequence_batching { max_sequence_idle_microseconds: 10000000/" \
+            config.pbtxt)
+
+SERVER_LOG="./inference_server_seq_1.log"
+run_server
+if [ "$SERVER_PID" == "0" ]; then
+    echo -e "\n***\n*** Failed to start $SERVER\n***"
+    cat $SERVER_LOG
+    exit 1
+fi
+
+set +e
+
+$SIMPLE_SEQ_CLIENT -v -a >> client_simple_seq.log 2>&1
+if [ $? -ne 0 ]; then
+    RET=1
+fi
+
+set -e
+
+kill $SERVER_PID
+wait $SERVER_PID
+
+# sequence batcher - 4 instance
+rm -fr models && cp -r simple_seq_models models
+(cd models/simple_sequence && \
+        echo "instance_group [{ count: 3 }]" >> config.pbtxt && \
+        sed -i "s/sequence_batching.*{.*/sequence_batching { max_sequence_idle_microseconds: 10000000/" \
+            config.pbtxt)
+
+SERVER_LOG="./inference_server_seq_4.log"
+run_server
+if [ "$SERVER_PID" == "0" ]; then
+    echo -e "\n***\n*** Failed to start $SERVER\n***"
+    cat $SERVER_LOG
+    exit 1
+fi
+
+set +e
+
+$SIMPLE_SEQ_CLIENT -v -a >> client_simple_seq.log 2>&1
+if [ $? -ne 0 ]; then
+    RET=1
+fi
+
+set -e
+
+kill $SERVER_PID
+wait $SERVER_PID
+
+if [ $RET -eq 0 ]; then
+    echo -e "\n***\n*** Test Passed\n***"
+else
+    echo -e "\n***\n*** Test FAILED\n***"
+fi
+
+exit $RET

--- a/src/core/dynamic_batch_scheduler.h
+++ b/src/core/dynamic_batch_scheduler.h
@@ -64,6 +64,7 @@ class DynamicBatchScheduler : public Scheduler {
       StandardRunFunc OnSchedule);
   void SchedulerThread(
       const uint32_t runner_id, const int nice,
+      const std::shared_ptr<std::atomic<bool>>& rthread_exit,
       std::promise<bool>* is_initialized);
   void InitPendingShape(const InferRequestHeader& request);
   bool CompareWithPendingShape(const InferRequestHeader& request) const;
@@ -97,7 +98,7 @@ class DynamicBatchScheduler : public Scheduler {
   std::deque<Scheduler::Payload> queue_;
 
   std::vector<std::unique_ptr<std::thread>> scheduler_threads_;
-  std::atomic<bool> scheduler_threads_exit_;
+  std::vector<std::shared_ptr<std::atomic<bool>>> scheduler_threads_exit_;
 
   size_t max_preferred_batch_size_;
   std::set<int32_t> preferred_batch_sizes_;

--- a/src/servers/http_server.cc
+++ b/src/servers/http_server.cc
@@ -1117,7 +1117,6 @@ HTTPAPIServer::HandleInfer(evhtp_request_t* req, const std::string& infer_uri)
         req, (request_status.code() == RequestStatusCode::SUCCESS)
                  ? EVHTP_RES_OK
                  : EVHTP_RES_BADREQ);
-    evhtp_request_resume(req);
   }
 
   TRTSERVER_ErrorDelete(err);

--- a/src/servers/shared_memory_block_manager.cc
+++ b/src/servers/shared_memory_block_manager.cc
@@ -43,6 +43,8 @@ SharedMemoryBlockManager::CpuCreate(
 {
   *smb = nullptr;
 
+  std::lock_guard<std::mutex> lock(mu_);
+
   if (blocks_.find(name) != blocks_.end()) {
     return TRTSERVER_ErrorNew(
         TRTSERVER_ERROR_ALREADY_EXISTS,
@@ -67,6 +69,8 @@ SharedMemoryBlockManager::GpuCreate(
 {
   *smb = nullptr;
 
+  std::lock_guard<std::mutex> lock(mu_);
+
   if (blocks_.find(name) != blocks_.end()) {
     return TRTSERVER_ErrorNew(
         TRTSERVER_ERROR_ALREADY_EXISTS,
@@ -89,6 +93,8 @@ SharedMemoryBlockManager::Get(
 {
   *smb = nullptr;
 
+  std::lock_guard<std::mutex> lock(mu_);
+
   auto itr = blocks_.find(name);
   if (itr == blocks_.end()) {
     return TRTSERVER_ErrorNew(
@@ -108,6 +114,8 @@ SharedMemoryBlockManager::Find(
 {
   *smb = nullptr;
 
+  std::lock_guard<std::mutex> lock(mu_);
+
   auto itr = blocks_.find(name);
   if (itr != blocks_.end()) {
     *smb = itr->second;
@@ -122,6 +130,8 @@ SharedMemoryBlockManager::Remove(
 {
   *smb = nullptr;
 
+  std::lock_guard<std::mutex> lock(mu_);
+
   auto itr = blocks_.find(name);
   if (itr != blocks_.end()) {
     *smb = itr->second;
@@ -135,6 +145,8 @@ TRTSERVER_Error*
 SharedMemoryBlockManager::Clear()
 {
   std::string failed_blocks;
+
+  std::lock_guard<std::mutex> lock(mu_);
 
   auto it = blocks_.begin();
   while (it != blocks_.cend()) {

--- a/src/servers/shared_memory_block_manager.h
+++ b/src/servers/shared_memory_block_manager.h
@@ -102,6 +102,7 @@ class SharedMemoryBlockManager {
   TRTSERVER_Error* Clear();
 
  private:
+  std::mutex mu_;
   std::unordered_map<std::string, TRTSERVER_SharedMemoryBlock*> blocks_;
 };
 


### PR DESCRIPTION
If the server is exiting or a backend is unloaded, it could be that a
scheduler thread for that backend is holding the last reference to the
backend. In this case the scheduler thread itself will destroy the
backend and thus destroy the DynamicBatchScheduler which owns the thread. So
the thread needs to handle this case where it is destroying itself correctly.