### PR TITLE
Fix custom backend to set input tensor shape correctly for each payload.

### DIFF
--- a/qa/L0_sequence_batcher/sequence_batcher_test.py
+++ b/qa/L0_sequence_batcher/sequence_batcher_test.py
@@ -625,7 +625,9 @@ class SequenceBatcherTest(su.SequenceBatcherTestUtil):
             return
 
         # Ragged batch only allowed for custom backend
-        for trial in ("custom",):
+        if "custom" in _trials:
+            trial = "custom"
+
             self.clear_deferred_exceptions()
             dtype = self.get_datatype(trial)
             precreated_shm0_handles = self.precreate_register_regions((1,2,3), dtype, 0,

--- a/qa/L0_sequence_batcher/test.sh
+++ b/qa/L0_sequence_batcher/test.sh
@@ -195,6 +195,7 @@ for model_trial in v 0 1 2 4; do
             test_half_batch \
             test_skip_batch \
             test_full_batch \
+            test_ragged_batch \
             test_backlog ; do
         export TRTSERVER_BACKLOG_DELAY_SCHEDULER=3 &&
             [[ "$i" != "test_backlog_fill_no_end" ]] && export TRTSERVER_BACKLOG_DELAY_SCHEDULER=2 &&

--- a/qa/common/sequence_util.py
+++ b/qa/common/sequence_util.py
@@ -104,7 +104,7 @@ class SequenceBatcherTestUtil(unittest.TestCase):
                     if dtype == np.object:
                         output_byte_size = 4 # size of empty string
                     else:
-                        output_byte_size = np.dtype(dtype).itemsize
+                        output_byte_size = 0
 
                     # create data
                     input_list = list()
@@ -116,6 +116,7 @@ class SequenceBatcherTestUtil(unittest.TestCase):
                             output_byte_size += 64 * in0.size
                         else:
                             in0 = np.full(tensor_shape, value, dtype=dtype)
+                            output_byte_size += np.dtype(dtype).itemsize * in0.size
                         input_list.append(in0)
 
                     input_list_tmp = iu._prepend_string_size(input_list) if (dtype == np.object) else input_list

--- a/qa/common/sequence_util.py
+++ b/qa/common/sequence_util.py
@@ -85,31 +85,41 @@ class SequenceBatcherTestUtil(unittest.TestCase):
     def check_failure(self):
         # Check securely whether a failure has been registered
         # This is generic because the failure behavior is undefined
-        # for rugged batches. 
+        # for rugged batches.
         with _deferred_exceptions_lock:
             if len(_deferred_exceptions) == 0:
                 raise Exception("Unexpected inference success")
 
-    def precreate_register_regions(self, value_list, dtype, i, batch_size=1, model_type="normal"):
+    def precreate_register_regions(self, value_list, dtype, i, batch_size=1,
+                                   model_type="normal",tensor_shape=(1,)):
         if _test_system_shared_memory or _test_cuda_shared_memory:
-            shared_memory_ctx = SharedMemoryControlContext("localhost:8000",  ProtocolType.HTTP, verbose=True)
+            shared_memory_ctx = SharedMemoryControlContext("localhost:8000",
+                                                           ProtocolType.HTTP, verbose=True)
             shm_region_handles = []
             if model_type == "normal":
                 for j, value in enumerate(value_list):
+                    # For string we can't know the size of the output
+                    # so we conservatively assume 64 bytes for each
+                    # element of the output
+                    if dtype == np.object:
+                        output_byte_size = 4 # size of empty string
+                    else:
+                        output_byte_size = np.dtype(dtype).itemsize
+
                     # create data
                     input_list = list()
                     for b in range(batch_size):
                         if dtype == np.object:
-                            in0 = np.full((1,), value, dtype=np.int32)
+                            in0 = np.full(tensor_shape, value, dtype=np.int32)
                             in0n = np.array([str(x) for x in in0.reshape(in0.size)], dtype=object)
-                            in0 = in0n.reshape((1,))
+                            in0 = in0n.reshape(tensor_shape)
+                            output_byte_size += 64 * in0.size
                         else:
-                            in0 = np.full((1,), value, dtype=dtype)
+                            in0 = np.full(tensor_shape, value, dtype=dtype)
                         input_list.append(in0)
 
                     input_list_tmp = iu._prepend_string_size(input_list) if (dtype == np.object) else input_list
                     input_byte_size = sum([i0.nbytes for i0 in input_list_tmp])
-                    output_byte_size = np.dtype(dtype).itemsize + 2
 
                     # create shared memory regions and copy data for input values
                     if _test_system_shared_memory:
@@ -138,16 +148,16 @@ class SequenceBatcherTestUtil(unittest.TestCase):
 
                     for b in range(batch_size):
                         if dtype == np.object:
-                            in0 = np.full((1,), value, dtype=np.int32)
+                            in0 = np.full(tensor_shape, value, dtype=np.int32)
                             in0n = np.array([str(x) for x in in0.reshape(in0.size)], dtype=object)
-                            in0 = in0n.reshape(1,)
+                            in0 = in0n.reshape(tensor_shape)
                         else:
-                            in0 = np.full((1,), value, dtype=dtype)
+                            in0 = np.full(tensor_shape, value, dtype=dtype)
                         input_list.append(in0)
 
                     # Only one shape tensor input per batch
-                    shape_input_list.append(np.full((1,), shape_value, dtype=np.int32))
-                
+                    shape_input_list.append(np.full(tensor_shape, shape_value, dtype=np.int32))
+
                     input_list_tmp = iu._prepend_string_size(input_list) if (dtype == np.object) else input_list
                     input_byte_size = sum([i0.nbytes for i0 in input_list_tmp])
                     shape_input_byte_size = sum([i0.nbytes for i0 in shape_input_list])
@@ -206,18 +216,18 @@ class SequenceBatcherTestUtil(unittest.TestCase):
 
                     for b in range(batch_size):
                         if dtype == np.object:
-                            dummy_in0 = np.full((1,), value, dtype=np.int32)
+                            dummy_in0 = np.full(tensor_shape, value, dtype=np.int32)
                             dummy_in0n = np.array([str(x) for x in dummy_in0.reshape(in0.size)], dtype=object)
-                            dummy_in0 = in0n.reshape(1,)
+                            dummy_in0 = in0n.reshape(tensor_shape)
                         else:
-                            dummy_in0 = np.full((1,), value, dtype=dtype)
+                            dummy_in0 = np.full(tensor_shape, value, dtype=dtype)
                         dummy_input_list.append(dummy_in0)
-                        in0 =  np.full((1,), value, dtype=np.int32)
+                        in0 =  np.full(tensor_shape, value, dtype=np.int32)
                         input_list.append(in0)
 
                     # Only one shape tensor input per batch
-                    shape_input_list.append(np.full((1,), shape_value, dtype=np.int32))
-                
+                    shape_input_list.append(np.full(tensor_shape, shape_value, dtype=np.int32))
+
                     input_list_tmp = iu._prepend_string_size(input_list) if (dtype == np.object) else input_list
                     input_byte_size = sum([i0.nbytes for i0 in input_list_tmp])
                     shape_input_byte_size = sum([i0.nbytes for i0 in shape_input_list])
@@ -295,19 +305,17 @@ class SequenceBatcherTestUtil(unittest.TestCase):
 
     def check_sequence(self, trial, model_name, input_dtype, correlation_id,
                        sequence_thresholds, values, expected_result,
-                       protocol, batch_size=1, sequence_name="<unknown>"):
+                       protocol, batch_size=1, sequence_name="<unknown>", tensor_shape=(1,)):
         """Perform sequence of inferences. The 'values' holds a list of
         tuples, one for each inference with format:
 
         (flag_str, value, (ls_ms, gt_ms), (pre_delay_ms, post_delay_ms)
 
         """
-        if (("savedmodel" in trial) or ("graphdef" in trial) or
-            ("netdef" in trial) or ("custom" in trial) or
-            ("onnx" in trial) or ("libtorch" in trial) or
-	        ("plan" in trial)):
-            tensor_shape = (1,)
-        else:
+        if (("savedmodel" not in trial) and ("graphdef" not in trial) and
+            ("netdef" not in trial) and ("custom" not in trial) and
+            ("onnx" not in trial) and ("libtorch" not in trial) and
+	    ("plan" not in trial)):
             self.assertFalse(True, "unknown trial type: " + trial)
 
         # Can only send the request exactly once since it is a
@@ -327,7 +335,8 @@ class SequenceBatcherTestUtil(unittest.TestCase):
 
         # create and register shared memory output region in advance
         if _test_system_shared_memory or _test_cuda_shared_memory:
-            shared_memory_ctx = SharedMemoryControlContext("localhost:8000",  ProtocolType.HTTP, verbose=True)
+            shared_memory_ctx = SharedMemoryControlContext("localhost:8000",
+                                                           ProtocolType.HTTP, verbose=True)
             output_byte_size = 512
             if _test_system_shared_memory:
                 shm_op_handle = shm.create_shared_memory_region("output_data", "/output", output_byte_size)
@@ -448,19 +457,18 @@ class SequenceBatcherTestUtil(unittest.TestCase):
 
     def check_sequence_async(self, trial, model_name, input_dtype, correlation_id,
                              sequence_thresholds, values, expected_result,
-                             protocol, shm_region_handles, batch_size=1, sequence_name="<unknown>"):
+                             protocol, shm_region_handles, batch_size=1,
+                             sequence_name="<unknown>", tensor_shape=(1,)):
         """Perform sequence of inferences using async run. The 'values' holds
         a list of tuples, one for each inference with format:
 
         (flag_str, value, pre_delay_ms)
 
         """
-        if (("savedmodel" in trial) or ("graphdef" in trial) or
-            ("netdef" in trial) or ("custom" in trial) or
-            ("onnx" in trial) or ("libtorch" in trial) or
-            ("plan" in trial)):
-            tensor_shape = (1,)
-        else:
+        if (("savedmodel" not in trial) and ("graphdef" not in trial) and
+            ("netdef" not in trial) and ("custom" not in trial) and
+            ("onnx" not in trial) and ("libtorch" not in trial) and
+	    ("plan" not in trial)):
             self.assertFalse(True, "unknown trial type: " + trial)
 
         self.assertFalse(_test_system_shared_memory and _test_cuda_shared_memory,
@@ -600,7 +608,7 @@ class SequenceBatcherTestUtil(unittest.TestCase):
                             flags = flags | InferRequestHeader.FLAG_SEQUENCE_START
                         if "end" in flag_str:
                             flags = flags | InferRequestHeader.FLAG_SEQUENCE_END
-                    
+
                     shape_values.append(np.full(tensor_shape, shape_value, dtype=np.int32))
                     if not (_test_system_shared_memory or _test_cuda_shared_memory):
                         input_list = list()
@@ -627,7 +635,7 @@ class SequenceBatcherTestUtil(unittest.TestCase):
                                 else:
                                     in0 = np.full(tensor_shape, value, dtype=input_dtype)
                                 input_list.append(in0)
-                            
+
 
                         input_info = input_list
                         dummy_input_info = dummy_input_list
@@ -707,7 +715,7 @@ class SequenceBatcherTestUtil(unittest.TestCase):
                                         "ms response time, got " + str(seq_end_ms - seq_start_ms) + " ms")
             except Exception as ex:
                 self.add_deferred_exception(ex)
-    
+
     def check_setup(self, model_name):
         # Make sure test.sh set up the correct batcher settings
         ctx = ServerStatusContext("localhost:8000", ProtocolType.HTTP, model_name, True)

--- a/qa/custom_models/custom_sequence_int32/config.pbtxt
+++ b/qa/custom_models/custom_sequence_int32/config.pbtxt
@@ -55,14 +55,14 @@ input [
   {
     name: "INPUT"
     data_type: TYPE_INT32
-    dims: [ 1 ]
+    dims: [ -1 ]
   }
 ]
 output [
   {
     name: "OUTPUT"
     data_type: TYPE_INT32
-    dims: [ 1 ]
+    dims: [ -1 ]
   }
 ]
 parameters [

--- a/src/backends/custom/custom_backend.cc
+++ b/src/backends/custom/custom_backend.cc
@@ -613,21 +613,14 @@ CustomBackend::Context::GetOutput(
         name, content, content_byte_size, shape,
         ToTRTServerMemoryType(*memory_type), *memory_type_id,
         &actual_memory_type, &actual_memory_type_id);
-
-    // Done with this output if 'content_byte_size' is 0
-    if (content_byte_size == 0) {
-      *content = nullptr;
-    } else if (*content == nullptr) {
+    if (!status.IsOk()) {
+      LOG_VERBOSE(1) << status.AsString();
       return false;
     }
 
     // Update memory type with actual memory type
     *memory_type = ToCustomMemoryType(actual_memory_type);
     *memory_type_id = actual_memory_type_id;
-
-    if (!status.IsOk()) {
-      LOG_VERBOSE(1) << status.AsString();
-    }
 
     return status.IsOk();
   }

--- a/src/backends/custom/custom_backend.h
+++ b/src/backends/custom/custom_backend.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2020, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -146,6 +146,13 @@ class CustomBackend : public InferenceBackend {
 
     // The version of the custom interface.
     int custom_version_;
+
+    // The shape for input tensors that have fixed size. These are
+    // collected at init time as a performance optimization. Input
+    // tensors with variable size must have their shape determine for
+    // each inference request and so are not included here.
+    std::unordered_map<std::string, std::unique_ptr<std::vector<int64_t>>>
+        fixed_input_shapes_;
   };
 
   std::vector<std::string> server_params_;

--- a/src/clients/python/shared_memory/__init__.py
+++ b/src/clients/python/shared_memory/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2019-2020, NVIDIA CORPORATION. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -150,8 +150,7 @@ def create_shared_memory_region(trtis_shm_name, shm_key, byte_size):
     return shm_handle
 
 def set_shared_memory_region(shm_handle, input_values):
-    """Copy the contents of the numpy array into a shared memory region with
-    the specified identifier, offset and size.
+    """Copy the contents of the numpy array into a shared memory region.
 
     Parameters
     ----------
@@ -167,10 +166,10 @@ def set_shared_memory_region(shm_handle, input_values):
     """
 
     if not isinstance(input_values, (list,tuple)):
-        _raise_error("input_values must be specified as a numpy array")
+        _raise_error("input_values must be specified as a list/tuple of numpy arrays")
     for input_value in input_values:
-        if not isinstance(input_value, (np.ndarray,)):
-            _raise_error("input_values must be specified as a list/tuple of numpy arrays")
+        if not isinstance(input_value, np.ndarray):
+            _raise_error("each element of input_values must be a numpy array")
 
     offset_current = 0
     for input_value in input_values:

--- a/src/core/provider_utils.cc
+++ b/src/core/provider_utils.cc
@@ -91,9 +91,9 @@ NormalizeRequestHeader(
       }
 
       // If there is a reshape for this input then clear the dims and
-      // set them to the reshape. As reshape may have variable-size dimensions,
-      // we need to record corresponding value
-      // so that we can set the value correctly for reshape.
+      // set them to the reshape. As reshape may have variable-size
+      // dimensions, we need to record corresponding value so that we
+      // can set the value correctly for reshape.
       if (input_config->has_reshape()) {
         std::deque<int64_t> variable_size_values;
         for (int64_t idx = 0; idx < input_config->dims_size(); idx++) {


### PR DESCRIPTION
Required to support ragged batches in custom backends. Each payload's
input tensors can have a different shape.