### PR TITLE
Fix build errors when HTTP and gRPC are both turned off

### DIFF
--- a/build/trtis/CMakeLists.txt
+++ b/build/trtis/CMakeLists.txt
@@ -147,9 +147,11 @@ include_directories(${Boost_INCLUDE_DIRS})
 #
 # libevent
 #
-find_package(Libevent CONFIG REQUIRED)
-message(STATUS "Using libevent ${Libevent_VERSION}")
-include_directories(${LIBEVENT_INCLUDE_DIRS})
+if(${TRTIS_ENABLE_HTTP} OR ${TRTIS_ENABLE_METRICS})
+  find_package(Libevent CONFIG REQUIRED)
+  message(STATUS "Using libevent ${Libevent_VERSION}")
+  include_directories(${LIBEVENT_INCLUDE_DIRS})
+endif()
 
 #
 # Protobuf
@@ -162,9 +164,11 @@ include_directories(${Protobuf_INCLUDE_DIRS})
 #
 # GRPC
 #
-find_package(gRPC CONFIG REQUIRED)
-message(STATUS "Using gRPC ${gRPC_VERSION}")
-include_directories($<TARGET_PROPERTY:gRPC::grpc,INTERFACE_INCLUDE_DIRECTORIES>)
+if(${TRTIS_ENABLE_GRPC})
+  find_package(gRPC CONFIG REQUIRED)
+  message(STATUS "Using gRPC ${gRPC_VERSION}")
+  include_directories($<TARGET_PROPERTY:gRPC::grpc,INTERFACE_INCLUDE_DIRECTORIES>)
+endif()
 
 add_subdirectory(../../src/core src/core)
 add_subdirectory(../../src/backends/caffe2 src/backends/caffe2)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -34,7 +34,9 @@ protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS ${proto-srcs})
 protobuf_generate_python(PROTO_PY ${proto-srcs})
 
 set(_PROTOBUF_PROTOC $<TARGET_FILE:protobuf::protoc>)
-set(_GRPC_CPP_PLUGIN_EXECUTABLE $<TARGET_FILE:gRPC::grpc_cpp_plugin>)
+if(${TRTIS_ENABLE_GRPC})
+  set(_GRPC_CPP_PLUGIN_EXECUTABLE $<TARGET_FILE:gRPC::grpc_cpp_plugin>)
+endif()
 
 add_library(
   proto-library EXCLUDE_FROM_ALL OBJECT

--- a/src/core/provider.h
+++ b/src/core/provider.h
@@ -25,7 +25,9 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
+#if defined(TRTIS_ENABLE_HTTP) || defined(TRTIS_ENABLE_METRICS)
 #include <event2/buffer.h>
+#endif
 #include "src/core/api.pb.h"
 #include "src/core/grpc_service.pb.h"
 #include "src/core/model_config.h"

--- a/src/core/provider_utils.h
+++ b/src/core/provider_utils.h
@@ -25,7 +25,9 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
+#if defined(TRTIS_ENABLE_HTTP) || defined(TRTIS_ENABLE_METRICS)
 #include <event2/buffer.h>
+#endif
 #include "src/core/api.pb.h"
 #include "src/core/grpc_service.pb.h"
 #include "src/core/model_config.h"

--- a/src/servers/CMakeLists.txt
+++ b/src/servers/CMakeLists.txt
@@ -194,6 +194,7 @@ add_executable(
   ${HTTP_ENDPOINT_OBJECTS}
   ${GRPC_ENDPOINT_OBJECTS}
   ${TRACING_OBJECTS}
+  $<TARGET_OBJECTS:proto-library>
 )
 set_property(TARGET main PROPERTY OUTPUT_NAME trtserver)
 if(${TRTIS_ENABLE_GPU})
@@ -204,6 +205,7 @@ target_link_libraries(
   ${HTTP_ENDPOINT_LIBRARIES}
   ${GRPC_ENDPOINT_LIBRARIES}
   ${TRACING_LIBRARIES}
+  PRIVATE protobuf::libprotobuf
   PRIVATE trtserver
 )
 install(

--- a/src/servers/main.cc
+++ b/src/servers/main.cc
@@ -41,6 +41,7 @@
 #include "src/core/trtserver.h"
 #include "src/servers/common.h"
 #include "src/servers/shared_memory_block_manager.h"
+#include "src/servers/tracer.h"
 
 #ifdef TRTIS_ENABLE_GPU
 static_assert(


### PR DESCRIPTION
Fix build errors when HTTP and gRPC are both turned off

Split from #942 