### PR TITLE
Adding dynamic batcher tests for shape tensor I/O

### DIFF
--- a/qa/L0_trt_shape_tensors/test.sh
+++ b/qa/L0_trt_shape_tensors/test.sh
@@ -39,15 +39,20 @@ CLIENT_LOG="./client.log"
 INFER_TEST=trt_shape_tensor_test.py
 
 SERVER=/opt/tensorrtserver/bin/trtserver
-SERVER_ARGS=--model-repository=`pwd`/models
+SERVER_ARGS="--model-repository=`pwd`/models"
 SERVER_LOG="./inference_server.log"
 source ../common/util.sh
 
 rm -f $SERVER_LOG $CLIENT_LOG
+rm -fr *.serverlog
 rm -fr models && mkdir models
 cp -r /data/inferenceserver/${REPO_VERSION}/qa_identity_shapetensor_model_repository/* models/.
 
 RET=0
+
+# Must run on a single device or else the TRTSERVER_DELAY_SCHEDULER
+# can fail when the requests are distributed to multiple devices.
+export CUDA_VISIBLE_DEVICES=0
 
 run_server
 if [ "$SERVER_PID" == "0" ]; then
@@ -61,7 +66,9 @@ set +e
 # python unittest seems to swallow ImportError and still return 0
 # exit code. So need to explicitly check CLIENT_LOG to make sure
 # we see some running tests
-python $INFER_TEST >$CLIENT_LOG 2>&1
+
+# Sanity tests
+python $INFER_TEST InferShapeTensorTest.test_static_batch >$CLIENT_LOG 2>&1
 if [ $? -ne 0 ]; then
     cat $CLIENT_LOG
     echo -e "\n***\n*** Test Failed\n***"
@@ -75,10 +82,68 @@ if [ $? -ne 0 ]; then
     RET=1
 fi
 
+python $INFER_TEST InferShapeTensorTest.test_nobatch >$CLIENT_LOG 2>&1
+if [ $? -ne 0 ]; then
+    cat $CLIENT_LOG
+    echo -e "\n***\n*** Test Failed\n***"
+    RET=1
+fi
+
+grep -c "HTTP/1.1 200 OK" $CLIENT_LOG
+if [ $? -ne 0 ]; then
+    cat $CLIENT_LOG
+    echo -e "\n***\n*** Test Failed To Run\n***"
+    RET=1
+fi
+
+python $INFER_TEST InferShapeTensorTest.test_wrong_shape_values >$CLIENT_LOG 2>&1
+if [ $? -ne 0 ]; then
+    cat $CLIENT_LOG
+    echo -e "\n***\n*** Test Failed\n***"
+    RET=1
+fi
+
 set -e
 
 kill $SERVER_PID
 wait $SERVER_PID
+
+if [ $RET -eq 0 ]; then
+  echo -e "\n*** Sanity Test Passed*** \n"
+else
+  exit $RET
+fi
+
+# Prepare the config file for dynamic batching tests
+CONFIG_FILE="models/plan_zero_1_float32/config.pbtxt"
+sed -i "s/^max_batch_size:.*/max_batch_size: 8/" $CONFIG_FILE && \
+sed -i "s/^version_policy:.*/version_policy: { specific { versions: [1] }}/" $CONFIG_FILE && \
+                echo "dynamic_batching { preferred_batch_size: [ 2, 6 ], max_queue_delay_microseconds: 10000000 }" >> $CONFIG_FILE
+
+for i in \
+            test_multi_batch_different_shape_values \
+            test_multi_batch_same_shape_values; do
+        SERVER_LOG="./$i.serverlog"
+        run_server
+        if [ "$SERVER_PID" == "0" ]; then
+            echo -e "\n***\n*** Failed to start $SERVER\n***"
+            cat $SERVER_LOG
+            exit 1
+        fi
+
+        echo "Test: $i, $model_type" >>$CLIENT_LOG
+
+        set +e
+        python $INFER_TEST InferShapeTensorTest.$i >>$CLIENT_LOG 2>&1
+        if [ $? -ne 0 ]; then
+            echo -e "\n***\n*** Test Failed\n***"
+            RET=1
+        fi
+        set -e
+
+        kill $SERVER_PID
+        wait $SERVER_PID
+    done
 
 if [ $RET -eq 0 ]; then
   echo -e "\n***\n*** Test Passed\n***"

--- a/qa/L0_trt_shape_tensors/trt_shape_tensor_test.py
+++ b/qa/L0_trt_shape_tensors/trt_shape_tensor_test.py
@@ -33,20 +33,223 @@ import unittest
 import numpy as np
 import infer_util as iu
 import test_util as tu
+import time
+import threading
+import traceback
+
 from tensorrtserver.api import *
 import os
 
+TEST_SYSTEM_SHARED_MEMORY = bool(
+    int(os.environ.get('TEST_SYSTEM_SHARED_MEMORY', 0)))
+TEST_CUDA_SHARED_MEMORY = bool(int(os.environ.get('TEST_CUDA_SHARED_MEMORY',
+                                                  0)))
+
+_max_queue_delay_ms = 10000
+
+_deferred_exceptions_lock = threading.Lock()
+_deferred_exceptions = []
+
+
 class InferShapeTensorTest(unittest.TestCase):
 
+    def setUp(self):
+        global _deferred_exceptions
+        _deferred_exceptions = []
+
+    def add_deferred_exception(self, ex):
+        global _deferred_exceptions
+        with _deferred_exceptions_lock:
+            _deferred_exceptions.append(ex)
+
+    def check_deferred_exception(self):
+        # Just raise one of the exceptions...
+        with _deferred_exceptions_lock:
+            if len(_deferred_exceptions) > 0:
+                raise _deferred_exceptions[0]
+
+    def check_response(self,
+                       bs,
+                       thresholds,
+                       shape_values,
+                       dummy_input_shapes,
+                       shm_region_names=None,
+                       precreated_shm_regions=None,
+                       shm_suffix=""):
+        try:
+            start_ms = int(round(time.time() * 1000))
+
+            iu.infer_shape_tensor(self,
+                                  'plan',
+                                  bs,
+                                  np.float32,
+                                  shape_values,
+                                  dummy_input_shapes,
+                                  use_grpc=False,
+                                  use_streaming=False,
+                                  shm_suffix=shm_suffix)
+
+            end_ms = int(round(time.time() * 1000))
+
+            lt_ms = thresholds[0]
+            gt_ms = thresholds[1]
+            if lt_ms is not None:
+                self.assertTrue(
+                    (end_ms - start_ms) < lt_ms,
+                    "expected less than " + str(lt_ms) +
+                    "ms response time, got " + str(end_ms - start_ms) + " ms")
+            if gt_ms is not None:
+                self.assertTrue(
+                    (end_ms - start_ms) > gt_ms,
+                    "expected greater than " + str(gt_ms) +
+                    "ms response time, got " + str(end_ms - start_ms) + " ms")
+        except Exception as ex:
+            self.add_deferred_exception(ex)
+
+    def check_setup(self, url, protocol, model_name):
+        # Make sure test.sh set up the correct batcher settings
+        ctx = ServerStatusContext(url, protocol, model_name, True)
+        ss = ctx.get_server_status()
+        self.assertEqual(len(ss.model_status), 1)
+        self.assertTrue(model_name in ss.model_status,
+                        "expected status for model " + model_name)
+        bconfig = ss.model_status[model_name].config.dynamic_batching
+        self.assertTrue(2 in bconfig.preferred_batch_size)
+        self.assertTrue(6 in bconfig.preferred_batch_size)
+        self.assertEqual(bconfig.max_queue_delay_microseconds,
+                         _max_queue_delay_ms * 1000)  # 10 secs
+
+    def check_status(self, url, protocol, model_name, static_bs, exec_cnt,
+                     infer_cnt):
+        ctx = ServerStatusContext(url, protocol, model_name, True)
+        ss = ctx.get_server_status()
+        self.assertEqual(len(ss.model_status), 1)
+        self.assertTrue(model_name in ss.model_status,
+                        "expected status for model " + model_name)
+        vs = ss.model_status[model_name].version_status
+        self.assertEqual(len(vs), 1)
+        self.assertTrue(1 in vs, "expected status for version 1")
+        infer = vs[1].infer_stats
+        self.assertEqual(
+            len(infer), len(static_bs), "expected batch-sizes (" +
+            ",".join(str(b) for b in static_bs) + "), got " + str(vs[1]))
+        for b in static_bs:
+            self.assertTrue(
+                b in infer,
+                "expected batch-size " + str(b) + ", got " + str(vs[1]))
+        self.assertEqual(
+            vs[1].model_execution_count, exec_cnt,
+            "expected model-execution-count " + str(exec_cnt) + ", got " +
+            str(vs[1].model_execution_count))
+        self.assertEqual(
+            vs[1].model_inference_count, infer_cnt,
+            "expected model-inference-count " + str(infer_cnt) + ", got " +
+            str(vs[1].model_inference_count))
+
     def test_static_batch(self):
-        iu.infer_shape_tensor(self, 'plan', 8, np.float32, [[32,32]], [[4,4]])
-        iu.infer_shape_tensor(self, 'plan', 8, np.float32, [[4,4]], [[32,32]])
-        iu.infer_shape_tensor(self, 'plan', 8, np.float32, [[4,4]], [[4,4]])
+        iu.infer_shape_tensor(self, 'plan', 8, np.float32, [[32, 32]], [[4, 4]])
+        iu.infer_shape_tensor(self, 'plan', 8, np.float32, [[4, 4]], [[32, 32]])
+        iu.infer_shape_tensor(self, 'plan', 8, np.float32, [[4, 4]], [[4, 4]])
 
     def test_nobatch(self):
-        iu.infer_shape_tensor(self, 'plan_nobatch', 1, np.float32, [[32,32]], [[4,4]])
-        iu.infer_shape_tensor(self, 'plan_nobatch', 1, np.float32, [[4,4]], [[32,32]])
-        iu.infer_shape_tensor(self, 'plan_nobatch', 1, np.float32, [[4,4]], [[4,4]])
+        iu.infer_shape_tensor(self, 'plan_nobatch', 1, np.float32, [[32, 32]],
+                              [[4, 4]])
+        iu.infer_shape_tensor(self, 'plan_nobatch', 1, np.float32, [[4, 4]],
+                              [[32, 32]])
+        iu.infer_shape_tensor(self, 'plan_nobatch', 1, np.float32, [[4, 4]],
+                              [[4, 4]])
+
+    def test_wrong_shape_values(self):
+        over_shape_values = [[32, 33]]
+        try:
+            iu.infer_shape_tensor(self, 'plan', 8, np.float32,
+                                  over_shape_values, [[4, 4]])
+        except InferenceServerException as ex:
+            self.assertEqual("inference:0", ex.server_id())
+            self.assertTrue(
+                "The shape value at index 2 is expected to be in range from 1 to 32, Got: 33"
+                in ex.message())
+
+    # Dynamic Batcher tests
+    def test_multi_batch_different_shape_values(self):
+        # Send two requests with sum of static batch sizes ==
+        # preferred size, but with different shape values. This
+        # should cause the requests to not be batched. The first
+        # response will come back immediately and the second
+        # delayed by the max batch queue delay
+        try:
+            url = "localhost:8000"
+            protocol = ProtocolType.HTTP
+            model_name = tu.get_zero_model_name("plan", 1, np.float32)
+            self.check_setup(url, protocol, model_name)
+            self.assertFalse("TRTSERVER_DELAY_SCHEDULER" in os.environ)
+
+            threads = []
+            threads.append(
+                threading.Thread(target=self.check_response,
+                                 args=(3, (6000, None)),
+                                 kwargs={
+                                     'shape_values': [[2, 2]],
+                                     'dummy_input_shapes': [[16, 16]],
+                                     'shm_suffix': '{}'.format(len(threads))
+                                 }))
+            threads.append(
+                threading.Thread(target=self.check_response,
+                                 args=(3, (_max_queue_delay_ms * 1.5,
+                                           _max_queue_delay_ms)),
+                                 kwargs={
+                                     'shape_values': [[4, 4]],
+                                     'dummy_input_shapes': [[16, 16]],
+                                     'shm_suffix': '{}'.format(len(threads))
+                                 }))
+            threads[0].start()
+            time.sleep(1)
+            threads[1].start()
+            for t in threads:
+                t.join()
+            self.check_deferred_exception()
+            self.check_status(url, protocol, model_name, (3,), 2, 6)
+        except InferenceServerException as ex:
+            self.assertTrue(False, "unexpected error {}".format(ex))
+
+    def test_multi_batch_same_shape_values(self):
+        # Send two requests with sum of static batch sizes ==
+        # preferred size, but with identical shape values. This
+        # should cause the requests to get batched. Both
+        # responses should come back immediately.
+        try:
+            url = "localhost:8000"
+            protocol = ProtocolType.HTTP
+            model_name = tu.get_zero_model_name("plan", 1, np.float32)
+            self.check_setup(url, protocol, model_name)
+            self.assertFalse("TRTSERVER_DELAY_SCHEDULER" in os.environ)
+
+            threads = []
+            threads.append(
+                threading.Thread(target=self.check_response,
+                                 args=(4, (6000, None)),
+                                 kwargs={
+                                     'shape_values': [[4, 4]],
+                                     'dummy_input_shapes': [[16, 16]],
+                                     'shm_suffix': '{}'.format(len(threads))
+                                 }))
+            threads.append(
+                threading.Thread(target=self.check_response,
+                                 args=(2, (6000, None)),
+                                 kwargs={
+                                     'shape_values': [[4, 4]],
+                                     'dummy_input_shapes': [[16, 16]],
+                                     'shm_suffix': '{}'.format(len(threads))
+                                 }))
+            threads[0].start()
+            time.sleep(1)
+            threads[1].start()
+            for t in threads:
+                t.join()
+            self.check_deferred_exception()
+            self.check_status(url, protocol, model_name, (4, 2), 1, 6)
+        except InferenceServerException as ex:
+            self.assertTrue(False, "unexpected error {}".format(ex))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The payloads with identical values should be batched together. These tests are meant for the same.