### PR TITLE
TRT Autofiller to support shape tensors 

### DIFF
--- a/qa/L0_model_config/autofill_noplatform/tensorrt/bad_input_shape_tensor/config.pbtxt
+++ b/qa/L0_model_config/autofill_noplatform/tensorrt/bad_input_shape_tensor/config.pbtxt
@@ -1,0 +1,26 @@
+max_batch_size: 8
+input [
+  {
+    name: "INPUT0"
+    data_type: TYPE_FP32
+    dims: [ 16 ]
+    is_shape_tensor: true
+  },
+  {
+    name: "INPUT1"
+    data_type: TYPE_FP32
+    dims: [ 16 ]
+  }
+]
+output [
+  {
+    name: "OUTPUT0"
+    data_type: TYPE_FP32
+    dims: [ 16 ]
+  },
+  {
+    name: "OUTPUT1"
+    data_type: TYPE_FP32
+    dims: [ 16 ]
+  }
+]

--- a/qa/L0_model_config/autofill_noplatform/tensorrt/bad_input_shape_tensor/expected
+++ b/qa/L0_model_config/autofill_noplatform/tensorrt/bad_input_shape_tensor/expected
@@ -1,0 +1,1 @@
+'INPUT0' is incorrectly specified as a shape tensor.

--- a/qa/L0_model_config/autofill_noplatform/tensorrt/bad_output_shape_tensor/config.pbtxt
+++ b/qa/L0_model_config/autofill_noplatform/tensorrt/bad_output_shape_tensor/config.pbtxt
@@ -1,0 +1,26 @@
+max_batch_size: 8
+input [
+  {
+    name: "INPUT0"
+    data_type: TYPE_FP32
+    dims: [ 16 ]
+  },
+  {
+    name: "INPUT1"
+    data_type: TYPE_FP32
+    dims: [ 16 ]
+  }
+]
+output [
+  {
+    name: "OUTPUT0"
+    data_type: TYPE_FP32
+    dims: [ 16 ]
+  },
+  {
+    name: "OUTPUT1"
+    data_type: TYPE_FP32
+    dims: [ 16 ]
+    is_shape_tensor: true
+  }
+]

--- a/qa/L0_model_config/autofill_noplatform/tensorrt/bad_output_shape_tensor/expected
+++ b/qa/L0_model_config/autofill_noplatform/tensorrt/bad_output_shape_tensor/expected
@@ -1,0 +1,1 @@
+'OUTPUT1' is incorrectly specified as a shape tensor.

--- a/qa/L0_model_config/autofill_noplatform/tensorrt/mixed_batch_hint_dims/config.pbtxt
+++ b/qa/L0_model_config/autofill_noplatform/tensorrt/mixed_batch_hint_dims/config.pbtxt
@@ -1,0 +1,24 @@
+input [
+  {
+    name: "DUMMY_INPUT0"
+    data_type: TYPE_FP32
+    dims: [ -1,-1 ]
+  },
+  {
+    name: "INPUT0"
+    data_type: TYPE_INT32
+    dims: [ 2 ]
+  }
+]
+output [
+  {
+    name: "DUMMY_OUTPUT0"
+    data_type: TYPE_FP32
+    dims: [ -1,-1,-1 ]
+  },
+  {
+    name: "OUTPUT0"
+    data_type: TYPE_INT32
+    dims: [ 2 ]
+  }
+]

--- a/qa/L0_model_config/autofill_noplatform/tensorrt/mixed_batch_hint_dims/expected
+++ b/qa/L0_model_config/autofill_noplatform/tensorrt/mixed_batch_hint_dims/expected
@@ -1,0 +1,1 @@
+model tensor configurations are contradicting each other in terms of whether batching is supported

--- a/qa/L0_model_config/autofill_noplatform/tensorrt/mixed_batch_hint_shape_values/config.pbtxt
+++ b/qa/L0_model_config/autofill_noplatform/tensorrt/mixed_batch_hint_shape_values/config.pbtxt
@@ -1,0 +1,24 @@
+input [
+  {
+    name: "DUMMY_INPUT0"
+    data_type: TYPE_FP32
+    dims: [ -1,-1 ]
+  },
+  {
+    name: "INPUT0"
+    data_type: TYPE_INT32
+    dims: [ 3 ]
+  }
+]
+output [
+  {
+    name: "DUMMY_OUTPUT0"
+    data_type: TYPE_FP32
+    dims: [ -1,-1 ]
+  },
+  {
+    name: "OUTPUT0"
+    data_type: TYPE_INT32
+    dims: [ 2 ]
+  }
+]

--- a/qa/L0_model_config/autofill_noplatform/tensorrt/mixed_batch_hint_shape_values/expected
+++ b/qa/L0_model_config/autofill_noplatform/tensorrt/mixed_batch_hint_shape_values/expected
@@ -1,0 +1,1 @@
+model tensor configurations are contradicting each other in terms of whether batching is supported

--- a/qa/L0_model_config/test.sh
+++ b/qa/L0_model_config/test.sh
@@ -51,8 +51,10 @@ TRIALS="tensorflow_savedmodel tensorflow_graphdef tensorrt_plan caffe2_netdef on
 for modelpath in \
         autofill_noplatform/tensorrt/bad_input_dims/1 \
         autofill_noplatform/tensorrt/bad_input_type/1 \
+        autofill_noplatform/tensorrt/bad_input_shape_tensor/1 \
         autofill_noplatform/tensorrt/bad_output_dims/1 \
         autofill_noplatform/tensorrt/bad_output_type/1 \
+        autofill_noplatform/tensorrt/bad_output_shape_tensor/1 \
         autofill_noplatform/tensorrt/too_few_inputs/1 \
         autofill_noplatform/tensorrt/too_many_inputs/1 \
         autofill_noplatform/tensorrt/unknown_input/1 \
@@ -64,6 +66,16 @@ for modelpath in \
         autofill_noplatform_success/tensorrt/incomplete_output/1 ; do
     mkdir -p $modelpath
     cp /data/inferenceserver/${REPO_VERSION}/qa_model_repository/plan_float32_float32_float32/1/model.plan \
+       $modelpath/.
+done
+
+
+# Copy TensorRT plans with shape tensor into the test model repositories.
+for modelpath in \
+        autofill_noplatform/tensorrt/mixed_batch_hint_dims/1 \
+        autofill_noplatform/tensorrt/mixed_batch_hint_shape_values/1 ; do
+    mkdir -p $modelpath
+    cp /data/inferenceserver/${REPO_VERSION}/qa_identity_shapetensor_model_repository/plan_zero_1_int32/1/model.plan \
        $modelpath/.
 done
 

--- a/qa/common/gen_qa_identity_models.py
+++ b/qa/common/gen_qa_identity_models.py
@@ -564,26 +564,60 @@ def create_plan_dynamic_rf_modelfile(
     builder = trt.infer.Builder(TRT_LOGGER)
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.EXPLICIT_BATCH))
     if max_batch == 0:
-        shape_with_batchsize = [i for i in shape]
+        if FLAGS.tensorrt_shape_io:
+            shape_with_batchsize = shape[0]
+            dummy_shape = [-1] * shape_with_batchsize
+        else:
+            shape_with_batchsize = [i for i in shape]
     else:
-        shape_with_batchsize = [-1] + [i for i in shape]
+        if FLAGS.tensorrt_shape_io:
+            shape_with_batchsize = shape[0] + 1
+            dummy_shape = [-1] * shape_with_batchsize
+        else:
+            shape_with_batchsize = [-1] + [i for i in shape]
 
     trt_dtype = np_to_trt_dtype(dtype)
     trt_memory_format = trt.TensorFormat.LINEAR
     for io_num in range(io_cnt):
-        in_node = network.add_input("INPUT{}".format(io_num), trt_dtype, shape_with_batchsize)
-        in_node.allowed_formats = 1 << int(trt_memory_format)
+        if FLAGS.tensorrt_shape_io:
+            in_node = network.add_input("INPUT{}".format(io_num), trt_dtype, [shape_with_batchsize])
+            in_node.allowed_formats = 1 << int(trt_memory_format)
+            dummy_in_node = network.add_input("DUMMY_INPUT{}".format(io_num), trt.float32, dummy_shape)
+            dummy_in_node.allowed_formats = 1 << int(trt_memory_format)
+            resize_layer = network.add_resize(dummy_in_node)
+            resize_layer.set_input(1, in_node)
+            out_node = network.add_shape(resize_layer.get_output(0))
 
-        out_node = network.add_identity(in_node)
+            dummy_out_node = resize_layer.get_output(0)
+            out_node.get_output(0).name = "OUTPUT{}".format(io_num)
 
-        out_node.get_output(0).set_name("OUTPUT{}".format(io_num))
-        out_node.get_output(0).set_type(trt_dtype)
-        network.mark_output(out_node.get_output(0))
-        out_node.get_output(0).allowed_formats = 1 << int(trt_memory_format)
+            dummy_out_node.name = "DUMMY_OUTPUT{}".format(io_num)
 
-        if (trt_dtype == trt.DataType.INT8):
-            in_node.dynamic_range = (-128.0, 127.0)
-            out_node.get_output(0).dynamic_range = (-128.0, 127.0)
+            dummy_out_node.set_type(trt.float32)
+            network.mark_output(dummy_out_node)
+            dummy_out_node.allowed_formats = 1 << int(trt_memory_format)
+
+            out_node.get_output(0).set_type(trt_dtype)
+            network.mark_output_for_shapes(out_node.get_output(0))
+            out_node.get_output(0).allowed_formats = 1 << int(trt_memory_format)
+
+            if (trt_dtype == trt.DataType.INT8):
+                in_node.dynamic_range = (-128.0, 127.0)
+                out_node.get_output(0).dynamic_range = (-128.0, 127.0)
+        else:
+            in_node = network.add_input("INPUT{}".format(io_num), trt_dtype, shape_with_batchsize)
+            in_node.allowed_formats = 1 << int(trt_memory_format)
+
+            out_node = network.add_identity(in_node)
+
+            out_node.get_output(0).set_name("OUTPUT{}".format(io_num))
+            out_node.get_output(0).set_type(trt_dtype)
+            network.mark_output(out_node.get_output(0))
+            out_node.get_output(0).allowed_formats = 1 << int(trt_memory_format)
+
+            if (trt_dtype == trt.DataType.INT8):
+                in_node.dynamic_range = (-128.0, 127.0)
+                out_node.get_output(0).dynamic_range = (-128.0, 127.0)
 
     min_shape = []
     opt_shape = []
@@ -592,20 +626,52 @@ def create_plan_dynamic_rf_modelfile(
         min_shape = min_shape + [1]
         opt_shape = opt_shape + [max(1, max_batch)]
         max_shape = max_shape + [max(1, max_batch)]
-    for i in shape:
-        if i == -1:
-            # Generating a very generous optimization profile
-            min_shape = min_shape + [1]
-            opt_shape = opt_shape + [8]
-            max_shape = max_shape + [profile_max_size]
-        else:
-            min_shape = min_shape + [i]
-            opt_shape = opt_shape + [i]
-            max_shape = max_shape + [i]
+    if not FLAGS.tensorrt_shape_io:
+        for i in shape:
+            if i == -1:
+                # Generating a very generous optimization profile
+                min_shape = min_shape + [1]
+                opt_shape = opt_shape + [8]
+                max_shape = max_shape + [profile_max_size]
+            else:
+                min_shape = min_shape + [i]
+                opt_shape = opt_shape + [i]
+                max_shape = max_shape + [i]
+    else:
+        min_shape = min_shape + [1] * shape[0]
+        opt_shape = opt_shape + [8] * shape[0]
+        max_shape = max_shape + [profile_max_size] * shape[0]
 
     profile = builder.create_optimization_profile()
     for io_num in range(io_cnt):
-        profile.set_shape("INPUT{}".format(io_num), min_shape, opt_shape, max_shape)
+        if FLAGS.tensorrt_shape_io:
+            if shape:
+                profile.set_shape_input("INPUT{}".format(io_num),
+                    [1] * shape_with_batchsize, [8] * shape_with_batchsize,
+                    [profile_max_size] * shape_with_batchsize)
+            profile.set_shape("DUMMY_INPUT{}".format(io_num), min_shape, opt_shape, max_shape)
+        else:
+             profile.set_shape("INPUT{}".format(io_num), min_shape, opt_shape, max_shape)
+
+	# Profiles that don't support batching.
+    if FLAGS.tensorrt_shape_io:
+        # The minimum shape value is 2
+    	profile = builder.create_optimization_profile()
+    	for io_num in range(io_cnt):
+            if shape:
+                profile.set_shape_input("INPUT{}".format(io_num),
+                    [2] * shape_with_batchsize, [8] * shape_with_batchsize,
+                    [profile_max_size] * shape_with_batchsize)
+            profile.set_shape("DUMMY_INPUT{}".format(io_num), min_shape, opt_shape, max_shape)
+        # The maximum shape value is less than max_batch 
+    	profile = builder.create_optimization_profile()
+    	for io_num in range(io_cnt):
+            if shape:
+                profile.set_shape_input("INPUT{}".format(io_num),
+                    [1] * shape_with_batchsize, [4] * shape_with_batchsize,
+                    [4] * shape_with_batchsize)
+            profile.set_shape("DUMMY_INPUT{}".format(io_num), min_shape, opt_shape, max_shape)
+
 
     flags = 1 <<  int(trt.BuilderFlag.STRICT_TYPES)
     datatype_set = set([trt_dtype])
@@ -704,17 +770,63 @@ def create_plan_modelconfig(
 
     shape_str = tu.shape_to_dims_str(shape)
 
-    model_name = tu.get_zero_model_name(
-        "plan_nobatch" if max_batch == 0 else "plan", io_cnt, dtype)
-    config_dir = models_dir + "/" + model_name
-    config = '''
+    if FLAGS.tensorrt_shape_io:
+        dummy_shape_str = tu.shape_to_dims_str([-1] * shape[0])
+
+
+    if FLAGS.tensorrt_shape_io:
+        model_name = tu.get_zero_model_name(
+            "plan_nobatch" if max_batch == 0 else "plan", io_cnt, dtype)
+        config_dir = models_dir + "/" + model_name
+        config = '''
 name: "{}"
 platform: "tensorrt_plan"
 max_batch_size: {}
 '''.format(model_name, max_batch)
 
-    for io_num in range(io_cnt):
-        config += '''
+        for io_num in range(io_cnt):
+            config += '''
+input [
+  {{
+    name: "DUMMY_INPUT{}"
+    data_type: TYPE_FP32
+    dims: [ {} ]
+  }},
+  {{
+    name: "INPUT{}"
+    data_type: {}
+    dims: [ {} ]
+  }}
+]
+output [
+  {{
+    name: "DUMMY_OUTPUT{}"
+    data_type: TYPE_FP32
+    dims: [ {} ]
+  }},
+  {{
+    name: "OUTPUT{}"
+    data_type: {}
+    dims: [ {} ]
+  }}
+]
+'''.format(io_num, dummy_shape_str,
+           io_num, np_to_model_dtype(dtype), shape_str,
+           io_num, dummy_shape_str,
+           io_num, np_to_model_dtype(dtype), shape_str)
+
+    else:
+        model_name = tu.get_zero_model_name(
+            "plan_nobatch" if max_batch == 0 else "plan", io_cnt, dtype)
+        config_dir = models_dir + "/" + model_name
+        config = '''
+name: "{}"
+platform: "tensorrt_plan"
+max_batch_size: {}
+'''.format(model_name, max_batch)
+
+        for io_num in range(io_cnt):
+            config += '''
 input [
   {{
     name: "INPUT{}"
@@ -795,6 +907,13 @@ def create_models(models_dir, dtype, shape, io_cnt=1, no_batch=True):
             create_plan_modelfile(True, models_dir, model_version, io_cnt, 0,
                                   dtype, shape, 16 * 1024 * 1024)
 
+    if FLAGS.tensorrt_shape_io:
+        create_plan_modelconfig(True, models_dir, model_version, io_cnt, 8, dtype, shape)
+        create_plan_modelfile(True, models_dir, model_version, io_cnt, 8, dtype, shape, 32)
+        if no_batch:
+            create_plan_modelconfig(True, models_dir, model_version, io_cnt, 0, dtype, shape)
+            create_plan_modelfile(True, models_dir, model_version, io_cnt, 0, dtype, shape, 32)
+
     if FLAGS.ensemble:
         emu.create_nop_modelconfig(models_dir, shape, dtype)
         create_ensemble_modelconfig(True, models_dir, model_version, io_cnt, 8, dtype, shape)
@@ -822,6 +941,8 @@ if __name__ == '__main__':
                         help='Generate TensorRT PLAN models')
     parser.add_argument('--tensorrt-big', required=False, action='store_true',
                         help='Generate TensorRT PLAN models w/ opt profile with large max')
+    parser.add_argument('--tensorrt-shape-io', required=False, action='store_true',
+                        help='Generate TensorRT PLAN models w/ shape tensor i/o')
     parser.add_argument('--ensemble', required=False, action='store_true',
                         help='Generate ensemble models')
     FLAGS, unparsed = parser.parse_known_args()
@@ -837,7 +958,7 @@ if __name__ == '__main__':
     if FLAGS.libtorch:
         import torch
         from torch import nn
-    if FLAGS.tensorrt or FLAGS.tensorrt_big:
+    if FLAGS.tensorrt or FLAGS.tensorrt_big or FLAGS.tensorrt_shape_io:
         import tensorrt.legacy as trt
 
     import test_util as tu
@@ -847,6 +968,10 @@ if __name__ == '__main__':
     # testing
     if FLAGS.tensorrt_big:
         create_models(FLAGS.models_dir, np.float32, [-1], io_cnt=1)
+    elif FLAGS.tensorrt_shape_io:
+        # The shape tensors should have data type of int32 and fixed
+        # 1-D shape
+        create_models(FLAGS.models_dir, np.int32, [2], io_cnt=1)
     else:
         create_models(FLAGS.models_dir, np.bool, [-1], io_cnt=1)
         create_models(FLAGS.models_dir, np.float32, [-1], io_cnt=1)

--- a/qa/common/gen_qa_model_repository
+++ b/qa/common/gen_qa_model_repository
@@ -60,6 +60,7 @@ HOST_DESTDIR=/tmp/$TRTIS_VERSION/qa_model_repository
 HOST_VARDESTDIR=/tmp/$TRTIS_VERSION/qa_variable_model_repository
 HOST_IDENTITYDESTDIR=/tmp/$TRTIS_VERSION/qa_identity_model_repository
 HOST_IDENTITYBIGDESTDIR=/tmp/$TRTIS_VERSION/qa_identity_big_model_repository
+HOST_IDENTITYSHAPEDESTDIR=/tmp/$TRTIS_VERSION/qa_identity_shapetensor_model_repository
 HOST_RESHAPEDESTDIR=/tmp/$TRTIS_VERSION/qa_reshape_model_repository
 HOST_SEQDESTDIR=/tmp/$TRTIS_VERSION/qa_sequence_model_repository
 HOST_DYNASEQDESTDIR=/tmp/$TRTIS_VERSION/qa_dyna_sequence_model_repository
@@ -69,15 +70,16 @@ HOST_NOSHAPEDESTDIR=/tmp/$TRTIS_VERSION/qa_noshape_model_repository
 HOST_PLGDESTDIR=/tmp/$TRTIS_VERSION/qa_trt_plugin_model_repository
 
 rm -fr $HOST_SRCDIR $HOST_DESTDIR $HOST_VARDESTDIR
-rm -fr $HOST_IDENTITYDESTDIR $HOST_IDENTITYBIGDESTDIR $HOST_RESHAPEDESTDIR
+rm -fr $HOST_IDENTITYDESTDIR $HOST_IDENTITYBIGDESTDIR $HOST_IDENTITYSHAPEDESTDIR
 rm -fr $HOST_SEQDESTDIR $HOST_DYNASEQDESTDIR $HOST_VARSEQDESTDIR
 rm -fr $HOST_ENSEMBLEDESTDIR $HOST_NOSHAPEDESTDIR
-rm -fr $HOST_PLGDESTDIR
+rm -fr $HOST_PLGDESTDIR $HOST_RESHAPEDESTDIR
 mkdir -p $HOST_SRCDIR
 mkdir -p $HOST_DESTDIR
 mkdir -p $HOST_VARDESTDIR
 mkdir -p $HOST_IDENTITYDESTDIR
 mkdir -p $HOST_IDENTITYBIGDESTDIR
+mkdir -p $HOST_IDENTITYSHAPEDESTDIR
 mkdir -p $HOST_RESHAPEDESTDIR
 mkdir -p $HOST_SEQDESTDIR
 mkdir -p $HOST_DYNASEQDESTDIR
@@ -118,6 +120,7 @@ DESTDIR=/tmp/models
 VARDESTDIR=/tmp/varmodels
 IDENTITYDESTDIR=/tmp/zeromodels
 IDENTITYBIGDESTDIR=/tmp/zerobigmodels
+IDENTITYSHAPEDESTDIR=/tmp/zeroshapetensormodels
 RESHAPEDESTDIR=/tmp/reshapemodels
 SEQDESTDIR=/tmp/seqmodels
 DYNASEQDESTDIR=/tmp/dynaseqmodels
@@ -240,6 +243,8 @@ python3 $SRCDIR/gen_qa_identity_models.py --tensorrt --models_dir=$IDENTITYDESTD
 chown -R $(id -u):$(id -g) $IDENTITYDESTDIR
 python3 $SRCDIR/gen_qa_identity_models.py --tensorrt-big --models_dir=$IDENTITYBIGDESTDIR
 chown -R $(id -u):$(id -g) $IDENTITYBIGDESTDIR
+python3 $SRCDIR/gen_qa_identity_models.py --tensorrt-shape-io --models_dir=$IDENTITYSHAPEDESTDIR
+chown -R $(id -u):$(id -g) $IDENTITYSHAPEDESTDIR
 python3 $SRCDIR/gen_qa_reshape_models.py --tensorrt --variable --models_dir=$RESHAPEDESTDIR
 chown -R $(id -u):$(id -g) $RESHAPEDESTDIR
 python3 $SRCDIR/gen_qa_sequence_models.py --tensorrt --models_dir=$SEQDESTDIR
@@ -268,6 +273,7 @@ nvidia-docker run --rm --entrypoint $SRCDIR/$TRTSCRIPT \
        --mount type=bind,source=$HOST_VARDESTDIR,target=$VARDESTDIR \
        --mount type=bind,source=$HOST_IDENTITYDESTDIR,target=$IDENTITYDESTDIR \
        --mount type=bind,source=$HOST_IDENTITYBIGDESTDIR,target=$IDENTITYBIGDESTDIR \
+       --mount type=bind,source=$HOST_IDENTITYSHAPEDESTDIR,target=$IDENTITYSHAPEDESTDIR \
        --mount type=bind,source=$HOST_RESHAPEDESTDIR,target=$RESHAPEDESTDIR \
        --mount type=bind,source=$HOST_SEQDESTDIR,target=$SEQDESTDIR \
        --mount type=bind,source=$HOST_DYNASEQDESTDIR,target=$DYNASEQDESTDIR \

--- a/src/backends/caffe2/netdef_backend.cc
+++ b/src/backends/caffe2/netdef_backend.cc
@@ -135,7 +135,11 @@ NetDefBackend::CreateExecutionContexts(
           uint32_t runner_idx, std::vector<Scheduler::Payload>* payloads,
           std::function<void(Status)> func) {
         Run(runner_idx, payloads, func);
-      }));
+      },
+      [this](
+          uint32_t runner_idx, const InferRequestHeader::Input& input,
+          const Scheduler::Payload& payload,
+          std::vector<int64_t>* shape) -> Status { return Status::Success; }));
 
   LOG_VERBOSE(1) << "netdef backend for " << Name() << std::endl << *this;
   return Status::Success;

--- a/src/backends/custom/custom_backend.cc
+++ b/src/backends/custom/custom_backend.cc
@@ -142,7 +142,11 @@ CustomBackend::CreateExecutionContexts(
           uint32_t runner_idx, std::vector<Scheduler::Payload>* payloads,
           std::function<void(Status)> func) {
         Run(runner_idx, payloads, func);
-      }));
+      },
+      [this](
+          uint32_t runner_idx, const InferRequestHeader::Input& input,
+          const Scheduler::Payload& payload,
+          std::vector<int64_t>* shape) -> Status { return Status::Success; }));
 
   LOG_VERBOSE(1) << "custom backend for " << Name() << std::endl << *this;
   return Status::Success;

--- a/src/backends/onnx/onnx_backend.cc
+++ b/src/backends/onnx/onnx_backend.cc
@@ -130,7 +130,11 @@ OnnxBackend::CreateExecutionContextsHelper(
           uint32_t runner_idx, std::vector<Scheduler::Payload>* payloads,
           std::function<void(Status)> func) {
         Run(runner_idx, payloads, func);
-      }));
+      },
+      [this](
+          uint32_t runner_idx, const InferRequestHeader::Input& input,
+          const Scheduler::Payload& payload,
+          std::vector<int64_t>* shape) -> Status { return Status::Success; }));
 
   return Status::Success;
 }

--- a/src/backends/pytorch/libtorch_backend.cc
+++ b/src/backends/pytorch/libtorch_backend.cc
@@ -173,7 +173,11 @@ LibTorchBackend::CreateExecutionContexts(
           uint32_t runner_idx, std::vector<Scheduler::Payload>* payloads,
           std::function<void(Status)> func) {
         Run(runner_idx, payloads, func);
-      }));
+      },
+      [this](
+          uint32_t runner_idx, const InferRequestHeader::Input& input,
+          const Scheduler::Payload& payload,
+          std::vector<int64_t>* shape) -> Status { return Status::Success; }));
 
   return Status::Success;
 }

--- a/src/backends/tensorflow/base_backend.cc
+++ b/src/backends/tensorflow/base_backend.cc
@@ -116,7 +116,11 @@ BaseBackend::CreateExecutionContexts(
           uint32_t runner_idx, std::vector<Scheduler::Payload>* payloads,
           std::function<void(Status)> func) {
         Run(runner_idx, payloads, func);
-      }));
+      },
+      [this](
+          uint32_t runner_idx, const InferRequestHeader::Input& input,
+          const Scheduler::Payload& payload,
+          std::vector<int64_t>* shape) -> Status { return Status::Success; }));
 
   LOG_VERBOSE(1) << "backend for " << Name() << std::endl << *this;
 

--- a/src/backends/tensorrt/autofill.cc
+++ b/src/backends/tensorrt/autofill.cc
@@ -280,7 +280,7 @@ AutoFillPlanImpl::Init(ModelConfig* config)
         }
       } else {
         LOG_WARNING << "Some of the profiles for " << model_name_
-                    << " does not support batching.";
+                    << " do not support batching.";
         max_batch_size_ = 0;
       }
     }

--- a/src/backends/tensorrt/plan_backend.cc
+++ b/src/backends/tensorrt/plan_backend.cc
@@ -154,11 +154,34 @@ PlanBackend::CreateExecutionContexts(
           uint32_t runner_idx, std::vector<Scheduler::Payload>* payloads,
           std::function<void(Status)> func) {
         Run(runner_idx, payloads, func);
+      },
+      [this](
+          uint32_t runner_idx, const InferRequestHeader::Input& input,
+          const Scheduler::Payload& payload,
+          std::vector<int64_t>* shape) -> Status {
+        return PeekShapeTensor(runner_idx, input, payload, shape);
       }));
 
   LOG_VERBOSE(1) << "plan backend for " << Name() << std::endl << *this;
 
   return Status::Success;
+}
+
+Status
+PlanBackend::PeekShapeTensor(
+    uint32_t runner_idx, const InferRequestHeader::Input& input,
+    const Scheduler::Payload& payload, std::vector<int64_t>* shape)
+{
+  // Each runner performs the peek using the corresponding since it
+  // may require a CUDA stream to get the tensor contents.
+  if (runner_idx >= contexts_.size()) {
+    return Status(
+        RequestStatusCode::INTERNAL,
+        "unexpected runner index" + std::to_string(runner_idx) +
+            ", max allowed " + std::to_string(contexts_.size()));
+  }
+
+  return contexts_[runner_idx]->PeekShapeTensor(input, payload, shape);
 }
 
 Status
@@ -796,6 +819,56 @@ PlanBackend::Context::InitializeConfigOutputBindings(
           num_expected_bindings_ * trt_context.first + io_index;
       buffer_bindings_[binding_index] = buffers_[io_index];
     }
+  }
+
+  return Status::Success;
+}
+
+Status
+PlanBackend::Context::PeekShapeTensor(
+    const InferRequestHeader::Input& input, const Scheduler::Payload& payload,
+    std::vector<int64_t>* shape)
+{
+  // It is the caller's responsibility to only call on shape tensors,
+  // which means the datatype must be INT32.
+  int64_t element_cnt = GetElementCount(input.dims());
+  size_t content_byte_size =
+      element_cnt * GetDataTypeByteSize(DataType::TYPE_INT32);
+  const char* content;
+
+  // Get the tensor contents into contiguous CPU memory...
+  std::unique_ptr<AllocatedSystemMemory> contiguous_buffer;
+  bool cuda_copy = false;
+  RETURN_IF_ERROR(GetContiguousInputContent(
+      input.name(), TRTSERVER_MEMORY_CPU, 0 /* src_memory_type_id */, payload,
+      &content, &content_byte_size, &contiguous_buffer, &cuda_copy));
+
+  if (cuda_copy) {
+    cudaStreamSynchronize(stream_);
+  }
+
+  shape->clear();
+
+  const int32_t* dims = reinterpret_cast<const int32_t*>(content);
+  for (int64_t i = 0; i < element_cnt; ++i) {
+    shape->push_back(dims[i]);
+  }
+
+  // If have an provider override for this tensor already (because
+  // peek was already called, then mark it as not being consumed so
+  // that the next peek or usage will be able to access it. If don't
+  // already have an override, add it...
+  if (payload.request_provider_->HasInputOverride(input.name())) {
+    payload.request_provider_->SetInputOverrideConsumed(input.name(), false);
+  } else {
+    InferRequestProvider::InputOverride override;
+    override.content_.assign(dims, dims + element_cnt);
+    override.dims_ = input.dims();
+    override.datatype_ = DataType::TYPE_INT32;
+
+    auto overrides = std::make_shared<InferRequestProvider::InputOverrideMap>();
+    overrides->insert(std::make_pair(input.name(), override));
+    payload.request_provider_->AddInputOverrides(overrides);
   }
 
   return Status::Success;

--- a/src/backends/tensorrt/plan_backend.h
+++ b/src/backends/tensorrt/plan_backend.h
@@ -53,6 +53,10 @@ class PlanBackend : public InferenceBackend {
   DISALLOW_COPY_AND_ASSIGN(PlanBackend);
   friend std::ostream& operator<<(std::ostream&, const PlanBackend&);
 
+  Status PeekShapeTensor(
+      uint32_t runner_idx, const InferRequestHeader::Input& input,
+      const Scheduler::Payload& payload, std::vector<int64_t>* shape);
+
   // For each model instance there is a context.
   struct Context : BackendContext {
     Context(
@@ -91,6 +95,11 @@ class PlanBackend : public InferenceBackend {
     Status Run(
         const InferenceBackend* base,
         std::vector<Scheduler::Payload>* payloads) override;
+
+    // See BackendContext::PeekShapeTensor()
+    Status PeekShapeTensor(
+        const InferRequestHeader::Input& input,
+        const Scheduler::Payload& payload, std::vector<int64_t>* shape);
 
     // A struct to hold TensorRT execution context and its meta data, a backend
     // context can have multiple of this struct if multiple optimization

--- a/src/core/backend.cc
+++ b/src/core/backend.cc
@@ -115,8 +115,9 @@ InferenceBackend::SetScheduler(std::unique_ptr<Scheduler> scheduler)
 
 Status
 InferenceBackend::SetConfiguredScheduler(
-    const uint32_t runner_cnt, Scheduler::StandardInitFunc OnInit,
-    Scheduler::StandardRunFunc OnRun)
+    const uint32_t runner_cnt, const Scheduler::StandardInitFunc& OnInit,
+    const Scheduler::StandardRunFunc& OnRun,
+    const Scheduler::StandardShapeTensorPeekFunc& OnPeek)
 {
   std::unique_ptr<Scheduler> scheduler;
 
@@ -167,29 +168,31 @@ InferenceBackend::SetConfiguredScheduler(
   // otherwise use the default DynamicBatchScheduler.
   if (config_.has_sequence_batching()) {
     RETURN_IF_ERROR(SequenceBatchScheduler::Create(
-        config_, runner_cnt, OnInit, OnWarmup, OnRun, &scheduler));
+        config_, runner_cnt, OnInit, OnWarmup, OnRun, OnPeek, &scheduler));
   } else if (config_.has_dynamic_batching()) {
     std::set<int32_t> preferred_batch_sizes;
     for (const auto size : config_.dynamic_batching().preferred_batch_size()) {
       preferred_batch_sizes.insert(size);
     }
 
-    // Need to enforce equal shape batches (i.e. non-ragged batches) if
-    // the model allows one or more variable-size input tensors. This is
-    // not needed if all input shapes are non-variable and so we don't
-    // enable it for efficiency reasons.
-    bool enforce_equal_shape_batch = false;
+    // Need to enforce equal shape batches (i.e. non-ragged batches)
+    // if the model allows one or more variable-size input tensors or
+    // has shape-tensor inputs. This is not needed if all input shapes
+    // are non-variable and if there are no shape tensors... so we
+    // don't enable it in that case for efficiency reasons.
+    std::unordered_map<std::string, bool> enforce_equal_shape_tensors;
     for (const auto input : config_.input()) {
-      if (GetElementCount(input) == -1) {
-        enforce_equal_shape_batch = true;
-        break;
+      if (input.is_shape_tensor()) {
+        enforce_equal_shape_tensors.insert({input.name(), true});
+      } else if (GetElementCount(input) == -1) {
+        enforce_equal_shape_tensors.insert({input.name(), false});
       }
     }
 
     RETURN_IF_ERROR(DynamicBatchScheduler::Create(
         0 /* runner_id_start */, runner_cnt, GetCpuNiceLevel(config_), OnInit,
-        OnWarmup, OnRun, true /* dynamic_batching_enabled */,
-        enforce_equal_shape_batch,
+        OnWarmup, OnRun, OnPeek, true /* dynamic_batching_enabled */,
+        enforce_equal_shape_tensors,
         config_.dynamic_batching().preserve_ordering(), preferred_batch_sizes,
         config_.dynamic_batching().max_queue_delay_microseconds(), &scheduler));
   } else {
@@ -197,8 +200,10 @@ InferenceBackend::SetConfiguredScheduler(
     // default scheduler.
     RETURN_IF_ERROR(DynamicBatchScheduler::Create(
         0 /* runner_id_start */, runner_cnt, GetCpuNiceLevel(config_), OnInit,
-        OnWarmup, OnRun, false /* dynamic_batching_enabled */,
-        false /* enforce_equal_shape_batch */, false /* preserve_ordering */,
+        OnWarmup, OnRun, OnPeek, false /* dynamic_batching_enabled */,
+        std::unordered_map<
+            std::string, bool>() /* enforce_equal_shape_tensors */,
+        false /* preserve_ordering */,
         std::set<int32_t>() /* preferred_batch_sizes */,
         0 /* max_queue_delay_microseconds */, &scheduler));
   }

--- a/src/core/backend.h
+++ b/src/core/backend.h
@@ -104,8 +104,9 @@ class InferenceBackend {
   // Set the scheduler based on the model configuration. The scheduler
   // can only be set once for a backend.
   Status SetConfiguredScheduler(
-      const uint32_t runner_cnt, Scheduler::StandardInitFunc OnInit,
-      Scheduler::StandardRunFunc OnRun);
+      const uint32_t runner_cnt, const Scheduler::StandardInitFunc& OnInit,
+      const Scheduler::StandardRunFunc& OnRun,
+      const Scheduler::StandardShapeTensorPeekFunc& OnPeek);
 
   // Get the raw pointer to the scheduler of this backend.
   Scheduler* BackendScheduler() { return scheduler_.get(); }

--- a/src/core/backend_context.cc
+++ b/src/core/backend_context.cc
@@ -286,4 +286,13 @@ BackendContext::GetContiguousInputContent(
   return Status::Success;
 }
 
+Status
+BackendContext::PeekShapeTensor(
+    const InferRequestHeader::Input& input, const Scheduler::Payload& payload,
+    std::vector<int64_t>* shape)
+{
+  // By default a backend doesn't support shape tensors.
+  return Status(RequestStatusCode::INTERNAL, "shape tensors not supported");
+}
+
 }}  // namespace nvidia::inferenceserver

--- a/src/core/backend_context.h
+++ b/src/core/backend_context.h
@@ -67,6 +67,14 @@ struct BackendContext {
       const InferenceBackend* base,
       std::vector<Scheduler::Payload>* payloads) = 0;
 
+  // Return the contents of a shape tensor. It is the caller's
+  // responsibility to call this only for shape tensors that are
+  // 1-dimensional, INT32 tensors. A non-OK status indicates that the
+  // contents of the tensor could not be peeked.
+  virtual Status PeekShapeTensor(
+      const InferRequestHeader::Input& input, const Scheduler::Payload& payload,
+      std::vector<int64_t>* shape);
+
   // Helper function to batch input data from payloads into 'input_buffer'.
   // 'input_buffer' must be a continuous block that can hold the sum of
   // 'expected_byte_sizes' bytes. On byte size mismatch, the function will

--- a/src/core/dynamic_batch_scheduler.cc
+++ b/src/core/dynamic_batch_scheduler.cc
@@ -41,18 +41,21 @@ namespace nvidia { namespace inferenceserver {
 
 DynamicBatchScheduler::DynamicBatchScheduler(
     const uint32_t runner_id_start, const uint32_t runner_cnt,
-    StandardInitFunc OnInit, StandardWarmupFunc OnWarmup,
-    StandardRunFunc OnSchedule, const bool dynamic_batching_enabled,
-    const bool enforce_equal_shape_batch, const bool preserve_ordering,
+    const StandardInitFunc& OnInit, const StandardWarmupFunc& OnWarmup,
+    const StandardRunFunc& OnSchedule,
+    const StandardShapeTensorPeekFunc& OnPeek,
+    const bool dynamic_batching_enabled,
+    const std::unordered_map<std::string, bool>& enforce_equal_shape_tensors,
+    const bool preserve_ordering,
     const std::set<int32_t>& preferred_batch_sizes,
     const uint64_t max_queue_delay_microseconds)
     : OnInit_(OnInit), OnWarmup_(OnWarmup), OnSchedule_(OnSchedule),
-      dynamic_batching_enabled_(dynamic_batching_enabled),
+      OnPeek_(OnPeek), dynamic_batching_enabled_(dynamic_batching_enabled),
       scheduler_thread_cnt_(runner_cnt), idle_scheduler_thread_cnt_(0),
       preferred_batch_sizes_(preferred_batch_sizes),
       pending_batch_delay_ns_(max_queue_delay_microseconds * 1000),
       pending_batch_size_(0), pending_batch_queue_cnt_(0),
-      enforce_equal_shape_batch_(enforce_equal_shape_batch),
+      enforce_equal_shape_tensors_(enforce_equal_shape_tensors),
       preserve_ordering_(preserve_ordering), last_processing_runner_id_(-1)
 {
   max_preferred_batch_size_ = 0;
@@ -65,16 +68,19 @@ DynamicBatchScheduler::DynamicBatchScheduler(
 Status
 DynamicBatchScheduler::Create(
     const uint32_t runner_id_start, const uint32_t runner_cnt, const int nice,
-    StandardInitFunc OnInit, StandardWarmupFunc OnWarmup,
-    StandardRunFunc OnSchedule, const bool dynamic_batching_enabled,
-    const bool enforce_equal_shape_batch, const bool preserve_ordering,
+    const StandardInitFunc& OnInit, const StandardWarmupFunc& OnWarmup,
+    const StandardRunFunc& OnSchedule,
+    const StandardShapeTensorPeekFunc& OnPeek,
+    const bool dynamic_batching_enabled,
+    const std::unordered_map<std::string, bool>& enforce_equal_shape_tensors,
+    const bool preserve_ordering,
     const std::set<int32_t>& preferred_batch_sizes,
     const uint64_t max_queue_delay_microseconds,
     std::unique_ptr<Scheduler>* scheduler)
 {
   DynamicBatchScheduler* dyna_sched = new DynamicBatchScheduler(
-      runner_id_start, runner_cnt, OnInit, OnWarmup, OnSchedule,
-      dynamic_batching_enabled, enforce_equal_shape_batch, preserve_ordering,
+      runner_id_start, runner_cnt, OnInit, OnWarmup, OnSchedule, OnPeek,
+      dynamic_batching_enabled, enforce_equal_shape_tensors, preserve_ordering,
       preferred_batch_sizes, max_queue_delay_microseconds);
   std::unique_ptr<DynamicBatchScheduler> sched(dyna_sched);
 
@@ -257,7 +263,7 @@ DynamicBatchScheduler::SchedulerThread(
         wait_microseconds = default_wait_microseconds;
       } else if (dynamic_batching_enabled_) {
         // Use dynamic batching to get request payload(s) to execute.
-        wait_microseconds = GetDynamicBatch();
+        wait_microseconds = GetDynamicBatch(runner_id);
         if (wait_microseconds == 0) {
           payloads = std::make_shared<std::vector<Scheduler::Payload>>();
           for (size_t idx = 0; idx < pending_batch_queue_cnt_; ++idx) {
@@ -391,32 +397,62 @@ DynamicBatchScheduler::SchedulerThread(
                  << "...";
 }
 
-void
-DynamicBatchScheduler::InitPendingShape(const InferRequestHeader& request)
+Status
+DynamicBatchScheduler::InitPendingShape(
+    const int64_t runner_id, const Scheduler::Payload& payload)
 {
   pending_batch_shapes_.clear();
 
+  const InferRequestHeader& request =
+      payload.request_provider_->RequestHeader();
   for (const auto& input : request.input()) {
-    pending_batch_shapes_.emplace(std::make_pair(input.name(), input.dims()));
+    const auto itr = enforce_equal_shape_tensors_.find(input.name());
+    if (itr != enforce_equal_shape_tensors_.end()) {
+      std::pair<DimsList, std::vector<int64_t>> shapes;
+      shapes.first = input.dims();
+
+      // For shape tensors must compare the contents of the tensor in
+      // addition to the tensor shape itself.
+      if (itr->second) {
+        RETURN_IF_ERROR(OnPeek_(runner_id, input, payload, &shapes.second));
+      }
+
+      pending_batch_shapes_.emplace(
+          std::make_pair(input.name(), std::move(shapes)));
+    }
   }
+
+  return Status::Success;
 }
 
 bool
 DynamicBatchScheduler::CompareWithPendingShape(
-    const InferRequestHeader& request) const
+    const int64_t runner_id, const Scheduler::Payload& payload) const
 {
+  const InferRequestHeader& request =
+      payload.request_provider_->RequestHeader();
+
   for (const auto& input : request.input()) {
     const auto itr = pending_batch_shapes_.find(input.name());
+    if (itr != pending_batch_shapes_.end()) {
+      if (!CompareDims(itr->second.first, input.dims())) {
+        return false;
+      }
 
-    // It should never happen that we don't find the shape for an
-    // input, but if it does just return to be conservative.
-    if (itr == pending_batch_shapes_.end()) {
-      LOG_ERROR << "expected to find shape for input '" << input.name() << "'";
-      return false;
-    }
+      // If there are shape-tensor contents then compare those as
+      // well.
+      if (!itr->second.second.empty()) {
+        std::vector<int64_t> shape;
 
-    if (!CompareDims(itr->second, input.dims())) {
-      return false;
+        // If fail getting the tensor shape then conservatively return
+        // false to indicate that the shapes don't match.
+        if (!OnPeek_(runner_id, input, payload, &shape).IsOk()) {
+          return false;
+        }
+        if (!CompareDims(itr->second.second, shape)) {
+          return false;
+        }
+      }
     }
   }
 
@@ -424,7 +460,7 @@ DynamicBatchScheduler::CompareWithPendingShape(
 }
 
 uint64_t
-DynamicBatchScheduler::GetDynamicBatch()
+DynamicBatchScheduler::GetDynamicBatch(const int64_t runner_id)
 {
   // 'mu_' mutex must be held when this function is called. queue_
   // must not be empty.
@@ -447,8 +483,11 @@ DynamicBatchScheduler::GetDynamicBatch()
     // new batch.
     if (search_batch_cnt == 0) {
       // Get the shape of the new batch that is being started...
-      if (enforce_equal_shape_batch_) {
-        InitPendingShape(queue_[idx].request_provider_->RequestHeader());
+      if (!enforce_equal_shape_tensors_.empty()) {
+        if (!InitPendingShape(runner_id, queue_[idx]).IsOk()) {
+          send_now = true;
+          break;
+        }
       }
     } else {
       // There is a pending batch and adding this request would make
@@ -460,9 +499,8 @@ DynamicBatchScheduler::GetDynamicBatch()
 
       // There is a pending batch and it has a different shape then
       // this request, so send the pending batch as it is.
-      if (enforce_equal_shape_batch_ &&
-          !CompareWithPendingShape(
-              queue_[idx].request_provider_->RequestHeader())) {
+      if (!enforce_equal_shape_tensors_.empty() &&
+          !CompareWithPendingShape(runner_id, queue_[idx])) {
         send_now = true;
         break;
       }

--- a/src/core/dynamic_batch_scheduler.h
+++ b/src/core/dynamic_batch_scheduler.h
@@ -47,9 +47,12 @@ class DynamicBatchScheduler : public Scheduler {
   // function to call when a request is scheduled.
   static Status Create(
       const uint32_t runner_id_start, const uint32_t runner_cnt, const int nice,
-      StandardInitFunc OnInit, StandardWarmupFunc OnWarmup,
-      StandardRunFunc OnSchedule, const bool dynamic_batching_enabled,
-      const bool enforce_equal_shape_batch, const bool preserve_ordering,
+      const StandardInitFunc& OnInit, const StandardWarmupFunc& OnWarmup,
+      const StandardRunFunc& OnSchedule,
+      const StandardShapeTensorPeekFunc& OnPeek,
+      const bool dynamic_batching_enabled,
+      const std::unordered_map<std::string, bool>& enforce_equal_shape_tensors,
+      const bool preserve_ordering,
       const std::set<int32_t>& preferred_batch_sizes,
       const uint64_t max_queue_delay_microseconds,
       std::unique_ptr<Scheduler>* scheduler);
@@ -66,18 +69,24 @@ class DynamicBatchScheduler : public Scheduler {
  private:
   DynamicBatchScheduler(
       const uint32_t runner_id_start, const uint32_t runner_cnt,
-      StandardInitFunc OnInit, StandardWarmupFunc OnWarmup,
-      StandardRunFunc OnSchedule, const bool dynamic_batching_enabled,
-      const bool enforce_equal_shape_batch, const bool preserve_ordering,
+      const StandardInitFunc& OnInit, const StandardWarmupFunc& OnWarmup,
+      const StandardRunFunc& OnSchedule,
+      const StandardShapeTensorPeekFunc& OnPeek,
+      const bool dynamic_batching_enabled,
+      const std::unordered_map<std::string, bool>& enforce_equal_shape_tensors,
+      const bool preserve_ordering,
       const std::set<int32_t>& preferred_batch_sizes,
       const uint64_t max_queue_delay_microseconds);
   void SchedulerThread(
       const uint32_t runner_id, const int nice,
       const std::shared_ptr<std::atomic<bool>>& rthread_exit,
       std::promise<bool>* is_initialized);
-  void InitPendingShape(const InferRequestHeader& request);
-  bool CompareWithPendingShape(const InferRequestHeader& request) const;
-  uint64_t GetDynamicBatch();
+  Status InitPendingShape(
+      const int64_t runner_id, const Scheduler::Payload& request_provider);
+  bool CompareWithPendingShape(
+      const int64_t runner_id,
+      const Scheduler::Payload& request_provider) const;
+  uint64_t GetDynamicBatch(const int64_t runner_id);
 
   // Function the scheduler will call to initialize a runner.
   const StandardInitFunc OnInit_;
@@ -88,6 +97,9 @@ class DynamicBatchScheduler : public Scheduler {
   // Function the scheduler will call to schedule a payload(s) for
   // execution.
   const StandardRunFunc OnSchedule_;
+
+  // Function the scheduler will call to peek at shape tensors.
+  const StandardShapeTensorPeekFunc OnPeek_;
 
   // True if dynamic batching is enabled.
   const bool dynamic_batching_enabled_;
@@ -115,8 +127,9 @@ class DynamicBatchScheduler : public Scheduler {
   size_t pending_batch_size_;
   size_t pending_batch_queue_cnt_;
 
-  const bool enforce_equal_shape_batch_;
-  std::unordered_map<std::string, DimsList> pending_batch_shapes_;
+  const std::unordered_map<std::string, bool> enforce_equal_shape_tensors_;
+  std::unordered_map<std::string, std::pair<DimsList, std::vector<int64_t>>>
+      pending_batch_shapes_;
 
   const bool preserve_ordering_;
   // the runner that is currently processing payloads

--- a/src/core/model_config.cc
+++ b/src/core/model_config.cc
@@ -290,6 +290,23 @@ CompareDims(const DimsList& dims0, const DimsList& dims1)
 }
 
 bool
+CompareDims(
+    const std::vector<int64_t>& dims0, const std::vector<int64_t>& dims1)
+{
+  if (dims0.size() != dims1.size()) {
+    return false;
+  }
+
+  for (size_t i = 0; i < dims0.size(); ++i) {
+    if (dims0[i] != dims1[i]) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool
 CompareDimsWithWildcard(const DimsList& dims0, const DimsList& dims1)
 {
   if (dims0.size() != dims1.size()) {

--- a/src/core/model_config.h
+++ b/src/core/model_config.h
@@ -198,6 +198,16 @@ bool CompareDims(const DimsList& dims0, const DimsList& dims1);
 
 /// Compare two model configuration shapes for equality. Wildcard
 /// dimensions (that is, dimensions with size WILDCARD_DIM) are
+/// compared literally so that to be equal the two shapes must both
+/// specify WILDCARD_DIM in the same dimensions.
+/// \params dims0 The first shape.
+/// \params dims1 The second shape.
+/// \return True if the shapes are equal, false if not equal.
+bool CompareDims(
+    const std::vector<int64_t>& dims0, const std::vector<int64_t>& dims1);
+
+/// Compare two model configuration shapes for equality. Wildcard
+/// dimensions (that is, dimensions with size WILDCARD_DIM) are
 /// allowed to match with any value. So, a dimension in one shape
 /// specified as WILDCARD_DIM will always match the same dimension in
 /// the other shape.

--- a/src/core/model_config.proto
+++ b/src/core/model_config.proto
@@ -255,6 +255,15 @@ message ModelInput
   //@@     specified by 'dims'. Optional.
   //@@
   ModelTensorReshape reshape = 5;
+
+  //@@  .. cpp:var:: bool is_shape_tensor
+  //@@
+  //@@     Whether or not the input is a shape tensor to the model. This field
+  //@@     is currently supported only for the TensorRT model. An error will be
+  //@@     generated if this specification does not comply with underlying
+  //@@     model.
+  //@@
+  bool is_shape_tensor = 6;
 }
 
 //@@
@@ -297,6 +306,16 @@ message ModelOutput
   //@@     for outputs that represent classifications. Optional.
   //@@
   string label_filename = 4;
+
+
+  //@@  .. cpp:var:: bool is_shape_tensor
+  //@@
+  //@@     Whether or not the output is a shape tensor to the model. This field
+  //@@     is currently supported only for the TensorRT model. An error will be
+  //@@     generated if this specification does not comply with underlying
+  //@@     model.
+  //@@
+  bool is_shape_tensor = 6;
 }
 
 //@@

--- a/src/core/model_config_utils.h
+++ b/src/core/model_config_utils.h
@@ -114,9 +114,11 @@ Status BuildEnsembleGraph(
 /// configuration.
 /// \param io The model input.
 /// \param max_batch_size The max batch size specified in model configuration.
+/// \param platform The platform name
 /// \return The error status. A non-OK status indicates the input
 /// is not valid.
-Status ValidateModelInput(const ModelInput& io, int32_t max_batch_size);
+Status ValidateModelInput(
+    const ModelInput& io, int32_t max_batch_size, const std::string& platform);
 
 /// Validate that an input matches one of the allowed input names.
 /// \param io The model input.
@@ -130,9 +132,11 @@ Status CheckAllowedModelInput(
 /// configuration.
 /// \param io The model output.
 /// \param max_batch_size The max batch size specified in model configuration.
+/// \param platform The platform name
 /// \return The error status. A non-OK status indicates the output
 /// is not valid.
-Status ValidateModelOutput(const ModelOutput& io, int32_t max_batch_size);
+Status ValidateModelOutput(
+    const ModelOutput& io, int32_t max_batch_size, const std::string& platform);
 
 /// Validate that an output matches one of the allowed output names.
 /// \param io The model output.

--- a/src/core/provider.cc
+++ b/src/core/provider.cc
@@ -222,6 +222,18 @@ InferRequestProvider::GetInputOverrides() const
   return overrides_maps_;
 }
 
+bool
+InferRequestProvider::HasInputOverride(const std::string& name)
+{
+  for (const auto& override_map : overrides_maps_) {
+    if (override_map->find(name) != override_map->end()) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 Status
 InferRequestProvider::AddInputOverrides(
     const std::shared_ptr<InputOverrideMap>& overrides)
@@ -231,6 +243,17 @@ InferRequestProvider::AddInputOverrides(
   }
 
   return Status::Success;
+}
+
+void
+InferRequestProvider::SetInputOverrideConsumed(
+    const std::string& name, const bool consumed)
+{
+  if (consumed) {
+    overrides_consumed_.insert(name);
+  } else {
+    overrides_consumed_.erase(name);
+  }
 }
 
 bool

--- a/src/core/provider.h
+++ b/src/core/provider.h
@@ -191,6 +191,8 @@ class InferRequestProvider {
   using InputOverrideMapVec = std::vector<std::shared_ptr<InputOverrideMap>>;
   const InputOverrideMapVec& GetInputOverrides() const;
   Status AddInputOverrides(const std::shared_ptr<InputOverrideMap>& overrides);
+  bool HasInputOverride(const std::string& name);
+  void SetInputOverrideConsumed(const std::string& name, const bool consumed);
 
  protected:
   explicit InferRequestProvider(

--- a/src/core/scheduler.h
+++ b/src/core/scheduler.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <functional>
+#include "src/core/api.pb.h"
 #include "src/core/server_status.h"
 #include "src/core/status.h"
 
@@ -98,6 +99,15 @@ class Scheduler {
   using StandardRunFunc = std::function<void(
       uint32_t runner_idx, std::vector<Payload>* payloads,
       std::function<void(const Status&)> OnRunComplete)>;
+
+  // The prototype for the shape-tensor peek function that can be
+  // called by the "standard" schedulers created based on a model's
+  // scheduling_choice settings. The peek function can be called to
+  // get the contents of a shape tensor. A non-OK error status
+  // indicates that the peek failed.
+  using StandardShapeTensorPeekFunc = std::function<Status(
+      uint32_t runner_idx, const InferRequestHeader::Input& input,
+      const Scheduler::Payload& payload, std::vector<int64_t>* shape)>;
 
   // Enqueue a request with the scheduler.
   virtual void Enqueue(

--- a/src/core/sequence_batch_scheduler.cc
+++ b/src/core/sequence_batch_scheduler.cc
@@ -42,8 +42,9 @@ namespace nvidia { namespace inferenceserver {
 Status
 SequenceBatchScheduler::Create(
     const ModelConfig& config, const uint32_t runner_cnt,
-    Scheduler::StandardInitFunc OnInit, Scheduler::StandardWarmupFunc OnWarmup,
-    Scheduler::StandardRunFunc OnSchedule,
+    const StandardInitFunc& OnInit, const StandardWarmupFunc& OnWarmup,
+    const StandardRunFunc& OnSchedule,
+    const StandardShapeTensorPeekFunc& OnPeek,
     std::unique_ptr<Scheduler>* scheduler)
 {
   std::unique_ptr<SequenceBatchScheduler> sched(new SequenceBatchScheduler());
@@ -95,7 +96,7 @@ SequenceBatchScheduler::Create(
     if (config.sequence_batching().has_oldest()) {
       sb.reset(new OldestSequenceBatch(
           sched.get(), c, seq_slot_cnt, config, OnInit, OnWarmup, OnSchedule,
-          start, end, startend, cont, notready, &init_state));
+          OnPeek, start, end, startend, cont, notready, &init_state));
     } else {
       sb.reset(new DirectSequenceBatch(
           sched.get(), c, seq_slot_cnt, config, OnInit, OnWarmup, OnSchedule,
@@ -766,8 +767,9 @@ SequenceBatch::SetControlTensors(
 DirectSequenceBatch::DirectSequenceBatch(
     SequenceBatchScheduler* base, const uint32_t batcher_idx,
     const size_t seq_slot_cnt, const ModelConfig& config,
-    Scheduler::StandardInitFunc OnInit, Scheduler::StandardWarmupFunc OnWarmup,
-    Scheduler::StandardRunFunc OnSchedule,
+    const Scheduler::StandardInitFunc& OnInit,
+    const Scheduler::StandardWarmupFunc& OnWarmup,
+    const Scheduler::StandardRunFunc& OnSchedule,
     const std::shared_ptr<InferRequestProvider::InputOverrideMap>&
         start_input_overrides,
     const std::shared_ptr<InferRequestProvider::InputOverrideMap>&
@@ -1158,8 +1160,10 @@ DirectSequenceBatch::SchedulerThread(
 OldestSequenceBatch::OldestSequenceBatch(
     SequenceBatchScheduler* base, const uint32_t batcher_idx,
     const size_t seq_slot_cnt, const ModelConfig& config,
-    Scheduler::StandardInitFunc OnInit, Scheduler::StandardWarmupFunc OnWarmup,
-    Scheduler::StandardRunFunc OnSchedule,
+    const Scheduler::StandardInitFunc& OnInit,
+    const Scheduler::StandardWarmupFunc& OnWarmup,
+    const Scheduler::StandardRunFunc& OnSchedule,
+    const Scheduler::StandardShapeTensorPeekFunc& OnPeek,
     const std::shared_ptr<InferRequestProvider::InputOverrideMap>&
         start_input_overrides,
     const std::shared_ptr<InferRequestProvider::InputOverrideMap>&
@@ -1195,9 +1199,9 @@ OldestSequenceBatch::OldestSequenceBatch(
 
   Status status = DynamicBatchScheduler::Create(
       batcher_idx_, 1 /* runner_cnt */, GetCpuNiceLevel(config), OnInit,
-      OnWarmup, OnSchedule, true /* dynamic_batching_enabled */,
-      false /* enforce_equal_shape_batch */, true /* preserve_ordering */,
-      preferred_batch_sizes,
+      OnWarmup, OnSchedule, OnPeek, true /* dynamic_batching_enabled */,
+      std::unordered_map<std::string, bool>() /* enforce_equal_shape_tensors */,
+      true /* preserve_ordering */, preferred_batch_sizes,
       config.sequence_batching().oldest().max_queue_delay_microseconds(),
       &dynamic_batcher_);
   if (!status.IsOk()) {

--- a/src/core/sequence_batch_scheduler.h
+++ b/src/core/sequence_batch_scheduler.h
@@ -55,8 +55,10 @@ class SequenceBatchScheduler : public Scheduler {
   // function to call when a request is scheduled.
   static Status Create(
       const ModelConfig& config, const uint32_t runner_cnt,
-      StandardInitFunc OnInit, StandardWarmupFunc OnWarmup,
-      StandardRunFunc OnSchedule, std::unique_ptr<Scheduler>* scheduler);
+      const StandardInitFunc& OnInit, const StandardWarmupFunc& OnWarmup,
+      const StandardRunFunc& OnSchedule,
+      const StandardShapeTensorPeekFunc& OnPeek,
+      std::unique_ptr<Scheduler>* scheduler);
 
   // \see Scheduler::Enqueue()
   void Enqueue(
@@ -234,9 +236,9 @@ class DirectSequenceBatch : public SequenceBatch {
   DirectSequenceBatch(
       SequenceBatchScheduler* base, const uint32_t batcher_idx,
       const size_t seq_slot_cnt, const ModelConfig& config,
-      Scheduler::StandardInitFunc OnInit,
-      Scheduler::StandardWarmupFunc OnWarmup,
-      Scheduler::StandardRunFunc OnSchedule,
+      const Scheduler::StandardInitFunc& OnInit,
+      const Scheduler::StandardWarmupFunc& OnWarmup,
+      const Scheduler::StandardRunFunc& OnSchedule,
       const std::shared_ptr<InferRequestProvider::InputOverrideMap>&
           start_input_overrides,
       const std::shared_ptr<InferRequestProvider::InputOverrideMap>&
@@ -309,9 +311,10 @@ class OldestSequenceBatch : public SequenceBatch {
   OldestSequenceBatch(
       SequenceBatchScheduler* base, const uint32_t batcher_idx,
       const size_t seq_slot_cnt, const ModelConfig& config,
-      Scheduler::StandardInitFunc OnInit,
-      Scheduler::StandardWarmupFunc OnWarmup,
-      Scheduler::StandardRunFunc OnSchedule,
+      const Scheduler::StandardInitFunc& OnInit,
+      const Scheduler::StandardWarmupFunc& OnWarmup,
+      const Scheduler::StandardRunFunc& OnSchedule,
+      const Scheduler::StandardShapeTensorPeekFunc& OnPeek,
       const std::shared_ptr<InferRequestProvider::InputOverrideMap>&
           start_input_overrides,
       const std::shared_ptr<InferRequestProvider::InputOverrideMap>&


### PR DESCRIPTION
These changes tests whether the shape binding corresponding to the input is a shape tensor and populates the configuration. It also use the shape values to deduce the batching hint and performs other validation on the applicability of selected profile.

The shape tensor configuration will be used to compute the correct expected byte sizes for these inputs. 

[**NOTE**: tanmayvv-trt7 is a branch based on r20.01]