### PR TITLE
Fix duplicate index incrementation for TF ShapeToString

### DIFF
--- a/src/backends/tensorflow/tf_utils.cc
+++ b/src/backends/tensorflow/tf_utils.cc
@@ -145,8 +145,6 @@ ShapeToString(const TRTISTF_Shape* shape, const size_t start_idx)
       }
       str += std::to_string(dim);
     }
-
-    idx++;
   }
 
   str += "]";


### PR DESCRIPTION
Fixing the bug in TensorFlow backend `ShapeToString` where the index in the for loop is incremented twice. This bug causes inaccurate error messages when the data shape is not matched for model.