### PR TITLE
Correctly cleanup request provider if early infer error

### DIFF
--- a/src/servers/grpc_server.cc
+++ b/src/servers/grpc_server.cc
@@ -982,13 +982,13 @@ InferHandler::Process(Handler::State* state, bool rpc_ok)
                 trtserver_.get(), trace, request_provider, allocator_,
                 &state->alloc_payload_ /* response_allocator_userp */,
                 InferComplete, reinterpret_cast<void*>(state));
-
-            // The request provider can be deleted immediately after the
-            // ServerInferAsync call returns.
-            TRTSERVER_InferenceRequestProviderDelete(request_provider);
           }
         }
       }
+
+      // The request provider can be deleted before ServerInferAsync
+      // callback completes.
+      TRTSERVER_InferenceRequestProviderDelete(request_provider);
     }
 
     // If not error then state->step_ == ISSUED and inference request
@@ -1287,13 +1287,13 @@ StreamInferHandler::Process(Handler::State* state, bool rpc_ok)
                 trtserver_.get(), trace, request_provider, allocator_,
                 &state->alloc_payload_ /* response_allocator_userp */,
                 StreamInferComplete, reinterpret_cast<void*>(state));
-
-            // The request provider can be deleted immediately after the
-            // ServerInferAsync call returns.
-            TRTSERVER_InferenceRequestProviderDelete(request_provider);
           }
         }
       }
+
+      // The request provider can be deleted before ServerInferAsync
+      // callback completes.
+      TRTSERVER_InferenceRequestProviderDelete(request_provider);
     }
 
     // If there was not an error in issuing the 'state' request then

--- a/src/servers/http_server.cc
+++ b/src/servers/http_server.cc
@@ -1085,12 +1085,12 @@ HTTPAPIServer::HandleInfer(evhtp_request_t* req, const std::string& infer_uri)
         delete infer_request;
         infer_request = nullptr;
       }
-
-      // The request provider can be deleted immediately after the
-      // ServerInferAsync call returns.
-      TRTSERVER_InferenceRequestProviderDelete(request_provider);
     }
   }
+
+  // The request provider can be deleted before ServerInferAsync
+  // callback completes.
+  TRTSERVER_InferenceRequestProviderDelete(request_provider);
 
   if (err != nullptr) {
     RequestStatus request_status;


### PR DESCRIPTION
Without this cleanup the provider is leaked which also keeps a backend
reference so that it can't be unloaded.