### PR TITLE
Update trace_summary to show nested results for ensemble

### DIFF
--- a/qa/L0_cmdline_trace/test.sh
+++ b/qa/L0_cmdline_trace/test.sh
@@ -278,6 +278,25 @@ set -e
 kill $SERVER_PID
 wait $SERVER_PID
 
+set +e
+
+$TRACE_SUMMARY -t trace_ensemble.log > summary_ensemble.log
+
+if [ `grep -c "compute input end" summary_ensemble.log` != "7" ]; then
+    cat summary_9.log
+    echo -e "\n***\n*** Test Failed\n***"
+    RET=1
+fi
+
+if [ `grep -c ^simple summary_ensemble.log` != "1" ]; then
+    cat summary_9.log
+    echo -e "\n***\n*** Test Failed\n***"
+    RET=1
+fi
+
+set -e
+
+
 if [ $RET -eq 0 ]; then
     echo -e "\n***\n*** Test Passed\n***"
 else


### PR DESCRIPTION
Should discuss more about what we want to show for ensemble traces, I think the trace_summary is focusing more on activities happened within the model, i.e. what is the time span for different stages of the execution. But for ensemble, we are interested more on how the models affect each other. For instance, if a ensemble is defined to execute a single model multiple times in parallel, we are interested in checking whether the executions are serialized (perhaps due to low amount of model instances). The summary log can still tell us that by looking at the queue time, but visualization will be more intuitive. Thus I think we want a tool to plot the timeline for ensemble.

The generated summary for ensemble looks like the following:
```
File: trace_ensemble.log
simple (-1):
	id: 0
	http recv start
		73us
	http recv end
		346us
	request handler start
		13096us
	request handler end
		218us
	http send start
		20us
	http send end
nop_TYPE_INT32_-1 (1):
	id: 1
	parent id: 0
	request handler start
		8us
	queue start
		82us
	compute start
		8us
	compute input end
		91us
	compute output start
		1us
	compute end
		9us
	request handler end
fan_graphdef_int32_int32_int32 (1):
	id: 2
	parent id: 0
	request handler start
		12452us
	request handler end
nop_TYPE_INT32_-1 (1):
	id: 3
	parent id: 2
	request handler start
		4us
	queue start
		19us
	compute start
		2us
	compute input end
		21us
	compute output start
		1us
	compute end
		2us
	request handler end
graphdef_int32_int32_int32 (1):
	id: 4
	parent id: 2
	request handler start
		3us
	queue start
		118us
	compute start
		123us
	compute input end
		10995us
	compute output start
		52us
	compute end
		7us
	request handler end
nop_TYPE_INT32_-1 (1):
	id: 5
	parent id: 2
	request handler start
		13us
	queue start
		71us
	compute start
		7us
	compute input end
		40us
	compute output start
		2us
	compute end
		7us
	request handler end
nop_TYPE_INT32_-1 (1):
	id: 6
	parent id: 2
	request handler start
		2us
	queue start
		167us
	compute start
		3us
	compute input end
		10us
	compute output start
		0us
	compute end
		1us
	request handler end
nop_TYPE_INT32_-1 (1):
	id: 7
	parent id: 0
	request handler start
		12us
	queue start
		37us
	compute start
		2us
	compute input end
		12us
	compute output start
		0us
	compute end
		1us
	request handler end
nop_TYPE_INT32_-1 (1):
	id: 8
	parent id: 0
	request handler start
		2us
	queue start
		66us
	compute start
		1us
	compute input end
		5us
	compute output start
		0us
	compute end
		1us
	request handler end
Summary for simple (-1): trace count = 1
HTTP infer request (avg): 13755us
	Receive (avg): 73us
	Send (avg): 20us
	Overhead (avg): 565us
	Handler (avg): 13096us
Summary for graphdef_int32_int32_int32 (1): trace count = 1
	Handler (avg): 11301us
		Overhead (avg): 10us
		Queue (avg): 118us
		Compute (avg): 11171us
			Input (avg): 123us
			Infer (avg): 10995us
			Output (avg): 52us
Summary for fan_graphdef_int32_int32_int32 (1): trace count = 1
	Handler (avg): 12452us
Summary for nop_TYPE_INT32_-1 (1): trace count = 6
	Handler (avg): 121us
		Overhead (avg): 11us
		Queue (avg): 74us
		Compute (avg): 35us
			Input (avg): 4us
			Infer (avg): 30us
			Output (avg): 1us
```