### PR TITLE
Fixes http v2 test failure

### DIFF
--- a/qa/L0_http_v2/test.sh
+++ b/qa/L0_http_v2/test.sh
@@ -73,7 +73,8 @@ fi
         pkg-config \
         python3 \
         python3-pip \
-        python3-dev && \
+        python3-dev \
+        rapidjson-dev && \
     pip3 install --upgrade wheel setuptools grpcio-tools && \
     ln -s /usr/bin/python3 /usr/bin/python)
 


### PR DESCRIPTION
Fixes HTTP V2 failure introduced with: https://github.com/NVIDIA/tensorrt-inference-server/pull/945