### PR TITLE
Set GRPC allocation pool default to better handle large inference

### DIFF
--- a/qa/L0_perf_resnet/test.sh
+++ b/qa/L0_perf_resnet/test.sh
@@ -87,6 +87,7 @@ $CAFFE2PLAN -h -b ${STATIC_BATCH} \
             -n prob -o tensorrt_models/${TRT_MODEL_NAME}/1/model.plan \
             $REPODIR/caffe_models/resnet50.prototxt $REPODIR/caffe_models/resnet50.caffemodel
 
+# Tests with each "non-optimized" model
 for MODEL_NAME in $MODEL_NAMES; do
     REPO=`pwd`/tensorrt_models && [ "$MODEL_NAME" != "$TRT_MODEL_NAME" ] && \
         REPO=$REPODIR/perf_model_store
@@ -114,10 +115,57 @@ for MODEL_NAME in $OPTIMIZED_MODEL_NAMES; do
 done
 
 #
+# Test large static batch = 128 w/ 2 instances
+#
+# Can't test ONNX since model only supports batch-size 1 (can fix this
+# if we find a RN50 onnx that supports batching).
+#
+STATIC_BATCH=128
+DYNAMIC_BATCH=1
+INSTANCE_CNT=2
+MODEL_NAMES="${TRT_MODEL_NAME} ${TF_MODEL_NAME} ${PYT_MODEL_NAME} ${NETDEF_MODEL_NAME}"
+OPTIMIZED_MODEL_NAMES="${TFTRT_MODEL_NAME}"
+
+# Create the TensorRT plan from Caffe model
+rm -fr tensorrt_models && mkdir tensorrt_models
+cp -r $REPODIR/caffe_models/trt_model_store/resnet50_plan tensorrt_models/${TRT_MODEL_NAME} && \
+    (cd tensorrt_models/${TRT_MODEL_NAME} && \
+            sed -i "s/^name:.*/name: \"${TRT_MODEL_NAME}\"/" config.pbtxt) && \
+    mkdir -p tensorrt_models/${TRT_MODEL_NAME}/1
+$CAFFE2PLAN -h -b ${STATIC_BATCH} \
+            -n prob -o tensorrt_models/${TRT_MODEL_NAME}/1/model.plan \
+            $REPODIR/caffe_models/resnet50.prototxt $REPODIR/caffe_models/resnet50.caffemodel
+
+for MODEL_NAME in $MODEL_NAMES; do
+    REPO=`pwd`/tensorrt_models && [ "$MODEL_NAME" != "$TRT_MODEL_NAME" ] && \
+        REPO=$REPODIR/perf_model_store
+    FRAMEWORK=$(echo ${MODEL_NAME} | cut -d '_' -f 3)
+    MODEL_NAME=${MODEL_NAME} \
+              MODEL_FRAMEWORK=${FRAMEWORK} \
+              MODEL_PATH="$REPO/${MODEL_NAME}" \
+              STATIC_BATCH_SIZES=${STATIC_BATCH} \
+              DYNAMIC_BATCH_SIZES=${DYNAMIC_BATCH} \
+              INSTANCE_COUNTS=${INSTANCE_CNT} \
+              bash -x run_test.sh
+done
+
+for MODEL_NAME in $OPTIMIZED_MODEL_NAMES; do
+    REPO=`pwd`/optimized_model_store
+    FRAMEWORK=$(echo ${MODEL_NAME} | cut -d '_' -f 3,4)
+    MODEL_NAME=${MODEL_NAME} \
+              MODEL_FRAMEWORK=${FRAMEWORK} \
+              MODEL_PATH="$REPO/${MODEL_NAME}" \
+              STATIC_BATCH_SIZES=${STATIC_BATCH} \
+              DYNAMIC_BATCH_SIZES=${DYNAMIC_BATCH} \
+              INSTANCE_COUNTS=${INSTANCE_CNT} \
+              bash -x run_test.sh
+done
+
+#
 # Test dynamic batcher 8 w/ 2 instances
 #
 # Can't test ONNX since model only supports batch-size 1 (can fix this
-# if we find a RN50 onnx that supports batching.
+# if we find a RN50 onnx that supports batching).
 #
 STATIC_BATCH=1
 DYNAMIC_BATCH=8

--- a/src/servers/main.cc
+++ b/src/servers/main.cc
@@ -121,7 +121,7 @@ int grpc_stream_infer_thread_cnt_ = 1;
 // remain allocated for reuse. As long as the number of in-flight
 // requests doesn't exceed this value there will be no
 // allocation/deallocation of request/response objects.
-int grpc_infer_allocation_pool_size_ = 0;
+int grpc_infer_allocation_pool_size_ = 8;
 #endif  // TRTIS_ENABLE_GRPC
 
 #ifdef TRTIS_ENABLE_HTTP


### PR DESCRIPTION
Large inference requests (like resnet50 with BS >= 128) benefit from
having some allocation pool reuse, so set the default appropriately.