### PR TITLE
Add installation of opencv libraries for example custom backend #964

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -376,14 +376,20 @@ RUN id -u $TENSORRT_SERVER_USER > /dev/null 2>&1 || \
 
 # libgoogle-glog0v5 is needed by caffe2 libraries.
 # libcurl is needed for GCS
+# libopencv-dev and libopencv-core-dev are needed for image_preprocess (Example Custom Backend)
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     if [ $(cat /etc/os-release | grep 'VERSION_ID="16.04"' | wc -l) -ne 0 ]; then \
         apt-get install -y --no-install-recommends \
+                libopencv-dev \
+                libopencv-core-dev \
                 libcurl3-dev \
                 libgoogle-glog0v5 \
                 libre2-1v5; \
     elif [ $(cat /etc/os-release | grep 'VERSION_ID="18.04"' | wc -l) -ne 0 ]; then \
         apt-get install -y --no-install-recommends \
+                libopencv-dev \
+                libopencv-core-dev \
                 libcurl4-openssl-dev \
                 libgoogle-glog0v5 \
                 libre2-4; \


### PR DESCRIPTION
I opened an issue.
https://github.com/NVIDIA/tensorrt-inference-server/issues/964

ENV DEBIAN_FRONTEND=noninteractive
was added to disable interactive installation of tzdata.