### PR TITLE
Improve CUDA feature check in build_wheel.sh

### DIFF
--- a/src/clients/python/build_wheel.sh
+++ b/src/clients/python/build_wheel.sh
@@ -75,7 +75,7 @@ function main() {
     cp shared_memory/__init__.py \
       "${WHLDIR}/tensorrtserver/shared_memory/."
 
-    if [ "$(expr $CUDA_VERSION)" != "" ]; then
+    if [ -f libccudashm.so ] && [ -f cuda_shared_memory/__init__.py ]; then
       mkdir -p ${WHLDIR}/tensorrtserver/cuda_shared_memory
       cp libccudashm.so \
         "${WHLDIR}/tensorrtserver/cuda_shared_memory/."


### PR DESCRIPTION
In the python client build_wheel.sh script, make the CUDA shared memory feature condition check if the needed files exist instead of looking for the CUDA_VERSION environment variable.  
The current check breaks builds that have the TRTIS_ENABLE_GPU flag disabled on systems that have CUDA installed.