### PR TITLE
Modify TRTServer tracing interface to better capture trace for ensemble

### DIFF
--- a/Dockerfile.QA
+++ b/Dockerfile.QA
@@ -158,6 +158,8 @@ RUN cp builddir/trtis-custom-backends/install/lib/libidentity.so \
         qa/L0_io/. && \
     cp builddir/trtis-custom-backends/install/lib/libidentity.so \
         qa/L0_warmup/. && \
+    cp builddir/trtis-custom-backends/install/lib/libidentity.so \
+        qa/L0_cmdline_trace/. && \
     mkdir -p qa/L0_infer_shm && \
     cp -r qa/L0_infer/. qa/L0_infer_shm && \
     mkdir -p qa/L0_infer_cudashm && \

--- a/src/core/ensemble_scheduler.cc
+++ b/src/core/ensemble_scheduler.cc
@@ -726,6 +726,7 @@ EnsembleContext::ScheduleSteps(
     infer_stats->SetBatchSize(
         step->request_provider_->RequestHeader().batch_size());
     infer_stats->SetFailed(true);
+    infer_stats->SetTrace(context->stats_->GetTrace());
 
     context->is_->InferAsync(
         step->backend_, step->request_provider_, step->response_provider_,

--- a/src/core/ensemble_scheduler.cc
+++ b/src/core/ensemble_scheduler.cc
@@ -730,7 +730,7 @@ EnsembleContext::ScheduleSteps(
 
     // Passing trace-related objects down
     infer_stats->SetTrace(context->stats_->GetTrace());
-    infer_stats->InitEnsemblePhase(context->stats_->GetEnsemblePhase());
+    infer_stats->InitDerivedModelInfo(context->stats_->GetDerivedModelInfo());
 
     context->is_->InferAsync(
         step->backend_, step->request_provider_, step->response_provider_,

--- a/src/core/ensemble_scheduler.cc
+++ b/src/core/ensemble_scheduler.cc
@@ -313,6 +313,13 @@ EnsembleContext::EnsembleContext(
   } else {
     allocator_.reset(allocator);
   }
+
+  // If there is no derived model info associated with the ensemble request,
+  // it will be the first and should initialize a model info for itself so that
+  // the sequential model execution will know the parent.
+  if (stats_->GetDerivedModelInfo() == nullptr) {
+    stats_->InitDerivedModelInfo(nullptr);
+  }
 }
 
 TRTSERVER_Error*

--- a/src/core/ensemble_scheduler.cc
+++ b/src/core/ensemble_scheduler.cc
@@ -313,13 +313,6 @@ EnsembleContext::EnsembleContext(
   } else {
     allocator_.reset(allocator);
   }
-
-  // If there is no derived model info associated with the ensemble request,
-  // it will be the first and should initialize a model info for itself so that
-  // the sequential model execution will know the parent.
-  if (stats_->GetDerivedModelInfo() == nullptr) {
-    stats_->InitDerivedModelInfo(nullptr);
-  }
 }
 
 TRTSERVER_Error*
@@ -736,8 +729,8 @@ EnsembleContext::ScheduleSteps(
     infer_stats->SetFailed(true);
 
     // Passing trace-related objects down
-    infer_stats->SetTrace(context->stats_->GetTrace());
-    infer_stats->InitDerivedModelInfo(context->stats_->GetDerivedModelInfo());
+    infer_stats->SetTraceManager(context->stats_->GetTraceManager());
+    infer_stats->NewTrace(context->stats_->GetTrace());
 
     context->is_->InferAsync(
         step->backend_, step->request_provider_, step->response_provider_,

--- a/src/core/ensemble_scheduler.cc
+++ b/src/core/ensemble_scheduler.cc
@@ -34,6 +34,7 @@
 #include "src/core/provider_utils.h"
 #include "src/core/server.h"
 #include "src/core/server_status.h"
+#include "src/core/trtserver.h"
 
 namespace nvidia { namespace inferenceserver {
 
@@ -726,7 +727,10 @@ EnsembleContext::ScheduleSteps(
     infer_stats->SetBatchSize(
         step->request_provider_->RequestHeader().batch_size());
     infer_stats->SetFailed(true);
+
+    // Passing trace-related objects down
     infer_stats->SetTrace(context->stats_->GetTrace());
+    infer_stats->InitEnsemblePhase(context->stats_->GetEnsemblePhase());
 
     context->is_->InferAsync(
         step->backend_, step->request_provider_, step->response_provider_,

--- a/src/core/server_status.cc
+++ b/src/core/server_status.cc
@@ -338,17 +338,18 @@ ServerStatTimerScoped::~ServerStatTimerScoped()
 }
 
 void
-ModelInferStats::InitEnsemblePhase(TRTSERVER_Ensemble_Phase* parent_phase)
+ModelInferStats::InitDerivedModelInfo(
+    TRTSERVER_Trace_Derived_Model_Info* parent)
 {
 #ifdef TRTIS_ENABLE_TRACING
   if (trace_ != nullptr) {
-    ensemble_phase_.reset(new TRTSERVER_Ensemble_Phase);
+    derived_model_info_.reset(new TRTSERVER_Trace_Derived_Model_Info);
     Trace* ltrace = reinterpret_cast<Trace*>(trace_);
     // Get an ID that is unique in respect to the trace
-    ensemble_phase_->phase_id_ = ltrace->NextId();
-    ensemble_phase_->model_name_ = model_name_.c_str();
-    ensemble_phase_->parent_id_ =
-        (parent_phase != nullptr) ? parent_phase->phase_id_ : -1;
+    derived_model_info_->id_ = ltrace->NextId();
+    derived_model_info_->model_name_ = model_name_.c_str();
+    derived_model_info_->version_ = requested_model_version_;
+    derived_model_info_->parent_id_ = (parent != nullptr) ? parent->id_ : -1;
   }
 #endif  // TRTIS_ENABLE_TRACING
 }

--- a/src/core/server_status.cc
+++ b/src/core/server_status.cc
@@ -32,6 +32,7 @@
 #include "src/core/metric_model_reporter.h"
 #include "src/core/metrics.h"
 #include "src/core/provider.h"
+#include "src/core/tracing.h"
 
 namespace nvidia { namespace inferenceserver {
 
@@ -339,6 +340,13 @@ ServerStatTimerScoped::~ServerStatTimerScoped()
 void
 ModelInferStats::Report()
 {
+#ifdef TRTIS_ENABLE_TRACING
+  if (trace_ != nullptr) {
+    Trace* ltrace = reinterpret_cast<Trace*>(trace_);
+    ltrace->Report(this);
+  }
+#endif  // TRTIS_ENABLE_TRACING
+
   // If the inference request failed before a backend could be
   // determined, there will be no metrics reporter.. so just use the
   // version directly from the inference request.

--- a/src/core/server_status.cc
+++ b/src/core/server_status.cc
@@ -338,6 +338,22 @@ ServerStatTimerScoped::~ServerStatTimerScoped()
 }
 
 void
+ModelInferStats::InitEnsemblePhase(TRTSERVER_Ensemble_Phase* parent_phase)
+{
+#ifdef TRTIS_ENABLE_TRACING
+  if (trace_ != nullptr) {
+    ensemble_phase_.reset(new TRTSERVER_Ensemble_Phase);
+    Trace* ltrace = reinterpret_cast<Trace*>(trace_);
+    // Get an ID that is unique in respect to the trace
+    ensemble_phase_->phase_id_ = ltrace->NextId();
+    ensemble_phase_->model_name_ = model_name_.c_str();
+    ensemble_phase_->parent_id_ =
+        (parent_phase != nullptr) ? parent_phase->phase_id_ : -1;
+  }
+#endif  // TRTIS_ENABLE_TRACING
+}
+
+void
 ModelInferStats::Report()
 {
 #ifdef TRTIS_ENABLE_TRACING

--- a/src/core/server_status.cc
+++ b/src/core/server_status.cc
@@ -369,7 +369,8 @@ ModelInferStats::Report()
     ltrace->Report(this);
     // Inform that the trace object is done and can be released
     auto ltrace_manager = reinterpret_cast<OpaqueTraceManager*>(trace_manager_);
-    ltrace_manager->release_fn_(trace_);
+    ltrace_manager->release_fn_(
+        trace_, ltrace->ActivityUserp(), ltrace_manager->userp_);
   }
 #endif  // TRTIS_ENABLE_TRACING
 

--- a/src/core/server_status.h
+++ b/src/core/server_status.h
@@ -140,7 +140,7 @@ class ModelInferStats {
   void SetTraceManager(TRTSERVER_TraceManager* tm) { trace_manager_ = tm; }
 
   // Get the trace manager associated with the inference.
-  TRTSERVER_TraceManager* GetTraceManager() { return trace_manager_; }
+  TRTSERVER_TraceManager* GetTraceManager() const { return trace_manager_; }
 
   // Create a trace object associated to the inference.
   // Optional 'parent' can be provided if the trace object has a parent.
@@ -152,7 +152,7 @@ class ModelInferStats {
   // Get the trace object associated to the inference.
   // Return nullptr if the inference will not be traced or if NewTrace()
   // has not been called.
-  TRTSERVER_Trace* GetTrace() { return trace_; }
+  TRTSERVER_Trace* GetTrace() const { return trace_; }
 
   // Get the timestamp for a kind.
   const struct timespec& Timestamp(TimestampKind kind) const
@@ -194,10 +194,12 @@ class ModelInferStats {
   uint64_t extra_queue_duration_;
   uint64_t extra_compute_duration_;
 
-  // not own
+  // The trace manager associated with these stats. This object is not owned by
+  // this ModelInferStats object and so is not destroyed by this object.
   TRTSERVER_TraceManager* trace_manager_;
 
-  // not own
+  // The trace associated with these stats. This object is not owned by
+  // this ModelInferStats object and so is not destroyed by this object.
   TRTSERVER_Trace* trace_;
 };
 

--- a/src/core/server_status.h
+++ b/src/core/server_status.h
@@ -103,7 +103,7 @@ class ModelInferStats {
         requested_model_version_(-1), batch_size_(0), gpu_device_(-1),
         failed_(false), execution_count_(0),
         timestamps_((size_t)TimestampKind::COUNT__), extra_queue_duration_(0),
-        extra_compute_duration_(0)
+        extra_compute_duration_(0), trace_(nullptr)
   {
     memset(&timestamps_[0], 0, sizeof(struct timespec) * timestamps_.size());
   }
@@ -135,6 +135,12 @@ class ModelInferStats {
   // batched with another request (in dynamic batch case only one of
   // the batched requests will count the execution).
   void SetModelExecutionCount(uint32_t count) { execution_count_ = count; }
+
+  // Set the trace object if the inference will be traced.
+  void SetTrace(TRTSERVER_Trace* trace) { trace_ = trace; }
+
+  // Get the trace object related to the inference.
+  TRTSERVER_Trace* GetTrace() { return trace_; }
 
   // Get the timestamp for a kind.
   const struct timespec& Timestamp(TimestampKind kind) const
@@ -175,6 +181,8 @@ class ModelInferStats {
 
   uint64_t extra_queue_duration_;
   uint64_t extra_compute_duration_;
+
+  TRTSERVER_Trace* trace_;
 };
 
 // Manage access and updates to server status information.

--- a/src/core/server_status.h
+++ b/src/core/server_status.h
@@ -142,6 +142,18 @@ class ModelInferStats {
   // Get the trace object related to the inference.
   TRTSERVER_Trace* GetTrace() { return trace_; }
 
+  // Populate the ensemble phase associated with this infer stats,
+  // which will be passed to tracer if it is being traced.
+  // This function Has no effect if not being traced.
+  void InitEnsemblePhase(TRTSERVER_Ensemble_Phase* parent_phase);
+
+  // Get the ensemble phase struct. nullptr will be returned if
+  // InitEnsemblePhase() hasn't been called.
+  TRTSERVER_Ensemble_Phase* GetEnsemblePhase() const
+  {
+    return ensemble_phase_.get();
+  }
+
   // Get the timestamp for a kind.
   const struct timespec& Timestamp(TimestampKind kind) const
   {
@@ -183,6 +195,7 @@ class ModelInferStats {
   uint64_t extra_compute_duration_;
 
   TRTSERVER_Trace* trace_;
+  std::unique_ptr<TRTSERVER_Ensemble_Phase> ensemble_phase_;
 };
 
 // Manage access and updates to server status information.

--- a/src/core/server_status.h
+++ b/src/core/server_status.h
@@ -142,16 +142,16 @@ class ModelInferStats {
   // Get the trace object related to the inference.
   TRTSERVER_Trace* GetTrace() { return trace_; }
 
-  // Populate the ensemble phase associated with this infer stats,
-  // which will be passed to tracer if it is being traced.
+  // Initialize the information of a model execution derived from request to
+  // an ensemble model, which will be used for tracing.
   // This function Has no effect if not being traced.
-  void InitEnsemblePhase(TRTSERVER_Ensemble_Phase* parent_phase);
+  void InitDerivedModelInfo(TRTSERVER_Trace_Derived_Model_Info* parent);
 
-  // Get the ensemble phase struct. nullptr will be returned if
-  // InitEnsemblePhase() hasn't been called.
-  TRTSERVER_Ensemble_Phase* GetEnsemblePhase() const
+  // Get the derived model information struct. nullptr will be returned if
+  // InitDerivedModelInfo() hasn't been called.
+  TRTSERVER_Trace_Derived_Model_Info* GetDerivedModelInfo() const
   {
-    return ensemble_phase_.get();
+    return derived_model_info_.get();
   }
 
   // Get the timestamp for a kind.
@@ -195,7 +195,7 @@ class ModelInferStats {
   uint64_t extra_compute_duration_;
 
   TRTSERVER_Trace* trace_;
-  std::unique_ptr<TRTSERVER_Ensemble_Phase> ensemble_phase_;
+  std::unique_ptr<TRTSERVER_Trace_Derived_Model_Info> derived_model_info_;
 };
 
 // Manage access and updates to server status information.

--- a/src/core/tracing.cc
+++ b/src/core/tracing.cc
@@ -33,7 +33,7 @@
 namespace nvidia { namespace inferenceserver {
 
 void
-Trace::Report(const std::shared_ptr<ModelInferStats>& infer_stats)
+Trace::Report(const ModelInferStats* infer_stats)
 {
   if (level_ != TRTSERVER_TRACE_LEVEL_DISABLED) {
     activity_fn_(

--- a/src/core/tracing.cc
+++ b/src/core/tracing.cc
@@ -36,47 +36,66 @@ void
 Trace::Report(const ModelInferStats* infer_stats)
 {
   auto ensemble_phase = infer_stats->GetEnsemblePhase();
+  // InferStats that is not captured should not be reported (i.e. ensemble
+  // only have valid timestamp for request start and end)
+  uint64_t timestamp = 0;
   if (level_ != TRTSERVER_TRACE_LEVEL_DISABLED) {
-    activity_fn_(
-        reinterpret_cast<TRTSERVER_Trace*>(this), TRTSERVER_TRACE_REQUEST_START,
-        TIMESPEC_TO_NANOS(infer_stats->Timestamp(
-            ModelInferStats::TimestampKind::kRequestStart)),
-        ensemble_phase, activity_userp_);
-    activity_fn_(
-        reinterpret_cast<TRTSERVER_Trace*>(this), TRTSERVER_TRACE_QUEUE_START,
-        TIMESPEC_TO_NANOS(infer_stats->Timestamp(
-            ModelInferStats::TimestampKind::kQueueStart)),
-        ensemble_phase, activity_userp_);
-    activity_fn_(
-        reinterpret_cast<TRTSERVER_Trace*>(this), TRTSERVER_TRACE_COMPUTE_START,
-        TIMESPEC_TO_NANOS(infer_stats->Timestamp(
-            ModelInferStats::TimestampKind::kComputeStart)),
-        ensemble_phase, activity_userp_);
-    activity_fn_(
-        reinterpret_cast<TRTSERVER_Trace*>(this), TRTSERVER_TRACE_COMPUTE_END,
-        TIMESPEC_TO_NANOS(infer_stats->Timestamp(
-            ModelInferStats::TimestampKind::kComputeEnd)),
-        ensemble_phase, activity_userp_);
-    activity_fn_(
-        reinterpret_cast<TRTSERVER_Trace*>(this), TRTSERVER_TRACE_REQUEST_END,
-        TIMESPEC_TO_NANOS(infer_stats->Timestamp(
-            ModelInferStats::TimestampKind::kRequestEnd)),
-        ensemble_phase, activity_userp_);
+    timestamp = TIMESPEC_TO_NANOS(
+        infer_stats->Timestamp(ModelInferStats::TimestampKind::kRequestStart));
+    if (timestamp != 0) {
+      activity_fn_(
+          reinterpret_cast<TRTSERVER_Trace*>(this),
+          TRTSERVER_TRACE_REQUEST_START, timestamp, ensemble_phase,
+          activity_userp_);
+    }
+    timestamp = TIMESPEC_TO_NANOS(
+        infer_stats->Timestamp(ModelInferStats::TimestampKind::kQueueStart));
+    if (timestamp != 0) {
+      activity_fn_(
+          reinterpret_cast<TRTSERVER_Trace*>(this), TRTSERVER_TRACE_QUEUE_START,
+          timestamp, ensemble_phase, activity_userp_);
+    }
+    timestamp = TIMESPEC_TO_NANOS(
+        infer_stats->Timestamp(ModelInferStats::TimestampKind::kComputeStart));
+    if (timestamp != 0) {
+      activity_fn_(
+          reinterpret_cast<TRTSERVER_Trace*>(this),
+          TRTSERVER_TRACE_COMPUTE_START, timestamp, ensemble_phase,
+          activity_userp_);
+    }
+    timestamp = TIMESPEC_TO_NANOS(
+        infer_stats->Timestamp(ModelInferStats::TimestampKind::kComputeEnd));
+    if (timestamp != 0) {
+      activity_fn_(
+          reinterpret_cast<TRTSERVER_Trace*>(this), TRTSERVER_TRACE_COMPUTE_END,
+          timestamp, ensemble_phase, activity_userp_);
+    }
+    timestamp = TIMESPEC_TO_NANOS(
+        infer_stats->Timestamp(ModelInferStats::TimestampKind::kRequestEnd));
+    if (timestamp != 0) {
+      activity_fn_(
+          reinterpret_cast<TRTSERVER_Trace*>(this), TRTSERVER_TRACE_REQUEST_END,
+          timestamp, ensemble_phase, activity_userp_);
+    }
   }
 
   if (level_ == TRTSERVER_TRACE_LEVEL_MAX) {
-    activity_fn_(
-        reinterpret_cast<TRTSERVER_Trace*>(this),
-        TRTSERVER_TRACE_COMPUTE_INPUT_END,
-        TIMESPEC_TO_NANOS(infer_stats->Timestamp(
-            ModelInferStats::TimestampKind::kComputeInputEnd)),
-        ensemble_phase, activity_userp_);
-    activity_fn_(
-        reinterpret_cast<TRTSERVER_Trace*>(this),
-        TRTSERVER_TRACE_COMPUTE_OUTPUT_START,
-        TIMESPEC_TO_NANOS(infer_stats->Timestamp(
-            ModelInferStats::TimestampKind::kComputeOutputStart)),
-        ensemble_phase, activity_userp_);
+    timestamp = TIMESPEC_TO_NANOS(infer_stats->Timestamp(
+        ModelInferStats::TimestampKind::kComputeInputEnd));
+    if (timestamp != 0) {
+      activity_fn_(
+          reinterpret_cast<TRTSERVER_Trace*>(this),
+          TRTSERVER_TRACE_COMPUTE_INPUT_END, timestamp, ensemble_phase,
+          activity_userp_);
+    }
+    timestamp = TIMESPEC_TO_NANOS(infer_stats->Timestamp(
+        ModelInferStats::TimestampKind::kComputeOutputStart));
+    if (timestamp != 0) {
+      activity_fn_(
+          reinterpret_cast<TRTSERVER_Trace*>(this),
+          TRTSERVER_TRACE_COMPUTE_OUTPUT_START, timestamp, ensemble_phase,
+          activity_userp_);
+    }
   }
 }
 

--- a/src/core/tracing.cc
+++ b/src/core/tracing.cc
@@ -35,32 +35,33 @@ namespace nvidia { namespace inferenceserver {
 void
 Trace::Report(const ModelInferStats* infer_stats)
 {
+  auto ensemble_phase = infer_stats->GetEnsemblePhase();
   if (level_ != TRTSERVER_TRACE_LEVEL_DISABLED) {
     activity_fn_(
         reinterpret_cast<TRTSERVER_Trace*>(this), TRTSERVER_TRACE_REQUEST_START,
         TIMESPEC_TO_NANOS(infer_stats->Timestamp(
             ModelInferStats::TimestampKind::kRequestStart)),
-        activity_userp_);
+        ensemble_phase, activity_userp_);
     activity_fn_(
         reinterpret_cast<TRTSERVER_Trace*>(this), TRTSERVER_TRACE_QUEUE_START,
         TIMESPEC_TO_NANOS(infer_stats->Timestamp(
             ModelInferStats::TimestampKind::kQueueStart)),
-        activity_userp_);
+        ensemble_phase, activity_userp_);
     activity_fn_(
         reinterpret_cast<TRTSERVER_Trace*>(this), TRTSERVER_TRACE_COMPUTE_START,
         TIMESPEC_TO_NANOS(infer_stats->Timestamp(
             ModelInferStats::TimestampKind::kComputeStart)),
-        activity_userp_);
+        ensemble_phase, activity_userp_);
     activity_fn_(
         reinterpret_cast<TRTSERVER_Trace*>(this), TRTSERVER_TRACE_COMPUTE_END,
         TIMESPEC_TO_NANOS(infer_stats->Timestamp(
             ModelInferStats::TimestampKind::kComputeEnd)),
-        activity_userp_);
+        ensemble_phase, activity_userp_);
     activity_fn_(
         reinterpret_cast<TRTSERVER_Trace*>(this), TRTSERVER_TRACE_REQUEST_END,
         TIMESPEC_TO_NANOS(infer_stats->Timestamp(
             ModelInferStats::TimestampKind::kRequestEnd)),
-        activity_userp_);
+        ensemble_phase, activity_userp_);
   }
 
   if (level_ == TRTSERVER_TRACE_LEVEL_MAX) {
@@ -69,13 +70,13 @@ Trace::Report(const ModelInferStats* infer_stats)
         TRTSERVER_TRACE_COMPUTE_INPUT_END,
         TIMESPEC_TO_NANOS(infer_stats->Timestamp(
             ModelInferStats::TimestampKind::kComputeInputEnd)),
-        activity_userp_);
+        ensemble_phase, activity_userp_);
     activity_fn_(
         reinterpret_cast<TRTSERVER_Trace*>(this),
         TRTSERVER_TRACE_COMPUTE_OUTPUT_START,
         TIMESPEC_TO_NANOS(infer_stats->Timestamp(
             ModelInferStats::TimestampKind::kComputeOutputStart)),
-        activity_userp_);
+        ensemble_phase, activity_userp_);
   }
 }
 

--- a/src/core/tracing.cc
+++ b/src/core/tracing.cc
@@ -32,6 +32,8 @@
 
 namespace nvidia { namespace inferenceserver {
 
+std::atomic<int64_t> Trace::id_(0);
+
 void
 Trace::Report(const ModelInferStats* infer_stats)
 {

--- a/src/core/tracing.h
+++ b/src/core/tracing.h
@@ -41,9 +41,11 @@ class Trace {
  public:
   static Status Create(
       TRTSERVER_Trace_Level level, TRTSERVER_TraceActivityFn_t activity_fn,
+      TRTSERVER_TracePushFn_t push_fn, TRTSERVER_TracePopFn_t pop_fn,
       void* activity_userp, std::unique_ptr<Trace>* trace)
   {
-    trace->reset(new Trace(level, activity_fn, activity_userp));
+    trace->reset(
+        new Trace(level, activity_fn, push_fn, pop_fn, activity_userp));
     return Status::Success;
   }
 
@@ -54,14 +56,17 @@ class Trace {
  private:
   Trace(
       TRTSERVER_Trace_Level level, TRTSERVER_TraceActivityFn_t activity_fn,
+      TRTSERVER_TracePushFn_t push_fn, TRTSERVER_TracePopFn_t pop_fn,
       void* activity_userp)
-      : level_(level), activity_fn_(activity_fn),
-        activity_userp_(activity_userp), id_(0)
+      : level_(level), activity_fn_(activity_fn), push_fn_(push_fn),
+        pop_fn_(pop_fn), activity_userp_(activity_userp), id_(0)
   {
   }
 
   const TRTSERVER_Trace_Level level_;
   TRTSERVER_TraceActivityFn_t activity_fn_;
+  TRTSERVER_TracePushFn_t push_fn_;
+  TRTSERVER_TracePopFn_t pop_fn_;
   void* activity_userp_;
   std::atomic<int64_t> id_;
 };

--- a/src/core/tracing.h
+++ b/src/core/tracing.h
@@ -47,7 +47,7 @@ class Trace {
     return Status::Success;
   }
 
-  void Report(const std::shared_ptr<ModelInferStats>& infer_stats);
+  void Report(const ModelInferStats* infer_stats);
 
  private:
   Trace(

--- a/src/core/tracing.h
+++ b/src/core/tracing.h
@@ -59,7 +59,7 @@ class Trace {
       TRTSERVER_TracePushFn_t push_fn, TRTSERVER_TracePopFn_t pop_fn,
       void* activity_userp)
       : level_(level), activity_fn_(activity_fn), push_fn_(push_fn),
-        pop_fn_(pop_fn), activity_userp_(activity_userp), id_(0)
+        pop_fn_(pop_fn), activity_userp_(activity_userp)
   {
   }
 
@@ -68,7 +68,9 @@ class Trace {
   TRTSERVER_TracePushFn_t push_fn_;
   TRTSERVER_TracePopFn_t pop_fn_;
   void* activity_userp_;
-  std::atomic<int64_t> id_;
+
+  // Declare static so that IDs are unique even across traces
+  static std::atomic<int64_t> id_;
 };
 
 }}  // namespace nvidia::inferenceserver

--- a/src/core/tracing.h
+++ b/src/core/tracing.h
@@ -47,6 +47,8 @@ class Trace {
     return Status::Success;
   }
 
+  int64_t NextId() { return ++id_; }
+
   void Report(const ModelInferStats* infer_stats);
 
  private:
@@ -54,13 +56,14 @@ class Trace {
       TRTSERVER_Trace_Level level, TRTSERVER_TraceActivityFn_t activity_fn,
       void* activity_userp)
       : level_(level), activity_fn_(activity_fn),
-        activity_userp_(activity_userp)
+        activity_userp_(activity_userp), id_(0)
   {
   }
 
   const TRTSERVER_Trace_Level level_;
   TRTSERVER_TraceActivityFn_t activity_fn_;
   void* activity_userp_;
+  std::atomic<int64_t> id_;
 };
 
 }}  // namespace nvidia::inferenceserver

--- a/src/core/tracing.h
+++ b/src/core/tracing.h
@@ -62,11 +62,11 @@ class Trace {
   void SetModelVersion(int64_t v) { model_version_ = v; }
   void SetParentId(int64_t pid) { parent_id_ = pid; }
 
-  void* ActivityUserp() { return activity_userp_; }
-  const char* ModelName() { return model_name_.c_str(); }
-  int64_t ModelVersion() { return model_version_; }
-  int64_t Id() { return id_; }
-  int64_t ParentId() { return parent_id_; }
+  void* ActivityUserp() const { return activity_userp_; }
+  const char* ModelName() const { return model_name_.c_str(); }
+  int64_t ModelVersion() const { return model_version_; }
+  int64_t Id() const { return id_; }
+  int64_t ParentId() const { return parent_id_; }
 
   void Report(const ModelInferStats* infer_stats);
 

--- a/src/core/trtserver.cc
+++ b/src/core/trtserver.cc
@@ -710,19 +710,6 @@ TRTSERVER_TraceDelete(TRTSERVER_Trace* trace)
 }
 
 TRTSERVER_Error*
-TRTSERVER_TraceUserp(TRTSERVER_Trace* trace, void** userp)
-{
-#ifdef TRTIS_ENABLE_TRACING
-  ni::Trace* ltrace = reinterpret_cast<ni::Trace*>(trace);
-  *userp = ltrace->ActivityUserp();
-  return nullptr;  // Success
-#else
-  return TRTSERVER_ErrorNew(
-      TRTSERVER_ERROR_UNSUPPORTED, "tracing not supported");
-#endif  // TRTIS_ENABLE_TRACING
-}
-
-TRTSERVER_Error*
 TRTSERVER_TraceModelName(TRTSERVER_Trace* trace, const char** model_name)
 {
 #ifdef TRTIS_ENABLE_TRACING

--- a/src/core/trtserver.cc
+++ b/src/core/trtserver.cc
@@ -1456,9 +1456,6 @@ TRTSERVER_ServerInferAsync(
   infer_stats->SetFailed(true);
   infer_stats->SetTraceManager(trace_manager);
   infer_stats->NewTrace();
-  // [TODO] is this necessary?
-  TRTSERVER_Trace* trace =
-      reinterpret_cast<TRTSERVER_Trace*>(infer_stats->GetTrace());
 
   std::shared_ptr<ni::InferRequestProvider> infer_request_provider;
   RETURN_IF_STATUS_ERROR(ni::InferRequestProvider::Create(
@@ -1478,7 +1475,7 @@ TRTSERVER_ServerInferAsync(
   lserver->InferAsync(
       lprovider->Backend(), infer_request_provider, infer_response_provider,
       infer_stats,
-      [infer_stats, trace, infer_response_provider, server, complete_fn,
+      [infer_stats, trace_manager, infer_response_provider, server, complete_fn,
        complete_userp](const ni::Status& status) mutable {
         infer_stats->SetFailed(!status.IsOk());
         if (!status.IsOk()) {
@@ -1498,7 +1495,7 @@ TRTSERVER_ServerInferAsync(
         TrtServerResponse* response =
             new TrtServerResponse(status, infer_response_provider);
         complete_fn(
-            server, trace,
+            server, trace_manager,
             reinterpret_cast<TRTSERVER_InferenceResponse*>(response),
             complete_userp);
       });

--- a/src/core/trtserver.cc
+++ b/src/core/trtserver.cc
@@ -681,13 +681,12 @@ TRTSERVER_MetricsFormatted(
 TRTSERVER_Error*
 TRTSERVER_TraceNew(
     TRTSERVER_Trace** trace, TRTSERVER_Trace_Level level,
-    TRTSERVER_TraceActivityFn_t activity_fn, TRTSERVER_TracePushFn_t push_fn,
-    TRTSERVER_TracePopFn_t pop_fn, void* activity_userp)
+    TRTSERVER_TraceActivityFn_t activity_fn, void* activity_userp)
 {
 #ifdef TRTIS_ENABLE_TRACING
   std::unique_ptr<ni::Trace> ltrace;
-  RETURN_IF_STATUS_ERROR(ni::Trace::Create(
-      level, activity_fn, push_fn, pop_fn, activity_userp, &ltrace));
+  RETURN_IF_STATUS_ERROR(
+      ni::Trace::Create(level, activity_fn, activity_userp, &ltrace));
   *trace = reinterpret_cast<TRTSERVER_Trace*>(ltrace.release());
   return nullptr;  // Success
 #else
@@ -703,6 +702,107 @@ TRTSERVER_TraceDelete(TRTSERVER_Trace* trace)
 #ifdef TRTIS_ENABLE_TRACING
   ni::Trace* ltrace = reinterpret_cast<ni::Trace*>(trace);
   delete ltrace;
+  return nullptr;  // Success
+#else
+  return TRTSERVER_ErrorNew(
+      TRTSERVER_ERROR_UNSUPPORTED, "tracing not supported");
+#endif  // TRTIS_ENABLE_TRACING
+}
+
+TRTSERVER_Error*
+TRTSERVER_TraceUserp(TRTSERVER_Trace* trace, void** userp)
+{
+#ifdef TRTIS_ENABLE_TRACING
+  ni::Trace* ltrace = reinterpret_cast<ni::Trace*>(trace);
+  *userp = ltrace->ActivityUserp();
+  return nullptr;  // Success
+#else
+  return TRTSERVER_ErrorNew(
+      TRTSERVER_ERROR_UNSUPPORTED, "tracing not supported");
+#endif  // TRTIS_ENABLE_TRACING
+}
+
+TRTSERVER_Error*
+TRTSERVER_TraceModelName(TRTSERVER_Trace* trace, const char** model_name)
+{
+#ifdef TRTIS_ENABLE_TRACING
+  ni::Trace* ltrace = reinterpret_cast<ni::Trace*>(trace);
+  *model_name = ltrace->ModelName();
+  return nullptr;  // Success
+#else
+  return TRTSERVER_ErrorNew(
+      TRTSERVER_ERROR_UNSUPPORTED, "tracing not supported");
+#endif  // TRTIS_ENABLE_TRACING
+}
+
+TRTSERVER_Error*
+TRTSERVER_TraceModelVersion(TRTSERVER_Trace* trace, int64_t* model_version)
+{
+#ifdef TRTIS_ENABLE_TRACING
+  ni::Trace* ltrace = reinterpret_cast<ni::Trace*>(trace);
+  *model_version = ltrace->ModelVersion();
+  return nullptr;  // Success
+#else
+  return TRTSERVER_ErrorNew(
+      TRTSERVER_ERROR_UNSUPPORTED, "tracing not supported");
+#endif  // TRTIS_ENABLE_TRACING
+}
+
+TRTSERVER_Error*
+TRTSERVER_TraceId(TRTSERVER_Trace* trace, int64_t* id)
+{
+#ifdef TRTIS_ENABLE_TRACING
+  ni::Trace* ltrace = reinterpret_cast<ni::Trace*>(trace);
+  *id = ltrace->Id();
+  return nullptr;  // Success
+#else
+  return TRTSERVER_ErrorNew(
+      TRTSERVER_ERROR_UNSUPPORTED, "tracing not supported");
+#endif  // TRTIS_ENABLE_TRACING
+}
+
+TRTSERVER_Error*
+TRTSERVER_TraceParentId(TRTSERVER_Trace* trace, int64_t* parent_id)
+{
+#ifdef TRTIS_ENABLE_TRACING
+  ni::Trace* ltrace = reinterpret_cast<ni::Trace*>(trace);
+  *parent_id = ltrace->ParentId();
+  return nullptr;  // Success
+#else
+  return TRTSERVER_ErrorNew(
+      TRTSERVER_ERROR_UNSUPPORTED, "tracing not supported");
+#endif  // TRTIS_ENABLE_TRACING
+}
+
+TRTSERVER_Error*
+TRTSERVER_TraceManagerNew(
+    TRTSERVER_TraceManager** trace_manager,
+    TRTSERVER_TraceManagerCreateTraceFn_t create_fn,
+    TRTSERVER_TraceManagerReleaseTraceFn_t release_fn, void* userp)
+{
+#ifdef TRTIS_ENABLE_TRACING
+  std::unique_ptr<ni::OpaqueTraceManager> ltrace_manager(
+      new ni::OpaqueTraceManager);
+  ltrace_manager->create_fn_ = create_fn;
+  ltrace_manager->release_fn_ = release_fn;
+  ltrace_manager->userp_ = userp;
+  *trace_manager =
+      reinterpret_cast<TRTSERVER_TraceManager*>(ltrace_manager.release());
+  return nullptr;  // Success
+#else
+  *trace_manager = nullptr;
+  return TRTSERVER_ErrorNew(
+      TRTSERVER_ERROR_UNSUPPORTED, "tracing not supported");
+#endif  // TRTIS_ENABLE_TRACING
+}
+
+TRTSERVER_Error*
+TRTSERVER_TraceManagerDelete(TRTSERVER_TraceManager* trace_manager)
+{
+#ifdef TRTIS_ENABLE_TRACING
+  ni::OpaqueTraceManager* ltrace_manager =
+      reinterpret_cast<ni::OpaqueTraceManager*>(trace_manager);
+  delete ltrace_manager;
   return nullptr;  // Success
 #else
   return TRTSERVER_ErrorNew(
@@ -1345,7 +1445,7 @@ TRTSERVER_ServerMetrics(TRTSERVER_Server* server, TRTSERVER_Metrics** metrics)
 
 TRTSERVER_Error*
 TRTSERVER_ServerInferAsync(
-    TRTSERVER_Server* server, TRTSERVER_Trace* trace,
+    TRTSERVER_Server* server, TRTSERVER_TraceManager* trace_manager,
     TRTSERVER_InferenceRequestProvider* request_provider,
     TRTSERVER_ResponseAllocator* response_allocator,
     void* response_allocator_userp, TRTSERVER_InferenceCompleteFn_t complete_fn,
@@ -1367,7 +1467,11 @@ TRTSERVER_ServerInferAsync(
   infer_stats->SetMetricReporter(lprovider->Backend()->MetricReporter());
   infer_stats->SetBatchSize(request_header->batch_size());
   infer_stats->SetFailed(true);
-  infer_stats->SetTrace(trace);
+  infer_stats->SetTraceManager(trace_manager);
+  infer_stats->NewTrace();
+  // [TODO] is this necessary?
+  TRTSERVER_Trace* trace =
+      reinterpret_cast<TRTSERVER_Trace*>(infer_stats->GetTrace());
 
   std::shared_ptr<ni::InferRequestProvider> infer_request_provider;
   RETURN_IF_STATUS_ERROR(ni::InferRequestProvider::Create(

--- a/src/core/trtserver.cc
+++ b/src/core/trtserver.cc
@@ -681,12 +681,13 @@ TRTSERVER_MetricsFormatted(
 TRTSERVER_Error*
 TRTSERVER_TraceNew(
     TRTSERVER_Trace** trace, TRTSERVER_Trace_Level level,
-    TRTSERVER_TraceActivityFn_t activity_fn, void* activity_userp)
+    TRTSERVER_TraceActivityFn_t activity_fn, TRTSERVER_TracePushFn_t push_fn,
+    TRTSERVER_TracePopFn_t pop_fn, void* activity_userp)
 {
 #ifdef TRTIS_ENABLE_TRACING
   std::unique_ptr<ni::Trace> ltrace;
-  RETURN_IF_STATUS_ERROR(
-      ni::Trace::Create(level, activity_fn, activity_userp, &ltrace));
+  RETURN_IF_STATUS_ERROR(ni::Trace::Create(
+      level, activity_fn, push_fn, pop_fn, activity_userp, &ltrace));
   *trace = reinterpret_cast<TRTSERVER_Trace*>(ltrace.release());
   return nullptr;  // Success
 #else

--- a/src/core/trtserver.cc
+++ b/src/core/trtserver.cc
@@ -1366,6 +1366,7 @@ TRTSERVER_ServerInferAsync(
   infer_stats->SetMetricReporter(lprovider->Backend()->MetricReporter());
   infer_stats->SetBatchSize(request_header->batch_size());
   infer_stats->SetFailed(true);
+  infer_stats->SetTrace(trace);
 
   std::shared_ptr<ni::InferRequestProvider> infer_request_provider;
   RETURN_IF_STATUS_ERROR(ni::InferRequestProvider::Create(
@@ -1394,13 +1395,6 @@ TRTSERVER_ServerInferAsync(
 
         infer_stats->CaptureTimestamp(
             ni::ModelInferStats::TimestampKind::kRequestEnd);
-
-#ifdef TRTIS_ENABLE_TRACING
-        if (trace != nullptr) {
-          ni::Trace* ltrace = reinterpret_cast<ni::Trace*>(trace);
-          ltrace->Report(infer_stats);
-        }
-#endif  // TRTIS_ENABLE_TRACING
 
         // We must explicitly update the inference stats before
         // sending the response... otherwise it is possible that the

--- a/src/core/trtserver.h
+++ b/src/core/trtserver.h
@@ -349,13 +349,24 @@ typedef enum trtserver_traceactivity_enum {
   TRTSERVER_TRACE_REQUEST_END
 } TRTSERVER_Trace_Activity;
 
+// [TODO] should this be generalized? Say for regular model, the struct can
+// be supplied with { parent_id_ = -1; phased_id_ = 0; model_name_ = name;}
+typedef struct trtserver_ensemble_phase_struct {
+  int64_t parent_id_;
+  int64_t phase_id_;
+  const char* model_name_;
+} TRTSERVER_Ensemble_Phase;
+
 /// Type for trace activity callback function. This callback function
-/// is used to report activity occurring during a traced request. The
-/// 'userp' data is the same as what is supplied in the call to
+/// is used to report activity occurring during a traced request. If a request
+/// for ensemble model is traced, the same type of activties may be reported
+/// repeatedly, in such case, 'ensemble_phase' will be set to provide additional
+/// context. The 'userp' data is the same as what is supplied in the call to
 /// TRTSERVER_TraceNew.
 typedef void (*TRTSERVER_TraceActivityFn_t)(
     TRTSERVER_Trace* trace, TRTSERVER_Trace_Activity activity,
-    uint64_t timestamp_ns, void* userp);
+    uint64_t timestamp_ns, TRTSERVER_Ensemble_Phase* ensemble_phase,
+    void* userp);
 
 /// Create a new trace object. The caller takes ownership of the
 /// TRTSERVER_Trace object and must call TRTSERVER_TraceDelete to

--- a/src/core/trtserver.h
+++ b/src/core/trtserver.h
@@ -951,16 +951,16 @@ TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_ServerMetrics(
     TRTSERVER_Server* server, TRTSERVER_Metrics** metrics);
 
 /// Type for inference completion callback function. If non-nullptr,
-/// the 'trace' object is the trace associated with the request that
-/// is completing. The callback function takes ownership of the
-/// TRTSERVER_Trace object and must call TRTSERVER_TraceDelete to
+/// the 'trace_manager' object is the trace manager associated with the request
+/// that is completing. The callback function takes ownership of the
+/// TRTSERVER_TraceManager object and must call TRTSERVER_TraceManagerDelete to
 /// release the object. The callback function takes ownership of the
 /// TRTSERVER_InferenceResponse object and must call
 /// TRTSERVER_InferenceResponseDelete to release the object. The
 /// 'userp' data is the same as what is supplied in the call to
 /// TRTSERVER_ServerInferAsync.
 typedef void (*TRTSERVER_InferenceCompleteFn_t)(
-    TRTSERVER_Server* server, TRTSERVER_Trace* trace,
+    TRTSERVER_Server* server, TRTSERVER_TraceManager* trace_manager,
     TRTSERVER_InferenceResponse* response, void* userp);
 
 /// Perform inference using the meta-data and inputs supplied by the

--- a/src/core/trtserver.h
+++ b/src/core/trtserver.h
@@ -443,10 +443,9 @@ typedef void (*TRTSERVER_TraceManagerCreateTraceFn_t)(
     void* userp);
 
 /// Type for trace release callback function. This callback function
-/// is used to release a trace object created from
-/// TRTSERVER_TraceManagerCreateTraceFn_t, and the callback function will be
-/// invoked when the corresponding model execution is completed.
-/// The user should call TRTSERVER_TraceDelete if 'trace' is not nullptr.
+/// is invoked when the model execution being traced is completed. By this point,
+/// It is the user's responsiblity to delete 'trace' object created from
+/// TRTSERVER_TraceManagerCreateTraceFn_t by calling TRTSERVER_TraceDelete.
 typedef void (*TRTSERVER_TraceManagerReleaseTraceFn_t)(TRTSERVER_Trace* trace);
 
 /// Create a new trace manager object.
@@ -454,8 +453,8 @@ typedef void (*TRTSERVER_TraceManagerReleaseTraceFn_t)(TRTSERVER_Trace* trace);
 /// \param create_fn The function to call to create trace object for a request.
 /// \param release_fn The function to call when the request associated with a
 /// trace object is complete.
-/// \param userp User-provided pointer that is delivered to the creation
-/// function.
+/// \param userp User-provided pointer that is delivered to the trace 
+/// creation function.
 /// \return a TRTSERVER_Error indicating success or failure.
 TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_TraceManagerNew(
     TRTSERVER_TraceManager** trace_manager,

--- a/src/core/trtserver.h
+++ b/src/core/trtserver.h
@@ -377,20 +377,12 @@ TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_TraceNew(
 /// \return a TRTSERVER_Error indicating success or failure.
 TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_TraceDelete(TRTSERVER_Trace* trace);
 
-/// Get the activity userp of the trace object, which is supplied in the call to
-/// TRTSERVER_TraceNew.
-/// \param trace The trace object.
-/// \param userp Returns the activity userp of the trace object.
-/// \return a TRTSERVER_Error indicating success or failure.
-TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_TraceUserp(
-    TRTSERVER_Trace* trace, void** userp);
-
 /// Get the name of the model being traced. The caller
 /// does not own the returned string and must not modify or delete
 /// it. The lifetime of the returned string extends only as long as
 /// 'trace' and must not be accessed once 'trace' is deleted.
-/// 'model_name' is guaranteed to be valid at invocation of
-/// TRTSERVER_TraceManagerReleaseTraceFn_t
+/// This method is only guaranteed to correctly return the 'model_name' in the
+/// invocation of TRTSERVER_TraceManagerReleaseTraceFn_t
 /// \param trace The trace object.
 /// \param model_name Returns the name of the model being traced.
 /// \return a TRTSERVER_Error indicating success or failure.
@@ -398,15 +390,16 @@ TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_TraceModelName(
     TRTSERVER_Trace* trace, const char** model_name);
 
 /// Get the version of the model being traced.
-/// 'model_version' is guaranteed to be valid at invocation of
-/// TRTSERVER_TraceManagerReleaseTraceFn_t
+/// This method is only guaranteed to correctly return the 'model_version' in
+/// the invocation of TRTSERVER_TraceManagerReleaseTraceFn_t
 /// \param trace The trace object.
 /// \param model_version Returns the version of the model being traced.
 /// \return a TRTSERVER_Error indicating success or failure.
 TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_TraceModelVersion(
     TRTSERVER_Trace* trace, int64_t* model_version);
 
-/// Get the id of the trace object.
+/// Get the id of the trace object. Each trace object created during execution
+/// of the inference server has a unique id.
 /// \param trace The trace object.
 /// \param id Returns the id of the trace object.
 /// \return a TRTSERVER_Error indicating success or failure.
@@ -417,8 +410,8 @@ TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_TraceId(
 /// trace object is created from within another traced request, and the parent
 /// id will be set to the id of the trace object associated with that
 /// traced request.
-/// 'parent_id' is guaranteed to be valid at invocation of
-/// TRTSERVER_TraceManagerReleaseTraceFn_t
+/// This method is only guaranteed to correctly return the 'parent_id' in
+/// the invocation of TRTSERVER_TraceManagerReleaseTraceFn_t
 /// \param trace The trace object.
 /// \param parent_id Returns the parent id of the trace object. -1 indicates
 /// that the trace object has no parent.
@@ -443,18 +436,23 @@ typedef void (*TRTSERVER_TraceManagerCreateTraceFn_t)(
     void* userp);
 
 /// Type for trace release callback function. This callback function
-/// is invoked when the model execution being traced is completed. By this point,
-/// It is the user's responsiblity to delete 'trace' object created from
+/// is invoked when the model execution being traced is completed. By this
+/// point, it is the user's responsiblity to delete 'trace' object created from
 /// TRTSERVER_TraceManagerCreateTraceFn_t by calling TRTSERVER_TraceDelete.
-typedef void (*TRTSERVER_TraceManagerReleaseTraceFn_t)(TRTSERVER_Trace* trace);
+/// The 'activity_userp' data is the same as 'activity_userp' supplied in the
+/// call to TRTSERVER_TraceNew.
+/// The 'userp' data is the same as 'userp' supplied in the call to
+/// TRTSERVER_TraceManagerNew.
+typedef void (*TRTSERVER_TraceManagerReleaseTraceFn_t)(
+    TRTSERVER_Trace* trace, void* activity_userp, void* userp);
 
 /// Create a new trace manager object.
 /// \param trace_manager Returns the new trace manager object.
 /// \param create_fn The function to call to create trace object for a request.
 /// \param release_fn The function to call when the request associated with a
 /// trace object is complete.
-/// \param userp User-provided pointer that is delivered to the trace 
-/// creation function.
+/// \param userp User-provided pointer that is delivered to the trace
+/// creation and release function.
 /// \return a TRTSERVER_Error indicating success or failure.
 TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_TraceManagerNew(
     TRTSERVER_TraceManager** trace_manager,

--- a/src/core/trtserver.h
+++ b/src/core/trtserver.h
@@ -349,6 +349,9 @@ typedef enum trtserver_traceactivity_enum {
   TRTSERVER_TRACE_REQUEST_END
 } TRTSERVER_Trace_Activity;
 
+/// Model information that distinguishes different model executions within
+/// a request to an ensemble model. 'parent_id_' == -1 indicates that this is
+/// the top level of the executions.
 typedef struct trtserver_tracederivedmodelinfo_struct {
   const char* model_name_;
   int64_t version_;
@@ -372,6 +375,8 @@ typedef void (*TRTSERVER_TraceActivityFn_t)(
 /// function is used to return an identifier for a derived model execution. The
 /// activities of the derived model execution will be report using
 /// TRTSERVER_TraceActivityFn_t, but the identifier will be used as 'userp'.
+/// Note that in the case of ensemble, this function will also be called with
+/// the ensemble model's information to provide the top level model ID.
 /// The 'userp' data is the same as what is supplied in the call to
 /// TRTSERVER_TraceNew.
 typedef void* (*TRTSERVER_TracePushFn_t)(

--- a/src/servers/grpc_server.cc
+++ b/src/servers/grpc_server.cc
@@ -981,7 +981,7 @@ class InferHandler : public Handler<
 
  private:
   static void InferComplete(
-      TRTSERVER_Server* server, TRTSERVER_Trace* trace,
+      TRTSERVER_Server* server, TRTSERVER_TraceManager* trace_manager,
       TRTSERVER_InferenceResponse* response, void* userp);
 
   std::shared_ptr<TraceManager> trace_manager_;
@@ -1145,7 +1145,7 @@ InferHandler::Process(Handler::State* state, bool rpc_ok)
 
 void
 InferHandler::InferComplete(
-    TRTSERVER_Server* server, TRTSERVER_Trace* trace,
+    TRTSERVER_Server* server, TRTSERVER_TraceManager* trace_manager,
     TRTSERVER_InferenceResponse* trtserver_response, void* userp)
 {
   State* state = reinterpret_cast<State*>(userp);
@@ -1200,8 +1200,8 @@ InferHandler::InferComplete(
       response.mutable_request_status(), response_status, state->unique_id_,
       state->context_->server_id_);
 
-  // Don't need to explicitly delete 'trace'. It will be deleted by
-  // the Tracer object in 'state'.
+  // Don't need to explicitly delete 'trace_manager'. It will be deleted by
+  // the TraceMetaData object in 'state'.
   LOG_IF_ERR(
       TRTSERVER_InferenceResponseDelete(trtserver_response),
       "deleting GRPC response");
@@ -1254,7 +1254,7 @@ class StreamInferHandler
 
  private:
   static void StreamInferComplete(
-      TRTSERVER_Server* server, TRTSERVER_Trace* trace,
+      TRTSERVER_Server* server, TRTSERVER_TraceManager* trace_manager,
       TRTSERVER_InferenceResponse* response, void* userp);
 
   std::shared_ptr<TraceManager> trace_manager_;
@@ -1509,7 +1509,7 @@ StreamInferHandler::Process(Handler::State* state, bool rpc_ok)
 
 void
 StreamInferHandler::StreamInferComplete(
-    TRTSERVER_Server* server, TRTSERVER_Trace* trace,
+    TRTSERVER_Server* server, TRTSERVER_TraceManager* trace_manager,
     TRTSERVER_InferenceResponse* trtserver_response, void* userp)
 {
   State* state = reinterpret_cast<State*>(userp);
@@ -1565,8 +1565,8 @@ StreamInferHandler::StreamInferComplete(
       response.mutable_request_status(), response_status, state->unique_id_,
       state->context_->server_id_);
 
-  // Don't need to explicitly delete 'trace'. It will be deleted by
-  // the Tracer object in 'state'.
+  // Don't need to explicitly delete 'trace_manager'. It will be deleted by
+  // the TraceMetaData object in 'state'.
   LOG_IF_ERR(
       TRTSERVER_InferenceResponseDelete(trtserver_response),
       "deleting GRPC response");

--- a/src/servers/grpc_server.cc
+++ b/src/servers/grpc_server.cc
@@ -203,8 +203,8 @@ class HandlerState {
       }
 
 #ifdef TRTIS_ENABLE_TRACING
-      if (state->tracer_ != nullptr) {
-        state->tracer_->CaptureTimestamp(
+      if (state->trace_meta_data_ != nullptr) {
+        state->trace_meta_data_->tracer_->CaptureTimestamp(
             TRTSERVER_TRACE_LEVEL_MIN, "grpc send start");
       }
 #endif  // TRTIS_ENABLE_TRACING
@@ -291,7 +291,7 @@ class HandlerState {
   Steps step_;
 
 #ifdef TRTIS_ENABLE_TRACING
-  std::unique_ptr<Tracer> tracer_;
+  std::unique_ptr<TraceMetaData> trace_meta_data_;
 #endif  // TRTIS_ENABLE_TRACING
 
   RequestType request_;
@@ -997,9 +997,9 @@ InferHandler::StartNewRequest()
 
 #ifdef TRTIS_ENABLE_TRACING
   if (trace_manager_ != nullptr) {
-    state->tracer_.reset(trace_manager_->SampleTrace());
-    if (state->tracer_ != nullptr) {
-      state->tracer_->CaptureTimestamp(
+    state->trace_meta_data_.reset(trace_manager_->SampleTrace());
+    if (state->trace_meta_data_ != nullptr) {
+      state->trace_meta_data_->tracer_->CaptureTimestamp(
           TRTSERVER_TRACE_LEVEL_MIN, "grpc wait/read start");
     }
   }
@@ -1039,9 +1039,10 @@ InferHandler::Process(Handler::State* state, bool rpc_ok)
 
   if (state->step_ == Steps::START) {
 #ifdef TRTIS_ENABLE_TRACING
-    if (state->tracer_ != nullptr) {
-      state->tracer_->SetModel(request.model_name(), request.model_version());
-      state->tracer_->CaptureTimestamp(
+    if (state->trace_meta_data_ != nullptr) {
+      state->trace_meta_data_->tracer_->SetModel(
+          request.model_name(), request.model_version());
+      state->trace_meta_data_->tracer_->CaptureTimestamp(
           TRTSERVER_TRACE_LEVEL_MIN, "grpc wait/read end");
     }
 #endif  // TRTIS_ENABLE_TRACING
@@ -1074,18 +1075,20 @@ InferHandler::Process(Handler::State* state, bool rpc_ok)
               trtserver_, smb_manager_, request.meta_data(), response,
               &state->alloc_payload_);
           if (err == nullptr) {
-            // Get the trace object to use for this request. If
+            // Provide the trace manager object to use for this request, if
             // nullptr then no tracing will be performed.
-            TRTSERVER_Trace* trace = nullptr;
+            TRTSERVER_TraceManager* trace_manager = nullptr;
 #ifdef TRTIS_ENABLE_TRACING
-            if (state->tracer_ != nullptr) {
-              trace = state->tracer_->ServerTrace();
+            if (state->trace_meta_data_ != nullptr) {
+              TRTSERVER_TraceManagerNew(
+                  &trace_manager, TraceManager::CreateTrace,
+                  TraceManager::ReleaseTrace, state->trace_meta_data_.get());
             }
 #endif  // TRTIS_ENABLE_TRACING
 
             state->step_ = ISSUED;
             err = TRTSERVER_ServerInferAsync(
-                trtserver_.get(), trace, request_provider, allocator_,
+                trtserver_.get(), trace_manager, request_provider, allocator_,
                 &state->alloc_payload_ /* response_allocator_userp */,
                 InferComplete, reinterpret_cast<void*>(state));
           }
@@ -1116,8 +1119,8 @@ InferHandler::Process(Handler::State* state, bool rpc_ok)
       response.mutable_meta_data()->set_id(request.meta_data().id());
 
 #ifdef TRTIS_ENABLE_TRACING
-      if (state->tracer_ != nullptr) {
-        state->tracer_->CaptureTimestamp(
+      if (state->trace_meta_data_ != nullptr) {
+        state->trace_meta_data_->tracer_->CaptureTimestamp(
             TRTSERVER_TRACE_LEVEL_MIN, "grpc send start");
       }
 #endif  // TRTIS_ENABLE_TRACING
@@ -1127,8 +1130,8 @@ InferHandler::Process(Handler::State* state, bool rpc_ok)
     }
   } else if (state->step_ == Steps::COMPLETE) {
 #ifdef TRTIS_ENABLE_TRACING
-    if (state->tracer_ != nullptr) {
-      state->tracer_->CaptureTimestamp(
+    if (state->trace_meta_data_ != nullptr) {
+      state->trace_meta_data_->tracer_->CaptureTimestamp(
           TRTSERVER_TRACE_LEVEL_MIN, "grpc send end");
     }
 #endif  // TRTIS_ENABLE_TRACING
@@ -1207,8 +1210,8 @@ InferHandler::InferComplete(
   response.mutable_meta_data()->set_id(request.meta_data().id());
 
 #ifdef TRTIS_ENABLE_TRACING
-  if (state->tracer_ != nullptr) {
-    state->tracer_->CaptureTimestamp(
+  if (state->trace_meta_data_ != nullptr) {
+    state->trace_meta_data_->tracer_->CaptureTimestamp(
         TRTSERVER_TRACE_LEVEL_MIN, "grpc send start");
   }
 #endif  // TRTIS_ENABLE_TRACING
@@ -1268,9 +1271,9 @@ StreamInferHandler::StartNewRequest()
 
 #ifdef TRTIS_ENABLE_TRACING
   if (trace_manager_ != nullptr) {
-    state->tracer_.reset(trace_manager_->SampleTrace());
-    if (state->tracer_ != nullptr) {
-      state->tracer_->CaptureTimestamp(
+    state->trace_meta_data_.reset(trace_manager_->SampleTrace());
+    if (state->trace_meta_data_ != nullptr) {
+      state->trace_meta_data_->tracer_->CaptureTimestamp(
           TRTSERVER_TRACE_LEVEL_MIN, "grpc wait/read start");
     }
   }
@@ -1315,10 +1318,10 @@ StreamInferHandler::Process(Handler::State* state, bool rpc_ok)
 
   } else if (state->step_ == Steps::READ) {
 #ifdef TRTIS_ENABLE_TRACING
-    if (state->tracer_ != nullptr) {
-      state->tracer_->SetModel(
+    if (state->trace_meta_data_ != nullptr) {
+      state->trace_meta_data_->tracer_->SetModel(
           state->request_.model_name(), state->request_.model_version());
-      state->tracer_->CaptureTimestamp(
+      state->trace_meta_data_->tracer_->CaptureTimestamp(
           TRTSERVER_TRACE_LEVEL_MIN, "grpc wait/read end");
     }
 #endif  // TRTIS_ENABLE_TRACING
@@ -1379,18 +1382,20 @@ StreamInferHandler::Process(Handler::State* state, bool rpc_ok)
               trtserver_, smb_manager_, request.meta_data(), response,
               &state->alloc_payload_);
           if (err == nullptr) {
-            // Get the trace object to use for this request. If
+            // Provide the trace manager object to use for this request, if
             // nullptr then no tracing will be performed.
-            TRTSERVER_Trace* trace = nullptr;
+            TRTSERVER_TraceManager* trace_manager = nullptr;
 #ifdef TRTIS_ENABLE_TRACING
-            if (state->tracer_ != nullptr) {
-              trace = state->tracer_->ServerTrace();
+            if (state->trace_meta_data_ != nullptr) {
+              TRTSERVER_TraceManagerNew(
+                  &trace_manager, TraceManager::CreateTrace,
+                  TraceManager::ReleaseTrace, state->trace_meta_data_.get());
             }
 #endif  // TRTIS_ENABLE_TRACING
 
             state->step_ = ISSUED;
             err = TRTSERVER_ServerInferAsync(
-                trtserver_.get(), trace, request_provider, allocator_,
+                trtserver_.get(), trace_manager, request_provider, allocator_,
                 &state->alloc_payload_ /* response_allocator_userp */,
                 StreamInferComplete, reinterpret_cast<void*>(state));
           }
@@ -1435,9 +1440,9 @@ StreamInferHandler::Process(Handler::State* state, bool rpc_ok)
     // Capture a timestamp for the time when we start waiting for this
     // next request to read.
     if (trace_manager_ != nullptr) {
-      next_read_state->tracer_.reset(trace_manager_->SampleTrace());
-      if (next_read_state->tracer_ != nullptr) {
-        next_read_state->tracer_->CaptureTimestamp(
+      next_read_state->trace_meta_data_.reset(trace_manager_->SampleTrace());
+      if (next_read_state->trace_meta_data_ != nullptr) {
+        next_read_state->trace_meta_data_->tracer_->CaptureTimestamp(
             TRTSERVER_TRACE_LEVEL_MIN, "grpc wait/read start");
       }
     }
@@ -1448,8 +1453,8 @@ StreamInferHandler::Process(Handler::State* state, bool rpc_ok)
 
   } else if (state->step_ == Steps::WRITTEN) {
 #ifdef TRTIS_ENABLE_TRACING
-    if (state->tracer_ != nullptr) {
-      state->tracer_->CaptureTimestamp(
+    if (state->trace_meta_data_ != nullptr) {
+      state->trace_meta_data_->tracer_->CaptureTimestamp(
           TRTSERVER_TRACE_LEVEL_MIN, "grpc send end");
     }
 #endif  // TRTIS_ENABLE_TRACING

--- a/src/servers/http_server.cc
+++ b/src/servers/http_server.cc
@@ -1258,7 +1258,7 @@ HTTPAPIServer::BADReplyCallback(evthr_t* thr, void* arg, void* shared)
   evhtp_request_resume(request);
 
 #ifdef TRTIS_ENABLE_TRACING
-  if (infer_request->trace_meta_data_->tracer_ != nullptr) {
+  if (infer_request->trace_meta_data_ != nullptr) {
     infer_request->trace_meta_data_->tracer_->CaptureTimestamp(
         TRTSERVER_TRACE_LEVEL_MIN, "http send start",
         TIMESPEC_TO_NANOS(request->send_start_ts));

--- a/src/servers/http_server.cc
+++ b/src/servers/http_server.cc
@@ -248,7 +248,7 @@ class HTTPAPIServer : public HTTPServerImpl {
     evhtp_request_t* EvHtpRequest() const { return req_; }
 
     static void InferComplete(
-        TRTSERVER_Server* server, TRTSERVER_Trace* trace,
+        TRTSERVER_Server* server, TRTSERVER_TraceManager* trace_manager,
         TRTSERVER_InferenceResponse* response, void* userp);
     evhtp_res FinalizeResponse(TRTSERVER_InferenceResponse* response);
 
@@ -1284,7 +1284,7 @@ HTTPAPIServer::InferRequest::InferRequest(
 
 void
 HTTPAPIServer::InferRequest::InferComplete(
-    TRTSERVER_Server* server, TRTSERVER_Trace* trace,
+    TRTSERVER_Server* server, TRTSERVER_TraceManager* trace_manager,
     TRTSERVER_InferenceResponse* response, void* userp)
 {
   HTTPAPIServer::InferRequest* infer_request =
@@ -1295,8 +1295,8 @@ HTTPAPIServer::InferRequest::InferComplete(
     evthr_defer(infer_request->thread_, BADReplyCallback, infer_request);
   }
 
-  // Don't need to explicitly delete 'trace'. It will be deleted by
-  // the Tracer object in 'infer_request'.
+  // Don't need to explicitly delete 'trace_manager'. It will be deleted by
+  // the TraceMetaData object in 'infer_request'.
   LOG_IF_ERR(
       TRTSERVER_InferenceResponseDelete(response), "deleting HTTP response");
 }

--- a/src/servers/http_v2_server.cc
+++ b/src/servers/http_v2_server.cc
@@ -189,7 +189,7 @@ class HTTPAPIServer : public HTTPServerImpl {
     evhtp_res FinalizeResponse(TRTSERVER_InferenceResponse* response);
 
 #ifdef TRTIS_ENABLE_TRACING
-    std::unique_ptr<Tracer> tracer_;
+    std::unique_ptr<TraceMetaData> trace_meta_data_;
 #endif  // TRTIS_ENABLE_TRACING
 
     std::unique_ptr<EVBufferPair> response_pair_;
@@ -582,15 +582,15 @@ HTTPAPIServer::HandleInfer(evhtp_request_t* req, const std::string& model_name)
 #ifdef TRTIS_ENABLE_TRACING
   // Timestamps from evhtp are capture in 'req'. We record here since
   // this is the first place where we have a tracer.
-  std::unique_ptr<Tracer> tracer;
+  std::unique_ptr<TraceMetaData> trace_meta_data;
   if (trace_manager_ != nullptr) {
-    tracer.reset(trace_manager_->SampleTrace());
-    if (tracer != nullptr) {
-      tracer->SetModel(model_name, model_version);
-      tracer->CaptureTimestamp(
+    trace_meta_data.reset(trace_manager_->SampleTrace());
+    if (trace_meta_data != nullptr) {
+      trace_meta_data->tracer_->SetModel(model_name, model_version);
+      trace_meta_data->tracer_->CaptureTimestamp(
           TRTSERVER_TRACE_LEVEL_MIN, "http recv start",
           TIMESPEC_TO_NANOS(req->recv_start_ts));
-      tracer->CaptureTimestamp(
+      trace_meta_data->tracer_->CaptureTimestamp(
           TRTSERVER_TRACE_LEVEL_MIN, "http recv end",
           TIMESPEC_TO_NANOS(req->recv_end_ts));
     }
@@ -633,18 +633,20 @@ HTTPAPIServer::HandleInfer(evhtp_request_t* req, const std::string& model_name)
       response_pair->first = req->buffer_out;
       infer_request->response_pair_.reset(response_pair);
 
-      // Get the trace object to use for this request. If nullptr then
-      // no tracing will be performed.
-      TRTSERVER_Trace* trace = nullptr;
+      // Provide the trace manager object to use for this request, if nullptr
+      // then no tracing will be performed.
+      TRTSERVER_TraceManager* trace_manager = nullptr;
 #ifdef TRTIS_ENABLE_TRACING
-      if (tracer != nullptr) {
-        infer_request->tracer_ = std::move(tracer);
-        trace = infer_request->tracer_->ServerTrace();
+      if (trace_meta_data != nullptr) {
+        infer_request->trace_meta_data_ = std::move(trace_meta_data);
+        TRTSERVER_TraceManagerNew(
+            &trace_manager, TraceManager::CreateTrace,
+            TraceManager::ReleaseTrace, infer_request->trace_meta_data_.get());
       }
 #endif  // TRTIS_ENABLE_TRACING
 
       err = TRTSERVER_ServerInferAsync(
-          server_.get(), trace, request_provider, allocator_,
+          server_.get(), trace_manager, request_provider, allocator_,
           reinterpret_cast<void*>(response_pair),
           InferRequestClass::InferComplete,
           reinterpret_cast<void*>(infer_request));
@@ -700,11 +702,11 @@ HTTPAPIServer::OKReplyCallback(evthr_t* thr, void* arg, void* shared)
   evhtp_request_resume(request);
 
 #ifdef TRTIS_ENABLE_TRACING
-  if (infer_request->tracer_ != nullptr) {
-    infer_request->tracer_->CaptureTimestamp(
+  if (infer_request->trace_meta_data_ != nullptr) {
+    infer_request->trace_meta_data_->tracer_->CaptureTimestamp(
         TRTSERVER_TRACE_LEVEL_MIN, "http send start",
         TIMESPEC_TO_NANOS(request->send_start_ts));
-    infer_request->tracer_->CaptureTimestamp(
+    infer_request->trace_meta_data_->tracer_->CaptureTimestamp(
         TRTSERVER_TRACE_LEVEL_MIN, "http send end",
         TIMESPEC_TO_NANOS(request->send_end_ts));
   }
@@ -724,11 +726,11 @@ HTTPAPIServer::BADReplyCallback(evthr_t* thr, void* arg, void* shared)
   evhtp_request_resume(request);
 
 #ifdef TRTIS_ENABLE_TRACING
-  if (infer_request->tracer_ != nullptr) {
-    infer_request->tracer_->CaptureTimestamp(
+  if (infer_request->trace_meta_data_ != nullptr) {
+    infer_request->trace_meta_data_->tracer_->CaptureTimestamp(
         TRTSERVER_TRACE_LEVEL_MIN, "http send start",
         TIMESPEC_TO_NANOS(request->send_start_ts));
-    infer_request->tracer_->CaptureTimestamp(
+    infer_request->trace_meta_data_->tracer_->CaptureTimestamp(
         TRTSERVER_TRACE_LEVEL_MIN, "http send end",
         TIMESPEC_TO_NANOS(request->send_end_ts));
   }

--- a/src/servers/http_v2_server.cc
+++ b/src/servers/http_v2_server.cc
@@ -752,7 +752,7 @@ HTTPAPIServer::InferRequestClass::InferRequestClass(
 
 void
 HTTPAPIServer::InferRequestClass::InferComplete(
-    TRTSERVER_Server* server, TRTSERVER_Trace* trace,
+    TRTSERVER_Server* server, TRTSERVER_TraceManager* trace_manager,
     TRTSERVER_InferenceResponse* response, void* userp)
 {
   HTTPAPIServer::InferRequestClass* infer_request =
@@ -763,8 +763,8 @@ HTTPAPIServer::InferRequestClass::InferComplete(
     evthr_defer(infer_request->thread_, BADReplyCallback, infer_request);
   }
 
-  // Don't need to explicitly delete 'trace'. It will be deleted by
-  // the Tracer object in 'infer_request'.
+  // Don't need to explicitly delete 'trace_manager'. It will be deleted by
+  // the TraceMetaData object in 'infer_request'.
   LOG_IF_ERR(
       TRTSERVER_InferenceResponseDelete(response), "deleting HTTP response");
 }

--- a/src/servers/memory_alloc.cc
+++ b/src/servers/memory_alloc.cc
@@ -191,7 +191,7 @@ ResponseRelease(
 
 void
 InferComplete(
-    TRTSERVER_Server* server, TRTSERVER_Trace* trace,
+    TRTSERVER_Server* server, TRTSERVER_TraceManager* trace_manager,
     TRTSERVER_InferenceResponse* response, void* userp)
 {
   std::promise<TRTSERVER_InferenceResponse*>* p =
@@ -199,7 +199,7 @@ InferComplete(
   p->set_value(response);
   delete p;
 
-  TRTSERVER_TraceDelete(trace);
+  TRTSERVER_TraceManagerDelete(trace_manager);
 }
 
 TRTSERVER_Error*

--- a/src/servers/memory_alloc.cc
+++ b/src/servers/memory_alloc.cc
@@ -663,8 +663,8 @@ main(int argc, char** argv)
 
   FAIL_IF_ERR(
       TRTSERVER_ServerInferAsync(
-          server.get(), nullptr /* trace */, request_provider, allocator,
-          nullptr /* response_allocator_userp */, InferComplete,
+          server.get(), nullptr /* trace_manager */, request_provider,
+          allocator, nullptr /* response_allocator_userp */, InferComplete,
           reinterpret_cast<void*>(p)),
       "running inference");
 

--- a/src/servers/simple.cc
+++ b/src/servers/simple.cc
@@ -193,7 +193,7 @@ ResponseRelease(
 
 void
 InferComplete(
-    TRTSERVER_Server* server, TRTSERVER_Trace* trace,
+    TRTSERVER_Server* server, TRTSERVER_TraceManager* trace_manager,
     TRTSERVER_InferenceResponse* response, void* userp)
 {
   std::promise<TRTSERVER_InferenceResponse*>* p =
@@ -201,7 +201,7 @@ InferComplete(
   p->set_value(response);
   delete p;
 
-  TRTSERVER_TraceDelete(trace);
+  TRTSERVER_TraceManagerDelete(trace_manager);
 }
 
 TRTSERVER_Error*

--- a/src/servers/simple.cc
+++ b/src/servers/simple.cc
@@ -529,8 +529,8 @@ main(int argc, char** argv)
 
   FAIL_IF_ERR(
       TRTSERVER_ServerInferAsync(
-          server.get(), nullptr /* trace */, request_provider, allocator,
-          nullptr /* response_allocator_userp */, InferComplete,
+          server.get(), nullptr /* trace_manager */, request_provider,
+          allocator, nullptr /* response_allocator_userp */, InferComplete,
           reinterpret_cast<void*>(p)),
       "running inference");
 

--- a/src/servers/tracer.cc
+++ b/src/servers/tracer.cc
@@ -153,7 +153,7 @@ TraceManager::WriteTrace(const std::stringstream& ss)
 Tracer::Tracer(
     const std::shared_ptr<TraceManager>& manager, TRTSERVER_Trace_Level level)
     : manager_(manager), level_(level), model_version_(-1), id_(-1),
-      parent_id_(-1), timestamp_cnt_(0)
+      parent_id_(-1), timestamp_cnt_(0), trace_(nullptr)
 {
   tout_ << "{ \"timestamps\": [";
 }
@@ -172,7 +172,9 @@ Tracer::~Tracer()
 
   manager_->WriteTrace(tout_);
 
-  LOG_IF_ERR(TRTSERVER_TraceDelete(trace_), "deleting trace");
+  if (trace_ != nullptr) {
+    LOG_IF_ERR(TRTSERVER_TraceDelete(trace_), "deleting trace");
+  }
 }
 
 void

--- a/src/servers/tracer.cc
+++ b/src/servers/tracer.cc
@@ -171,13 +171,10 @@ TraceManager::NewTrace(TRTSERVER_Trace** trace)
 }
 
 void
-TraceManager::ReleaseTrace(TRTSERVER_Trace* trace)
+TraceManager::ReleaseTrace(
+    TRTSERVER_Trace* trace, void* activity_userp, void* userp)
 {
   if (trace != nullptr) {
-    Tracer* tracer = nullptr;
-    LOG_IF_ERR(
-        TRTSERVER_TraceUserp(trace, (void**)&tracer),
-        "getting associated tracer");
     // Gather trace info
     const char* model_name;
     int64_t model_version, id, parent_id;
@@ -189,6 +186,8 @@ TraceManager::ReleaseTrace(TRTSERVER_Trace* trace)
     LOG_IF_ERR(TRTSERVER_TraceId(trace, &id), "getting trace id");
     LOG_IF_ERR(
         TRTSERVER_TraceParentId(trace, &parent_id), "getting trace parent id");
+
+    auto tracer = reinterpret_cast<Tracer*>(activity_userp);
     tracer->SetModel(model_name, model_version);
     tracer->SetId(id, parent_id);
 

--- a/src/servers/tracer.cc
+++ b/src/servers/tracer.cc
@@ -103,7 +103,7 @@ TraceManager::SetRate(uint32_t rate)
   return nullptr;  // success
 }
 
-Tracer*
+TraceMetaData*
 TraceManager::SampleTrace()
 {
   uint64_t s = sample_.fetch_add(1);
@@ -111,25 +111,94 @@ TraceManager::SampleTrace()
     return nullptr;
   }
 
-  Tracer* tracer = new Tracer(shared_from_this(), level_);
+  auto trace_meta_data = new TraceMetaData;
+  trace_meta_data->manager_ = this;
+  trace_meta_data->trace_set_ = false;
 
-  TRTSERVER_Trace* trace = nullptr;
+  // An outermost tracer object that also in charge of collecting timestamps
+  // in server frontend, it will not bind to a particular TRTSERVER_Trace as
+  // it lives longer than the trace.
+  trace_meta_data->tracer_.reset(new Tracer(shared_from_this(), level_));
+  return trace_meta_data;
+}
+
+void
+TraceManager::CreateTrace(
+    TRTSERVER_Trace** trace, const char* model_name, int64_t version,
+    void* userp)
+{
+  // 'userp' should be not be nullptr if the request should be traced
+  if (userp == nullptr) {
+    *trace = nullptr;
+    return;
+  }
+
+  auto lmeta_data = reinterpret_cast<TraceMetaData*>(userp);
+
+  if (lmeta_data->trace_set_.exchange(true)) {
+    // If true has been stored, this is not the first trace to be created
+    lmeta_data->manager_->NewTrace(trace);
+  } else {
+    // Otherwise, just link the trace with the tracer in meta data.
+    // Note that SetServerTrace() is not called to hint that the tracer
+    // should not share the same lifetime as the trace.
+    TRTSERVER_Error* err = TRTSERVER_TraceNew(
+        trace, lmeta_data->manager_->level_, Tracer::TraceActivity,
+        lmeta_data->tracer_.get() /* userp */);
+    if (err != nullptr) {
+      LOG_ERROR << "error creating trace: " << TRTSERVER_ErrorCodeString(err)
+                << " - " << TRTSERVER_ErrorMessage(err);
+      TRTSERVER_ErrorDelete(err);
+    }
+  }
+}
+
+void
+TraceManager::NewTrace(TRTSERVER_Trace** trace)
+{
+  auto tracer = new Tracer(shared_from_this(), level_);
   TRTSERVER_Error* err = TRTSERVER_TraceNew(
-      &trace, level_, Tracer::TraceActivity, Tracer::CreateDerivedTracer,
-      Tracer::ReleaseDerivedTracer, tracer /* userp */);
+      trace, level_, Tracer::TraceActivity, (void*)tracer /* userp */);
   if (err != nullptr) {
     delete tracer;
 
     LOG_ERROR << "error creating trace: " << TRTSERVER_ErrorCodeString(err)
               << " - " << TRTSERVER_ErrorMessage(err);
     TRTSERVER_ErrorDelete(err);
-
-    return nullptr;
+  } else {
+    tracer->SetServerTrace(*trace);
   }
+}
 
-  tracer->SetServerTrace(trace);
+void
+TraceManager::ReleaseTrace(TRTSERVER_Trace* trace)
+{
+  if (trace != nullptr) {
+    Tracer* tracer = nullptr;
+    LOG_IF_ERR(
+        TRTSERVER_TraceUserp(trace, (void**)&tracer),
+        "getting associated tracer");
+    // Gather trace info
+    const char* model_name;
+    int64_t model_version, id, parent_id;
+    LOG_IF_ERR(
+        TRTSERVER_TraceModelName(trace, &model_name), "getting model name");
+    LOG_IF_ERR(
+        TRTSERVER_TraceModelVersion(trace, &model_version),
+        "getting model version");
+    LOG_IF_ERR(TRTSERVER_TraceId(trace, &id), "getting trace id");
+    LOG_IF_ERR(
+        TRTSERVER_TraceParentId(trace, &parent_id), "getting trace parent id");
+    tracer->SetModel(model_name, model_version);
+    tracer->SetId(id, parent_id);
 
-  return tracer;
+    if (tracer->ServerTrace() != nullptr) {
+      delete tracer;
+    } else {
+      // If the tracer is not tied with a trace, then only delete the trace.
+      LOG_IF_ERR(TRTSERVER_TraceDelete(trace), "deleting trace");
+    }
+  }
 }
 
 void
@@ -230,34 +299,6 @@ Tracer::TraceActivity(
   }
 
   tracer->CaptureTimestamp(tracer->level_, activity_name, timestamp_ns);
-}
-
-void*
-Tracer::CreateDerivedTracer(
-    TRTSERVER_Trace* trace,
-    TRTSERVER_Trace_Derived_Model_Info* derived_model_info, void* userp)
-{
-  Tracer* tracer = reinterpret_cast<Tracer*>(userp);
-  Tracer* derived_tracer = tracer;
-  // Initialize derived tracer if the model info is not referring to
-  // the ensemble model itself. Otherwise just keep track of the id.
-  if (derived_model_info->parent_id_ != -1) {
-    derived_tracer = new Tracer(tracer->manager_, tracer->level_);
-    derived_tracer->parent_id_ = derived_model_info->parent_id_;
-    derived_tracer->SetModel(
-        derived_model_info->model_name_, derived_model_info->version_);
-  }
-  derived_tracer->id_ = derived_model_info->id_;
-  return derived_tracer;
-}
-
-void
-Tracer::ReleaseDerivedTracer(TRTSERVER_Trace* trace, void* userp)
-{
-  Tracer* tracer = reinterpret_cast<Tracer*>(userp);
-  if (tracer->parent_id_ != -1) {
-    delete tracer;
-  }
 }
 
 }}  // namespace nvidia::inferenceserver

--- a/src/servers/tracer.cc
+++ b/src/servers/tracer.cc
@@ -167,7 +167,8 @@ Tracer::~Tracer()
 
 void
 Tracer::CaptureTimestamp(
-    TRTSERVER_Trace_Level level, const std::string& name, uint64_t timestamp_ns)
+    TRTSERVER_Trace_Level level, const std::string& name, uint64_t timestamp_ns,
+    TRTSERVER_Ensemble_Phase* ensemble_phase)
 {
   // In the case of tracing an ensemble, it is possible to access a trace object
   // concurrently
@@ -183,7 +184,13 @@ Tracer::CaptureTimestamp(
       tout_ << ",";
     }
 
-    tout_ << "{\"name\":\"" << name << "\", \"ns\":" << timestamp_ns << "}";
+    tout_ << "{\"name\":\"" << name << "\", \"ns\":" << timestamp_ns;
+    if (ensemble_phase != nullptr) {
+      tout_ << ", \"model_name\":\"" << ensemble_phase->model_name_
+            << "\", \"phase_id\":" << ensemble_phase->phase_id_
+            << ", \"parent_id\":" << ensemble_phase->parent_id_;
+    }
+    tout_ << "}";
     timestamp_cnt_++;
   }
 }
@@ -191,7 +198,8 @@ Tracer::CaptureTimestamp(
 void
 Tracer::TraceActivity(
     TRTSERVER_Trace* trace, TRTSERVER_Trace_Activity activity,
-    uint64_t timestamp_ns, void* userp)
+    uint64_t timestamp_ns, TRTSERVER_Ensemble_Phase* ensemble_phase,
+    void* userp)
 {
   Tracer* tracer = reinterpret_cast<Tracer*>(userp);
 
@@ -220,7 +228,8 @@ Tracer::TraceActivity(
       break;
   }
 
-  tracer->CaptureTimestamp(tracer->level_, activity_name, timestamp_ns);
+  tracer->CaptureTimestamp(
+      tracer->level_, activity_name, timestamp_ns, ensemble_phase);
 }
 
 }}  // namespace nvidia::inferenceserver

--- a/src/servers/tracer.cc
+++ b/src/servers/tracer.cc
@@ -169,6 +169,9 @@ void
 Tracer::CaptureTimestamp(
     TRTSERVER_Trace_Level level, const std::string& name, uint64_t timestamp_ns)
 {
+  // In the case of tracing an ensemble, it is possible to access a trace object
+  // concurrently
+  std::lock_guard<std::mutex> lk(mtx_);
   if (level <= level_) {
     if (timestamp_ns == 0) {
       struct timespec ts;

--- a/src/servers/tracer.h
+++ b/src/servers/tracer.h
@@ -61,13 +61,13 @@ class TraceManager : public std::enable_shared_from_this<TraceManager> {
   TRTSERVER_Error* SetLevel(TRTSERVER_Trace_Level level);
   TRTSERVER_Error* SetRate(uint32_t rate);
 
-  // Return a trace object that should be used to collected trace
+  // Return a trace meta data object that should be used to collected trace
   // activities for an inference request. Return nullptr if no tracing
   // should occur.
   TraceMetaData* SampleTrace();
 
   // Create a trace object that should be used to collected trace
-  // activities for the inference request. Return nullptr if no tracing
+  // activities for the model execution. Return nullptr if no tracing
   // should occur.
   static void CreateTrace(
       TRTSERVER_Trace** trace, const char* model_name, int64_t version,
@@ -81,6 +81,7 @@ class TraceManager : public std::enable_shared_from_this<TraceManager> {
  private:
   TraceManager(std::unique_ptr<std::ofstream> trace_file);
 
+  // Helper function to create a new trace object.
   void NewTrace(TRTSERVER_Trace** trace);
 
   std::mutex mu_;

--- a/src/servers/tracer.h
+++ b/src/servers/tracer.h
@@ -73,7 +73,8 @@ class TraceManager : public std::enable_shared_from_this<TraceManager> {
       TRTSERVER_Trace** trace, const char* model_name, int64_t version,
       void* userp);
 
-  static void ReleaseTrace(TRTSERVER_Trace* trace);
+  static void ReleaseTrace(
+      TRTSERVER_Trace* trace, void* activity_userp, void* userp);
 
   // Write to the trace file.
   void WriteTrace(const std::stringstream& ss);

--- a/src/servers/tracer.h
+++ b/src/servers/tracer.h
@@ -116,6 +116,8 @@ class Tracer {
   uint32_t timestamp_cnt_;
 
   TRTSERVER_Trace* trace_;
+
+  std::mutex mtx_;
 };
 
 }}  // namespace nvidia::inferenceserver

--- a/src/servers/tracer.h
+++ b/src/servers/tracer.h
@@ -87,7 +87,8 @@ class Tracer {
 
   static void TraceActivity(
       TRTSERVER_Trace* trace, TRTSERVER_Trace_Activity activity,
-      uint64_t timestamp_ns, void* userp);
+      uint64_t timestamp_ns, TRTSERVER_Ensemble_Phase* ensemble_phase,
+      void* userp);
 
   void SetModel(const std::string& model_name, int64_t model_version)
   {
@@ -103,7 +104,8 @@ class Tracer {
   // will be used.
   void CaptureTimestamp(
       TRTSERVER_Trace_Level level, const std::string& name,
-      uint64_t timestamp_ns = 0);
+      uint64_t timestamp_ns = 0,
+      TRTSERVER_Ensemble_Phase* ensemble_phase = nullptr);
 
  private:
   std::shared_ptr<TraceManager> manager_;

--- a/src/servers/tracer.h
+++ b/src/servers/tracer.h
@@ -87,8 +87,13 @@ class Tracer {
 
   static void TraceActivity(
       TRTSERVER_Trace* trace, TRTSERVER_Trace_Activity activity,
-      uint64_t timestamp_ns, TRTSERVER_Ensemble_Phase* ensemble_phase,
-      void* userp);
+      uint64_t timestamp_ns, void* userp);
+
+  static void* CreateDerivedTracer(
+      TRTSERVER_Trace* trace,
+      TRTSERVER_Trace_Derived_Model_Info* derived_model_info, void* userp);
+
+  static void ReleaseDerivedTracer(TRTSERVER_Trace* trace, void* userp);
 
   void SetModel(const std::string& model_name, int64_t model_version)
   {
@@ -104,8 +109,7 @@ class Tracer {
   // will be used.
   void CaptureTimestamp(
       TRTSERVER_Trace_Level level, const std::string& name,
-      uint64_t timestamp_ns = 0,
-      TRTSERVER_Ensemble_Phase* ensemble_phase = nullptr);
+      uint64_t timestamp_ns = 0);
 
  private:
   std::shared_ptr<TraceManager> manager_;
@@ -114,12 +118,13 @@ class Tracer {
   std::string model_name_;
   int64_t model_version_;
 
+  int64_t id_;
+  int64_t parent_id_;
+
   std::stringstream tout_;
   uint32_t timestamp_cnt_;
 
   TRTSERVER_Trace* trace_;
-
-  std::mutex mtx_;
 };
 
 }}  // namespace nvidia::inferenceserver


### PR DESCRIPTION
For ensemble case, the tracer generates the below trace (formatted). In short, additional fields "id" and "parent_id" will be shown for model execution within ensemble. "id" shows the order that the model is executed in the request. "parent_id" will be set if the model is part of another nested ensemble, and it will be set to the "id" of the nested ensemble.

```JSON
[
   {
      "timestamps":[
         {
            "name":"request handler start",
            "ns":2198577174107855
         },
         {
            "name":"queue start",
            "ns":2198577174110088
         },
         {
            "name":"compute start",
            "ns":2198577174191902
         },
         {
            "name":"compute end",
            "ns":2198577174274423
         },
         {
            "name":"request handler end",
            "ns":2198577174284459
         },
         {
            "name":"compute input end",
            "ns":2198577174200233
         },
         {
            "name":"compute output start",
            "ns":2198577174272504
         }
      ],
      "model_name":"nop_TYPE_INT32_-1",
      "model_version":1,
      "id":2,
      "parent_id":1
   },
   {
      "timestamps":[
         {
            "name":"request handler start",
            "ns":2198577174487837
         },
         {
            "name":"queue start",
            "ns":2198577174489562
         },
         {
            "name":"compute start",
            "ns":2198577174508965
         },
         {
            "name":"compute end",
            "ns":2198577174530718
         },
         {
            "name":"request handler end",
            "ns":2198577174533632
         },
         {
            "name":"compute input end",
            "ns":2198577174512277
         },
         {
            "name":"compute output start",
            "ns":2198577174529666
         }
      ],
      "model_name":"nop_TYPE_INT32_-1",
      "model_version":1,
      "id":4,
      "parent_id":3
   },
   {
      "timestamps":[
         {
            "name":"request handler start",
            "ns":2198577174572424
         },
         {
            "name":"queue start",
            "ns":2198577174573726
         },
         {
            "name":"compute start",
            "ns":2198577174684513
         },
         {
            "name":"compute end",
            "ns":2198577185542527
         },
         {
            "name":"request handler end",
            "ns":2198577185550798
         },
         {
            "name":"compute input end",
            "ns":2198577174790515
         },
         {
            "name":"compute output start",
            "ns":2198577185482135
         }
      ],
      "model_name":"graphdef_int32_int32_int32",
      "model_version":1,
      "id":5,
      "parent_id":3
   },
   {
      "timestamps":[
         {
            "name":"request handler start",
            "ns":2198577186819400
         },
         {
            "name":"queue start",
            "ns":2198577186822557
         },
         {
            "name":"compute start",
            "ns":2198577186895407
         },
         {
            "name":"compute end",
            "ns":2198577186948709
         },
         {
            "name":"request handler end",
            "ns":2198577186957462
         },
         {
            "name":"compute input end",
            "ns":2198577186904225
         },
         {
            "name":"compute output start",
            "ns":2198577186946460
         }
      ],
      "model_name":"nop_TYPE_INT32_-1",
      "model_version":1,
      "id":6,
      "parent_id":3
   },
   {
      "timestamps":[
         {
            "name":"request handler start",
            "ns":2198577186836337
         },
         {
            "name":"queue start",
            "ns":2198577186837275
         },
         {
            "name":"compute start",
            "ns":2198577187015314
         },
         {
            "name":"compute end",
            "ns":2198577187029820
         },
         {
            "name":"request handler end",
            "ns":2198577187031594
         },
         {
            "name":"compute input end",
            "ns":2198577187018058
         },
         {
            "name":"compute output start",
            "ns":2198577187028880
         }
      ],
      "model_name":"nop_TYPE_INT32_-1",
      "model_version":1,
      "id":7,
      "parent_id":3
   },
   {
      "timestamps":[
         {
            "name":"request handler start",
            "ns":2198577174435913
         },
         {
            "name":"request handler end",
            "ns":2198577187075624
         }
      ],
      "model_name":"fan_graphdef_int32_int32_int32",
      "model_version":1,
      "id":3,
      "parent_id":1
   },
   {
      "timestamps":[
         {
            "name":"request handler start",
            "ns":2198577187185224
         },
         {
            "name":"queue start",
            "ns":2198577187188112
         },
         {
            "name":"compute start",
            "ns":2198577187221723
         },
         {
            "name":"compute end",
            "ns":2198577187234234
         },
         {
            "name":"request handler end",
            "ns":2198577187235678
         },
         {
            "name":"compute input end",
            "ns":2198577187223858
         },
         {
            "name":"compute output start",
            "ns":2198577187233324
         }
      ],
      "model_name":"nop_TYPE_INT32_-1",
      "model_version":1,
      "id":8,
      "parent_id":1
   },
   {
      "timestamps":[
         {
            "name":"request handler start",
            "ns":2198577187190861
         },
         {
            "name":"queue start",
            "ns":2198577187191817
         },
         {
            "name":"compute start",
            "ns":2198577187253869
         },
         {
            "name":"compute end",
            "ns":2198577187261236
         },
         {
            "name":"request handler end",
            "ns":2198577187262356
         },
         {
            "name":"compute input end",
            "ns":2198577187255204
         },
         {
            "name":"compute output start",
            "ns":2198577187260606
         }
      ],
      "model_name":"nop_TYPE_INT32_-1",
      "model_version":1,
      "id":9,
      "parent_id":1
   },
   {
      "timestamps":[
         {
            "name":"http recv start",
            "ns":2198577173632496
         },
         {
            "name":"http recv end",
            "ns":2198577173682718
         },
         {
            "name":"request handler start",
            "ns":2198577174037215
         },
         {
            "name":"request handler end",
            "ns":2198577187289411
         },
         {
            "name":"http send start",
            "ns":2198577187449851
         },
         {
            "name":"http send end",
            "ns":2198577187474657
         }
      ],
      "model_name":"simple",
      "model_version":-1,
      "id":1
   },
   {
      "timestamps":[
         {
            "name":"grpc wait/read start",
            "ns":2198576714241001
         }
      ],
      "model_name":"",
      "model_version":-1
   },
   {
      "timestamps":[
         {
            "name":"grpc wait/read start",
            "ns":2198576714362215
         }
      ],
      "model_name":"",
      "model_version":-1
   }
]
```