### PR TITLE
Use correct version of TRT enqueue API

### DIFF
--- a/src/backends/tensorrt/loader.cc
+++ b/src/backends/tensorrt/loader.cc
@@ -47,8 +47,8 @@ LoadPlan(
         RequestStatusCode::INTERNAL, "unable to create TensorRT runtime");
   }
 
-  *engine = (*runtime)->deserializeCudaEngine(
-      &model_data[0], model_data.size());
+  *engine =
+      (*runtime)->deserializeCudaEngine(&model_data[0], model_data.size());
   if (*engine == nullptr) {
     return Status(
         RequestStatusCode::INTERNAL, "unable to create TensorRT engine");

--- a/src/backends/tensorrt/plan_backend.cc
+++ b/src/backends/tensorrt/plan_backend.cc
@@ -337,9 +337,9 @@ PlanBackend::CreateExecutionContext(
     }
   }
 
-  // As we have visited all the input bindings at this point, if any of the
-  // shapes had dynamic dimension then is_dynamic_ flag would be set.
-  if (!context->is_dynamic_ &&
+  // Validate the batch dimension against the implicit batch dimension if
+  // available
+  if (context->engine_->hasImplicitBatchDimension() &&
       (context->max_batch_size_ > context->engine_->getMaxBatchSize())) {
     return Status(
         RequestStatusCode::INVALID_ARG,
@@ -985,12 +985,13 @@ PlanBackend::Context::Run(
     LOG_VERBOSE(1) << "Context with profile " << citr->second.profile_name_
                    << " [" << std::to_string(citr->first)
                    << "] is being executed for " << name_;
-    if (is_dynamic_) {
-      if (!citr->second.context_->allInputDimensionsSpecified()) {
-        return Status(
-            RequestStatusCode::INTERNAL,
-            "failed to specify the dimensions of all input bindings");
-      }
+    if (is_dynamic_ &&
+        (!citr->second.context_->allInputDimensionsSpecified())) {
+      return Status(
+          RequestStatusCode::INTERNAL,
+          "failed to specify the dimensions of all input bindings");
+    }
+    if (!engine_->hasImplicitBatchDimension()) {
       if (!citr->second.context_->enqueueV2(
               buffer_bindings_.data(), stream_, nullptr)) {
         cudaStreamSynchronize(stream_);

--- a/src/backends/tensorrt/plan_utils.cc
+++ b/src/backends/tensorrt/plan_utils.cc
@@ -345,6 +345,16 @@ ContainsWildcard(const nvinfer1::Dims& dims)
   return false;
 }
 
+bool
+ContainsWildcardAtExplicitBatchDim(const nvinfer1::Dims& dims)
+{
+  if (dims.d[0] == WILDCARD_DIM) {
+    return true;
+  }
+  return false;
+}
+
+
 const std::string
 DimsDebugString(const nvinfer1::Dims& dims)
 {

--- a/src/backends/tensorrt/plan_utils.h
+++ b/src/backends/tensorrt/plan_utils.h
@@ -88,6 +88,8 @@ bool DimVecToDims(const std::vector<int64_t>& dim_vec, nvinfer1::Dims* dims);
 
 bool ContainsWildcard(const nvinfer1::Dims& dims);
 
+bool ContainsWildcardAtExplicitBatchDim(const nvinfer1::Dims& dims);
+
 const std::string DimsDebugString(const nvinfer1::Dims& dims);
 
 }}  // namespace nvidia::inferenceserver


### PR DESCRIPTION
**NOTE** : Merge to master when TRT 7  is released.

When using fixed shape models with explicit batch dimensions there were a bunch of warnings being generated by TRT.

**Before:**
```
# ../clients/perf_client -m plan_nobatch_float32_float32_float32
*** Measurement Settings ***
  Batch size: 1
  Measurement window: 5000 msec
  Using synchronous calls for inference
  Stabilizing using average latency

Request concurrency: 1
W1213 00:17:06.015177 29518 logging.cc:46] Explicit batch network detected and batch size specified, use enqueue without batch size instead.
W1213 00:17:06.016012 29518 logging.cc:46] Explicit batch network detected and batch size specified, use enqueue without batch size instead.
W1213 00:17:06.016669 29518 logging.cc:46] Explicit batch network detected and batch size specified, use enqueue without batch size instead.
W1213 00:17:06.017329 29518 logging.cc:46] Explicit batch network detected and batch size specified, use enqueue without batch size instead.
W1213 00:17:06.018013 29518 logging.cc:46] Explicit batch network detected and batch size specified, use enqueue without batch size instead.
W1213 00:17:06.018661 29518 logging.cc:46] Explicit batch network detected and batch size specified, use enqueue without batch size instead.
W1213 00:17:06.019374 29518 logging.cc:46] Explicit batch network detected and batch size specified, use enqueue without batch size instead.
W1213 00:17:06.019979 29518 logging.cc:46] Explicit batch network detected and batch size specified, use enqueue without batch size instead.
.
.
.

```

**Now**

```
 # ../clients/perf_client -m plan_nobatch_float32_float32_float32
 *** Measurement Settings ***
   Batch size: 1
   Measurement window: 5000 msec
   Using synchronous calls for inference
   Stabilizing using average latency
 
 Request concurrency: 1
   Client: 
     Request count: 11918
     Throughput: 2383.6 infer/sec
     Avg latency: 417 usec (standard deviation 99 usec)
     p50 latency: 423 usec
     p90 latency: 518 usec
     p95 latency: 566 usec
     p99 latency: 705 usec
     Avg HTTP time: 418 usec (send/recv 62 usec + response wait 356 usec)
   Server: 
     Request count: 14241
     Avg request latency: 107 usec (overhead 12 usec + queue 16 usec + compute 79 usec)
 
 Inferences/Second vs. Client Average Batch Latency
 Concurrency: 1, throughput: 2383.6 infer/sec, latency 417 usec
```