### PR TITLE
Update to new Nvidia docker command

### DIFF
--- a/qa/common/gen_qa_custom_ops
+++ b/qa/common/gen_qa_custom_ops
@@ -100,7 +100,7 @@ if [ $? -ne 0 ]; then
 fi
 
 docker pull $TENSORFLOW_IMAGE
-nvidia-docker run --rm --entrypoint $SRCDIR/$TFSCRIPT \
+docker run --gpus=1 --rm --entrypoint $SRCDIR/$TFSCRIPT \
        --mount type=bind,source=$HOST_SRCDIR,target=$SRCDIR \
        --mount type=bind,source=$HOST_DESTDIR,target=$DESTDIR \
        $TENSORFLOW_IMAGE

--- a/qa/common/gen_qa_model_repository
+++ b/qa/common/gen_qa_model_repository
@@ -155,7 +155,7 @@ if [ $? -ne 0 ]; then
 fi
 
 docker pull $PYTORCH_IMAGE
-nvidia-docker run --rm --entrypoint $SRCDIR/$C2SCRIPT \
+docker run --gpus=1 --rm --entrypoint $SRCDIR/$C2SCRIPT \
        --mount type=bind,source=$HOST_SRCDIR,target=$SRCDIR \
        --mount type=bind,source=$HOST_DESTDIR,target=$DESTDIR \
        --mount type=bind,source=$HOST_VARDESTDIR,target=$VARDESTDIR \
@@ -208,7 +208,7 @@ if [ $? -ne 0 ]; then
 fi
 
 docker pull $TENSORFLOW_IMAGE
-nvidia-docker run --rm --entrypoint $SRCDIR/$TFSCRIPT \
+docker run --gpus=1 --rm --entrypoint $SRCDIR/$TFSCRIPT \
        --mount type=bind,source=$HOST_SRCDIR,target=$SRCDIR \
        --mount type=bind,source=$HOST_DESTDIR,target=$DESTDIR \
        --mount type=bind,source=$HOST_VARDESTDIR,target=$VARDESTDIR \
@@ -262,7 +262,7 @@ if [ $? -ne 0 ]; then
 fi
 
 docker pull $TENSORRT_IMAGE
-nvidia-docker run --rm --entrypoint $SRCDIR/$TRTSCRIPT \
+docker run --gpus=1 --rm --entrypoint $SRCDIR/$TRTSCRIPT \
        --mount type=bind,source=$HOST_SRCDIR,target=$SRCDIR \
        --mount type=bind,source=$HOST_DESTDIR,target=$DESTDIR \
        --mount type=bind,source=$HOST_VARDESTDIR,target=$VARDESTDIR \


### PR DESCRIPTION
The latest nvidia-docker no longer uses `nvidia-docker`. The standard way is to call `docker run --gpus=#` where `#` is the number of GPUs. This change updates the model generation scripts to use the correct nvidia docker command.