### PR TITLE
Add JSON Format Reporting for Server Status

### DIFF
--- a/docs/http_grpc_api.rst
+++ b/docs/http_grpc_api.rst
@@ -102,12 +102,13 @@ Performing an HTTP GET to /api/status returns status information about
 the server and all the models being served. Performing an HTTP GET to
 /api/status/<model name> returns information about the server and the
 single model specified by <model name>. The server status is returned
-in the HTTP response body in either text format (the default) or in
-binary format if query parameter format=binary is specified (for
-example, /api/status?format=binary). The success or failure of the
-status request is indicated in the HTTP response code and the
-**NV-Status** response header. The **NV-Status** response header
-returns a text protobuf formatted :cpp:var:`RequestStatus
+in the HTTP response body in either text format (the default), in binary
+format if query parameter format=binary is specified (for example,
+/api/status?format=binary) or in json format if query parameter
+format=json is specified (for example, /api/status?format=json).
+The success or failure of the status request is indicated in the HTTP
+response code and the **NV-Status** response header. The **NV-Status**
+response header returns a text protobuf formatted :cpp:var:`RequestStatus
 <nvidia::inferenceserver::RequestStatus>` message.
 
 For GRPC the :cpp:var:`GRPCService

--- a/src/servers/http_server.cc
+++ b/src/servers/http_server.cc
@@ -29,6 +29,7 @@
 #include <event2/buffer.h>
 #include <evhtp/evhtp.h>
 #include <google/protobuf/text_format.h>
+#include <google/protobuf/util/json_util.h>
 #include <re2/re2.h>
 #include <algorithm>
 #include <thread>
@@ -588,10 +589,19 @@ HTTPAPIServer::HandleStatus(evhtp_request_t* req, const std::string& status_uri)
           err = TRTSERVER_ErrorNew(
               TRTSERVER_ERROR_UNKNOWN, "failed to parse server status");
         } else {
-          std::string server_status_str = server_status.DebugString();
-          evbuffer_add(
-              req->buffer_out, server_status_str.c_str(),
-              server_status_str.size());
+          if (format == "json") {
+            std::string server_status_json;
+            ::google::protobuf::util::MessageToJsonString(
+                server_status, &server_status_json);
+            evbuffer_add(
+                req->buffer_out, server_status_json.c_str(),
+                server_status_json.size());
+          } else {
+            std::string server_status_str = server_status.DebugString();
+            evbuffer_add(
+                req->buffer_out, server_status_str.c_str(),
+                server_status_str.size());
+          }
         }
       }
     }

--- a/src/servers/http_server.cc
+++ b/src/servers/http_server.cc
@@ -575,7 +575,13 @@ HTTPAPIServer::HandleStatus(evhtp_request_t* req, const std::string& status_uri)
       if (format_c_str != NULL) {
         format = std::string(format_c_str);
       } else {
-        format = "text";
+        // If format empty, Accept: application/json in header then return json
+        const char* header_accept = evhtp_kv_find(req->headers_in, "Accept");
+        if (std::string(header_accept) == "application/json") {
+          format = "json";
+        } else {
+          format = "text";
+        }
       }
 
       if (format == "binary") {

--- a/src/servers/http_server.cc
+++ b/src/servers/http_server.cc
@@ -576,9 +576,15 @@ HTTPAPIServer::HandleStatus(evhtp_request_t* req, const std::string& status_uri)
         format = std::string(format_c_str);
       } else {
         // If format empty, Accept: application/json in header then return json
-        const char* header_accept = evhtp_kv_find(req->headers_in, "Accept");
-        if (std::string(header_accept) == "application/json") {
-          format = "json";
+        const char* header_accept_c_str =
+            evhtp_kv_find(req->headers_in, "Accept");
+        if (header_accept_c_str != NULL) {
+          std::string header_accept = std::string(header_accept_c_str);
+          if (header_accept == "application/json") {
+            format = "json";
+          } else {
+            format = "text";
+          }
         } else {
           format = "text";
         }


### PR DESCRIPTION
Option to use `?format=json` in request url or Accept: `application/json` to get server status as JSON