### PR TITLE
Add memory type CPU_PINNED

### DIFF
--- a/src/backends/caffe2/netdef_backend.cc
+++ b/src/backends/caffe2/netdef_backend.cc
@@ -347,14 +347,16 @@ NetDefBackend::Context::SetFixedSizedInputTensor(
     const std::string& name, const std::vector<int64_t>& shape,
     const Caffe2Workspace::DataType dtype, const size_t batch1_byte_size,
     const size_t total_byte_size, std::vector<Scheduler::Payload>* payloads,
-    std::vector<std::unique_ptr<char[]>>* input_buffers, bool* cuda_copy)
+    std::vector<AllocatedSystemMemory>* input_buffers, bool* cuda_copy)
 {
   // The entire input tensor must be delivered as a single
   // contiguous chunk so create a buffer large enough to hold the
   // entire dynamic batched input.
-  input_buffers->emplace_back(new char[total_byte_size]);
-  char* buffer = input_buffers->back().get();
-  constexpr auto buffer_memory_type = TRTSERVER_MEMORY_CPU;
+  input_buffers->emplace_back(total_byte_size, TRTSERVER_MEMORY_CPU_PINNED, 0);
+  TRTSERVER_Memory_Type buffer_memory_type;
+  int64_t buffer_memory_id;
+  char* buffer = input_buffers->back().MutableBuffer(
+      &buffer_memory_type, &buffer_memory_id);
 
   // Visit the payloads in order and copy the input tensors to
   // 'buffer'.
@@ -367,7 +369,8 @@ NetDefBackend::Context::SetFixedSizedInputTensor(
   }
 
   *cuda_copy |= SetInputBuffer(
-      name, expected_byte_sizes, payloads, buffer_memory_type, 0, buffer);
+      name, expected_byte_sizes, payloads, buffer_memory_type, buffer_memory_id,
+      buffer);
 
   Caffe2Workspace::Error err = workspace_->SetInputTensor(
       name, shape, dtype, static_cast<const char*>(buffer), total_byte_size);
@@ -439,7 +442,7 @@ Status
 NetDefBackend::Context::SetInput(
     const std::string& name, const DataType datatype, const DimsList& dims,
     const size_t total_batch_size, std::vector<Scheduler::Payload>* payloads,
-    std::vector<std::unique_ptr<char[]>>* input_buffers, bool* cuda_copy)
+    std::vector<AllocatedSystemMemory>* input_buffers, bool* cuda_copy)
 {
   // Get the shape of the input. The provider has already checked that
   // the request shape is valid so don't need to do it here.
@@ -516,7 +519,7 @@ NetDefBackend::Context::Run(
 
   // Hold reference to each buffer of input data to that it stays
   // until the inference has completed.
-  std::vector<std::unique_ptr<char[]>> input_buffers;
+  std::vector<AllocatedSystemMemory> input_buffers;
 
   // Create a tensor for each input sized correctly for the total
   // payload batch size. Concatenate input values from each payload

--- a/src/backends/caffe2/netdef_backend.cc
+++ b/src/backends/caffe2/netdef_backend.cc
@@ -354,6 +354,7 @@ NetDefBackend::Context::SetFixedSizedInputTensor(
   // entire dynamic batched input.
   input_buffers->emplace_back(new char[total_byte_size]);
   char* buffer = input_buffers->back().get();
+  constexpr auto buffer_memory_type = TRTSERVER_MEMORY_CPU;
 
   // Visit the payloads in order and copy the input tensors to
   // 'buffer'.
@@ -366,7 +367,7 @@ NetDefBackend::Context::SetFixedSizedInputTensor(
   }
 
   *cuda_copy |= SetInputBuffer(
-      name, expected_byte_sizes, payloads, TRTSERVER_MEMORY_CPU, 0, buffer);
+      name, expected_byte_sizes, payloads, buffer_memory_type, 0, buffer);
 
   Caffe2Workspace::Error err = workspace_->SetInputTensor(
       name, shape, dtype, static_cast<const char*>(buffer), total_byte_size);

--- a/src/backends/caffe2/netdef_backend.h
+++ b/src/backends/caffe2/netdef_backend.h
@@ -25,6 +25,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
+#include <memory>
 #include "src/backends/caffe2/netdef_backend_c2.h"
 #include "src/core/backend.h"
 #include "src/core/backend_context.h"
@@ -79,7 +80,8 @@ class NetDefBackend : public InferenceBackend {
         const std::string& name, const DataType datatype, const DimsList& dims,
         const size_t total_batch_size,
         std::vector<Scheduler::Payload>* payloads,
-        std::vector<AllocatedSystemMemory>* input_buffers, bool* cuda_copy);
+        std::vector<std::unique_ptr<AllocatedSystemMemory>>* input_buffers,
+        bool* cuda_copy);
 
     // See BackendContext::Run()
     Status Run(
@@ -91,7 +93,8 @@ class NetDefBackend : public InferenceBackend {
         const std::string& input_name, const std::vector<int64_t>& shape,
         const Caffe2Workspace::DataType dtype, const size_t batch1_byte_size,
         const size_t total_byte_size, std::vector<Scheduler::Payload>* payloads,
-        std::vector<AllocatedSystemMemory>* input_buffers, bool* cuda_copy);
+        std::vector<std::unique_ptr<AllocatedSystemMemory>>* input_buffers,
+        bool* cuda_copy);
 
     // Read an output tensor into one or more payloads.
     Status ReadFixedSizedOutputTensor(

--- a/src/backends/caffe2/netdef_backend.h
+++ b/src/backends/caffe2/netdef_backend.h
@@ -79,7 +79,7 @@ class NetDefBackend : public InferenceBackend {
         const std::string& name, const DataType datatype, const DimsList& dims,
         const size_t total_batch_size,
         std::vector<Scheduler::Payload>* payloads,
-        std::vector<std::unique_ptr<char[]>>* input_buffers, bool* cuda_copy);
+        std::vector<AllocatedSystemMemory>* input_buffers, bool* cuda_copy);
 
     // See BackendContext::Run()
     Status Run(
@@ -91,7 +91,7 @@ class NetDefBackend : public InferenceBackend {
         const std::string& input_name, const std::vector<int64_t>& shape,
         const Caffe2Workspace::DataType dtype, const size_t batch1_byte_size,
         const size_t total_byte_size, std::vector<Scheduler::Payload>* payloads,
-        std::vector<std::unique_ptr<char[]>>* input_buffers, bool* cuda_copy);
+        std::vector<AllocatedSystemMemory>* input_buffers, bool* cuda_copy);
 
     // Read an output tensor into one or more payloads.
     Status ReadFixedSizedOutputTensor(

--- a/src/backends/custom/custom.h
+++ b/src/backends/custom/custom.h
@@ -54,7 +54,8 @@ extern "C" {
 /// Types of memory recognized by TRTSERVER and custom backend.
 typedef enum custom_memorytype_enum {
   CUSTOM_MEMORY_CPU,
-  CUSTOM_MEMORY_GPU
+  CUSTOM_MEMORY_GPU,
+  CUSTOM_MEMORY_CPU_PINNED
 } CustomMemoryType;
 
 /// The server parameter values provided to custom backends. New

--- a/src/backends/custom/custom_backend.cc
+++ b/src/backends/custom/custom_backend.cc
@@ -47,6 +47,8 @@ ToCustomMemoryType(TRTSERVER_Memory_Type memory_type)
   switch (memory_type) {
     case TRTSERVER_MEMORY_GPU:
       return CUSTOM_MEMORY_GPU;
+    case TRTSERVER_MEMORY_CPU_PINNED:
+      return CUSTOM_MEMORY_CPU_PINNED;
     default:
       break;
   }
@@ -59,6 +61,8 @@ ToTRTServerMemoryType(CustomMemoryType memory_type)
   switch (memory_type) {
     case CUSTOM_MEMORY_GPU:
       return TRTSERVER_MEMORY_GPU;
+    case CUSTOM_MEMORY_CPU_PINNED:
+      return TRTSERVER_MEMORY_CPU_PINNED;
     default:
       break;
   }

--- a/src/backends/onnx/onnx_backend.cc
+++ b/src/backends/onnx/onnx_backend.cc
@@ -697,10 +697,11 @@ OnnxBackend::Context::SetInputTensor(
       total_byte_size + ((data_type != TYPE_STRING) ? 0 : 1);
   input_buffers->back().reset((new char[buffer_size]));
   char* buffer = input_buffers->back().get();
+  constexpr auto buffer_memory_type = TRTSERVER_MEMORY_CPU;
 
   // Store data into input buffer
   SetInputBuffer(
-      name, expected_byte_sizes, payloads, TRTSERVER_MEMORY_CPU, 0, buffer);
+      name, expected_byte_sizes, payloads, buffer_memory_type, 0, buffer);
 
   if (data_type != TYPE_STRING) {
     const OrtMemoryInfo* allocator_info;
@@ -921,7 +922,7 @@ OnnxBackend::Context::SetStringOutputBuffer(
           data_byte_size + sizeof(uint32_t) * expected_element_cnt;
 
       void* buffer;
-      TRTSERVER_Memory_Type preferred_memory_type = TRTSERVER_MEMORY_CPU;
+      TRTSERVER_Memory_Type preferred_memory_type = TRTSERVER_MEMORY_CPU_PINNED;
       TRTSERVER_Memory_Type actual_memory_type;
       int64_t actual_memory_type_id;
       Status status = payload.response_provider_->AllocateOutputBuffer(

--- a/src/backends/onnx/onnx_backend.h
+++ b/src/backends/onnx/onnx_backend.h
@@ -96,7 +96,7 @@ class OnnxBackend : public InferenceBackend {
         const std::string& name, const DataType data_type, const DimsList& dims,
         size_t total_batch_size, std::vector<Scheduler::Payload>* payloads,
         std::vector<std::unique_ptr<AllocatedSystemMemory>>* input_buffers,
-        std::vector<const char*>* input_names);
+        std::vector<const char*>* input_names, bool* cuda_used);
 
     // Helper function to modify 'input_buffer' into format needed for creating
     // Onnx String tensor and to set meta data 'string_data'

--- a/src/backends/onnx/onnx_backend.h
+++ b/src/backends/onnx/onnx_backend.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <onnxruntime_c_api.h>
+#include <memory>
 #include "src/core/backend.h"
 #include "src/core/backend_context.h"
 #include "src/core/model_config.pb.h"
@@ -94,7 +95,7 @@ class OnnxBackend : public InferenceBackend {
     Status SetInputTensor(
         const std::string& name, const DataType data_type, const DimsList& dims,
         size_t total_batch_size, std::vector<Scheduler::Payload>* payloads,
-        std::vector<AllocatedSystemMemory>* input_buffers,
+        std::vector<std::unique_ptr<AllocatedSystemMemory>>* input_buffers,
         std::vector<const char*>* input_names);
 
     // Helper function to modify 'input_buffer' into format needed for creating

--- a/src/backends/onnx/onnx_backend.h
+++ b/src/backends/onnx/onnx_backend.h
@@ -94,7 +94,7 @@ class OnnxBackend : public InferenceBackend {
     Status SetInputTensor(
         const std::string& name, const DataType data_type, const DimsList& dims,
         size_t total_batch_size, std::vector<Scheduler::Payload>* payloads,
-        std::vector<std::unique_ptr<char[]>>* input_buffers,
+        std::vector<AllocatedSystemMemory>* input_buffers,
         std::vector<const char*>* input_names);
 
     // Helper function to modify 'input_buffer' into format needed for creating

--- a/src/backends/pytorch/libtorch_backend.cc
+++ b/src/backends/pytorch/libtorch_backend.cc
@@ -349,9 +349,9 @@ LibTorchBackend::Context::SetInputTensor(
       meta_data.input_buffer_->MutableBuffer(&memory_type, &memory_type_id);
 
   torch::TensorOptions options{meta_data.torch_type_};
-  auto updated_options = (memory_type == TRTSERVER_MEMORY_CPU)
-                             ? options.device(torch::kCPU)
-                             : options.device(torch::kCUDA, memory_type_id);
+  auto updated_options = (memory_type == TRTSERVER_MEMORY_GPU)
+                             ? options.device(torch::kCUDA, memory_type_id)
+                             : options.device(torch::kCPU);
   torch::Tensor input_tensor =
       torch::from_blob(buffer, meta_data.shape_, updated_options);
 
@@ -506,8 +506,9 @@ LibTorchBackend::Context::SetFixedSizedInputBuffer(
   // The entire input tensor must be delivered as a single
   // contiguous chunk so create a buffer large enough to hold the
   // entire dynamic batched input.
-  auto memory_type = (gpu_device_ == NO_GPU_DEVICE) ? TRTSERVER_MEMORY_CPU
-                                                    : TRTSERVER_MEMORY_GPU;
+  auto memory_type = (gpu_device_ == NO_GPU_DEVICE)
+                         ? TRTSERVER_MEMORY_CPU_PINNED
+                         : TRTSERVER_MEMORY_GPU;
   int64_t memory_type_id = (gpu_device_ == NO_GPU_DEVICE) ? 0 : gpu_device_;
   meta_data->input_buffer_.reset(
       new AllocatedSystemMemory(total_byte_size, memory_type, memory_type_id));

--- a/src/backends/tensorflow/base_backend.cc
+++ b/src/backends/tensorflow/base_backend.cc
@@ -467,7 +467,7 @@ BaseBackend::Context::SetStringInputTensor(
 
     // For string data type, we always need to copy the data to CPU so that
     // we can read string length and construct the string properly.
-    auto buffer_memory_type = TRTSERVER_MEMORY_CPU;
+    auto buffer_memory_type = TRTSERVER_MEMORY_CPU_PINNED;
     int64_t buffer_memory_type_id = 0;
     const char* content;
     size_t content_byte_size = expected_element_cnt * sizeof(uint32_t);
@@ -613,7 +613,7 @@ BaseBackend::Context::ReadStringOutputTensor(
       if (status.IsOk()) {
         bool cuda_used = false;
         status = CopyBuffer(
-            output_name, TRTSERVER_MEMORY_CPU_PINNED /* src_memory_type */,
+            output_name, TRTSERVER_MEMORY_CPU /* src_memory_type */,
             0 /* src_memory_type_id */, actual_memory_type,
             actual_memory_type_id, serialized.size(),
             reinterpret_cast<const void*>(serialized.c_str()), content, stream_,

--- a/src/backends/tensorflow/base_backend.cc
+++ b/src/backends/tensorflow/base_backend.cc
@@ -467,16 +467,16 @@ BaseBackend::Context::SetStringInputTensor(
 
     // For string data type, we always need to copy the data to CPU so that
     // we can read string length and construct the string properly.
-    auto src_memory_type = TRTSERVER_MEMORY_CPU;
-    int64_t src_memory_type_id = 0;
+    auto buffer_memory_type = TRTSERVER_MEMORY_CPU;
+    int64_t buffer_memory_type_id = 0;
     const char* content;
     size_t content_byte_size = expected_element_cnt * sizeof(uint32_t);
     // If contiguous buffer is created, it needs to live until tensor is filled
     std::unique_ptr<AllocatedSystemMemory> contiguous_buffer;
     bool cuda_copy = false;
     payload.status_ = GetContiguousInputContent(
-        input_name, src_memory_type, src_memory_type_id, payload, &content,
-        &content_byte_size, &contiguous_buffer, &cuda_copy);
+        input_name, buffer_memory_type, buffer_memory_type_id, payload,
+        &content, &content_byte_size, &contiguous_buffer, &cuda_copy);
 
     if (!payload.status_.IsOk()) {
       FillStringTensor(
@@ -607,13 +607,13 @@ BaseBackend::Context::ReadStringOutputTensor(
       int64_t actual_memory_type_id;
       Status status = payload.response_provider_->AllocateOutputBuffer(
           output_name, &content, serialized.size(), shape,
-          TRTSERVER_MEMORY_CPU /* preferred_memory_type */,
+          TRTSERVER_MEMORY_CPU_PINNED /* preferred_memory_type */,
           0 /* preferred_memory_type_id */, &actual_memory_type,
           &actual_memory_type_id);
       if (status.IsOk()) {
         bool cuda_used = false;
         status = CopyBuffer(
-            output_name, TRTSERVER_MEMORY_CPU /* src_memory_type */,
+            output_name, TRTSERVER_MEMORY_CPU_PINNED /* src_memory_type */,
             0 /* src_memory_type_id */, actual_memory_type,
             actual_memory_type_id, serialized.size(),
             reinterpret_cast<const void*>(serialized.c_str()), content, stream_,

--- a/src/core/backend.cc
+++ b/src/core/backend.cc
@@ -321,13 +321,13 @@ InferenceBackend::GenerateWarmupData(std::vector<WarmupData>* samples)
     TRTSERVER_Memory_Type type;
     int64_t type_id;
     warmup_data.zero_data_.reset(new AllocatedSystemMemory(
-        max_zero_byte_size, TRTSERVER_MEMORY_CPU /* memory_type */,
+        max_zero_byte_size, TRTSERVER_MEMORY_CPU_PINNED /* memory_type */,
         0 /* memory_type_id */));
     char* zero_buffer = warmup_data.zero_data_->MutableBuffer(&type, &type_id);
     memset(zero_buffer, 0, max_zero_byte_size);
 
     warmup_data.random_data_.reset(new AllocatedSystemMemory(
-        max_random_byte_size, TRTSERVER_MEMORY_CPU /* memory_type */,
+        max_random_byte_size, TRTSERVER_MEMORY_CPU_PINNED /* memory_type */,
         0 /* memory_type_id */));
     char* random_buffer =
         warmup_data.random_data_->MutableBuffer(&type, &type_id);

--- a/src/core/pinned_memory_manager.h
+++ b/src/core/pinned_memory_manager.h
@@ -56,7 +56,8 @@ class PinnedMemoryManager {
   // be allocated.
   // Return true on success, false otherwise.
   static Status Alloc(
-      void** ptr, uint64_t size, bool allow_nonpinned_fallback = false);
+      void** ptr, uint64_t size, TRTSERVER_Memory_Type* allocated_type,
+      bool allow_nonpinned_fallback = false);
 
   // Free the memory allocated by the pinned memory manager.
   static Status Free(void* ptr);
@@ -65,7 +66,8 @@ class PinnedMemoryManager {
   PinnedMemoryManager(void* pinned_memory_buffer, uint64_t size);
 
   Status AllocInternal(
-      void** ptr, uint64_t size, bool allow_nonpinned_fallback = false);
+      void** ptr, uint64_t size, TRTSERVER_Memory_Type* allocated_type,
+      bool allow_nonpinned_fallback = false);
   Status FreeInternal(void* ptr);
 
  private:

--- a/src/core/provider.cc
+++ b/src/core/provider.cc
@@ -112,11 +112,8 @@ AllocatedSystemMemory::AllocatedSystemMemory(
       }
 
       default: {
-        // [TODO] set memory type to pinned if true, currently always return as
-        // non-pinned until all parts are aware of the new memory type
-        auto tmp_type = memory_type_;
         auto status = PinnedMemoryManager::Alloc(
-            (void**)&buffer_, byte_size, &tmp_type, true);
+            (void**)&buffer_, byte_size, &memory_type_, true);
         if (!status.IsOk()) {
           LOG_ERROR << status.Message();
           buffer_ = nullptr;

--- a/src/core/provider.cc
+++ b/src/core/provider.cc
@@ -79,38 +79,50 @@ AllocatedSystemMemory::AllocatedSystemMemory(
 {
   buffer_ = nullptr;
   if (byte_size != 0) {
-    if (memory_type_ == TRTSERVER_MEMORY_CPU) {
-      auto status =
-          PinnedMemoryManager::Alloc((void**)&buffer_, byte_size, true);
-      if (!status.IsOk()) {
-        LOG_ERROR << status.Message();
-        buffer_ = nullptr;
-      }
-    } else {
+    // If the requested memory type is not GPU, we always attempt to allocated
+    // on pinned memory first
+    switch (memory_type_) {
+      case TRTSERVER_MEMORY_GPU: {
 #ifdef TRTIS_ENABLE_GPU
-      int current_device;
-      auto err = cudaGetDevice(&current_device);
-      bool overridden = false;
-      if (err == cudaSuccess) {
-        overridden = (current_device != memory_type_id_);
-        if (overridden) {
-          err = cudaSetDevice(memory_type_id_);
+        int current_device;
+        auto err = cudaGetDevice(&current_device);
+        bool overridden = false;
+        if (err == cudaSuccess) {
+          overridden = (current_device != memory_type_id_);
+          if (overridden) {
+            err = cudaSetDevice(memory_type_id_);
+          }
         }
-      }
-      if (err == cudaSuccess) {
-        err = cudaMalloc((void**)&buffer_, byte_size);
-      }
-      if (err != cudaSuccess) {
-        LOG_ERROR << "failed to allocate GPU memory with byte size" << byte_size
-                  << ": " << std::string(cudaGetErrorString(err));
-        buffer_ = nullptr;
-      }
-      if (overridden) {
-        cudaSetDevice(current_device);
-      }
+        if (err == cudaSuccess) {
+          err = cudaMalloc((void**)&buffer_, byte_size);
+        }
+        if (err != cudaSuccess) {
+          LOG_ERROR << "failed to allocate GPU memory with byte size"
+                    << byte_size << ": "
+                    << std::string(cudaGetErrorString(err));
+          buffer_ = nullptr;
+        }
+        if (overridden) {
+          cudaSetDevice(current_device);
+        }
 #else
-      buffer_ = nullptr;
+        buffer_ = nullptr;
 #endif  // TRTIS_ENABLE_GPU
+        break;
+      }
+
+      default: {
+        // [TODO] set memory type to pinned if true, currently always return as
+        // non-pinned until all parts are aware of the new memory type
+        auto tmp_type = memory_type_;
+        auto status = PinnedMemoryManager::Alloc(
+            (void**)&buffer_, byte_size, &tmp_type, true);
+        if (!status.IsOk()) {
+          LOG_ERROR << status.Message();
+          buffer_ = nullptr;
+        }
+        break;
+      }
     }
   }
   total_byte_size_ = (buffer_ == nullptr) ? 0 : byte_size;
@@ -119,34 +131,40 @@ AllocatedSystemMemory::AllocatedSystemMemory(
 AllocatedSystemMemory::~AllocatedSystemMemory()
 {
   if (buffer_ != nullptr) {
-    if (memory_type_ == TRTSERVER_MEMORY_CPU) {
-      auto status = PinnedMemoryManager::Free(buffer_);
-      if (!status.IsOk()) {
-        LOG_ERROR << status.Message();
-        buffer_ = nullptr;
-      }
-    } else {
+    switch (memory_type_) {
+      case TRTSERVER_MEMORY_GPU: {
 #ifdef TRTIS_ENABLE_GPU
-      int current_device;
-      auto err = cudaGetDevice(&current_device);
-      bool overridden = false;
-      if (err == cudaSuccess) {
-        overridden = (current_device != memory_type_id_);
-        if (overridden) {
-          err = cudaSetDevice(memory_type_id_);
+        int current_device;
+        auto err = cudaGetDevice(&current_device);
+        bool overridden = false;
+        if (err == cudaSuccess) {
+          overridden = (current_device != memory_type_id_);
+          if (overridden) {
+            err = cudaSetDevice(memory_type_id_);
+          }
         }
-      }
-      if (err == cudaSuccess) {
-        err = cudaFree(buffer_);
-      }
-      if (err != cudaSuccess) {
-        LOG_ERROR << "failed to free GPU memory at address " << buffer_ << ": "
-                  << std::string(cudaGetErrorString(err));
-      }
-      if (overridden) {
-        cudaSetDevice(current_device);
-      }
+        if (err == cudaSuccess) {
+          err = cudaFree(buffer_);
+        }
+        if (err != cudaSuccess) {
+          LOG_ERROR << "failed to free GPU memory at address " << buffer_
+                    << ": " << std::string(cudaGetErrorString(err));
+        }
+        if (overridden) {
+          cudaSetDevice(current_device);
+        }
 #endif  // TRTIS_ENABLE_GPU
+        break;
+      }
+
+      default: {
+        auto status = PinnedMemoryManager::Free(buffer_);
+        if (!status.IsOk()) {
+          LOG_ERROR << status.Message();
+          buffer_ = nullptr;
+        }
+        break;
+      }
     }
     buffer_ = nullptr;
   }

--- a/src/core/provider.h
+++ b/src/core/provider.h
@@ -29,6 +29,7 @@
 #include <event2/buffer.h>
 #endif
 #include "src/core/api.pb.h"
+#include "src/core/constants.h"
 #include "src/core/grpc_service.pb.h"
 #include "src/core/model_config.h"
 #include "src/core/status.h"
@@ -105,6 +106,8 @@ class AllocatedSystemMemory : public Memory {
   AllocatedSystemMemory(
       size_t byte_size, TRTSERVER_Memory_Type memory_type,
       int64_t memory_type_id);
+
+  DISALLOW_COPY_AND_ASSIGN(AllocatedSystemMemory);
 
   ~AllocatedSystemMemory();
 

--- a/src/core/trtserver.h
+++ b/src/core/trtserver.h
@@ -65,7 +65,8 @@ struct TRTSERVER_TraceManager;
 /// Types of memory recognized by TRTSERVER.
 typedef enum trtserver_memorytype_enum {
   TRTSERVER_MEMORY_CPU,
-  TRTSERVER_MEMORY_GPU
+  TRTSERVER_MEMORY_GPU,
+  TRTSERVER_MEMORY_CPU_PINNED
 } TRTSERVER_Memory_Type;
 
 /// TRTSERVER_Error

--- a/src/custom/identity/identity.cc
+++ b/src/custom/identity/identity.cc
@@ -299,14 +299,29 @@ Context::Execute(
         }
 
         auto copy_type = cudaMemcpyHostToHost;
-        if (src_memory_type == dst_memory_type) {
-          if (src_memory_type == CUSTOM_MEMORY_GPU) {
-            copy_type = cudaMemcpyDeviceToDevice;
+        switch (src_memory_type) {
+          case CUSTOM_MEMORY_GPU: {
+            switch (dst_memory_type) {
+              case CUSTOM_MEMORY_GPU:
+                copy_type = cudaMemcpyDeviceToDevice;
+                break;
+              default:
+                copy_type = cudaMemcpyDeviceToHost;
+                break;
+            }
+            break;
           }
-        } else {
-          copy_type = (src_memory_type == CUSTOM_MEMORY_CPU)
-                          ? cudaMemcpyHostToDevice
-                          : cudaMemcpyDeviceToHost;
+          default: {
+            switch (dst_memory_type) {
+              case CUSTOM_MEMORY_GPU:
+                copy_type = cudaMemcpyHostToDevice;
+                break;
+              default:
+                // default 'copy_type' value: cudaMemcpyHostToHost
+                break;
+            }
+            break;
+          }
         }
 
         if (copy_type == cudaMemcpyHostToHost) {

--- a/src/servers/common.cc
+++ b/src/servers/common.cc
@@ -134,4 +134,19 @@ SetTRTSERVER_InferenceRequestOptions(
   return nullptr;  // Success
 }
 
+std::string
+MemoryTypeString(TRTSERVER_Memory_Type memory_type)
+{
+  switch (memory_type) {
+    case TRTSERVER_MEMORY_CPU:
+      return "CPU memory";
+    case TRTSERVER_MEMORY_CPU_PINNED:
+      return "Pinned CPU memory";
+    case TRTSERVER_MEMORY_GPU:
+      return "GPU memory";
+    default:
+      return "unknown memory type";
+  }
+}
+
 }}  // namespace nvidia::inferenceserver

--- a/src/servers/common.h
+++ b/src/servers/common.h
@@ -115,4 +115,6 @@ TRTSERVER_Error* SetTRTSERVER_InferenceRequestOptions(
     TRTSERVER_InferenceRequestOptions* request_options,
     InferRequestHeader request_header_protobuf);
 
+std::string MemoryTypeString(TRTSERVER_Memory_Type memory_type);
+
 }}  // namespace nvidia::inferenceserver

--- a/src/servers/grpc_server.cc
+++ b/src/servers/grpc_server.cc
@@ -815,9 +815,9 @@ InferResponseAlloc(
       // Can't allocate for any memory type other than CPU. If asked to
       // allocate on GPU memory then force allocation on CPU instead.
       if (*actual_memory_type != TRTSERVER_MEMORY_CPU) {
-        LOG_VERBOSE(1)
-            << "GRPC: unable to provide '" << tensor_name
-            << "' in TRTSERVER_MEMORY_GPU, will use type TRTSERVER_MEMORY_CPU";
+        LOG_VERBOSE(1) << "GRPC: unable to provide '" << tensor_name << "' in "
+                       << MemoryTypeString(*actual_memory_type) << ", will use "
+                       << MemoryTypeString(TRTSERVER_MEMORY_CPU);
         *actual_memory_type = TRTSERVER_MEMORY_CPU;
         *actual_memory_type_id = 0;
       }

--- a/src/servers/http_server.cc
+++ b/src/servers/http_server.cc
@@ -372,9 +372,10 @@ HTTPAPIServer::ResponseAlloc(
     } else {
       // Can't allocate for any memory type other than CPU.
       if (preferred_memory_type != TRTSERVER_MEMORY_CPU) {
-        LOG_VERBOSE(1)
-            << "HTTP: unable to provide '" << tensor_name
-            << "' in TRTSERVER_MEMORY_GPU, will use type TRTSERVER_MEMORY_CPU";
+        LOG_VERBOSE(1) << "HTTP: unable to provide '" << tensor_name << "' in "
+                       << MemoryTypeString(preferred_memory_type)
+                       << ", will use "
+                       << MemoryTypeString(TRTSERVER_MEMORY_CPU);
         *actual_memory_type = TRTSERVER_MEMORY_CPU;
         *actual_memory_type_id = 0;
       }

--- a/src/servers/http_v2_server.cc
+++ b/src/servers/http_v2_server.cc
@@ -296,9 +296,10 @@ HTTPAPIServer::ResponseAlloc(
     } else {
       // Can't allocate for any memory type other than CPU.
       if (preferred_memory_type != TRTSERVER_MEMORY_CPU) {
-        LOG_VERBOSE(1)
-            << "HTTP V2: unable to provide '" << tensor_name
-            << "' in TRTSERVER_MEMORY_GPU, will use type TRTSERVER_MEMORY_CPU";
+        LOG_VERBOSE(1) << "HTTP V2: unable to provide '" << tensor_name
+                       << "' in " << MemoryTypeString(preferred_memory_type)
+                       << ", will use "
+                       << MemoryTypeString(TRTSERVER_MEMORY_CPU);
         *actual_memory_type = TRTSERVER_MEMORY_CPU;
         *actual_memory_type_id = 0;
       }

--- a/src/servers/memory_alloc.cc
+++ b/src/servers/memory_alloc.cc
@@ -81,12 +81,6 @@ Usage(char** argv, const std::string& msg = std::string())
   exit(1);
 }
 
-std::string
-MemoryTypeString(TRTSERVER_Memory_Type memory_type)
-{
-  return (memory_type == TRTSERVER_MEMORY_CPU) ? "CPU memory" : "GPU memory";
-}
-
 TRTSERVER_Error*
 ResponseAlloc(
     TRTSERVER_ResponseAllocator* allocator, const char* tensor_name,
@@ -128,16 +122,16 @@ ResponseAlloc(
           TRTSERVER_ERROR_INTERNAL,
           std::string(
               "failed to allocate " + std::to_string(byte_size) + " bytes in " +
-              MemoryTypeString(io_spec.output_type_) + " for result tensor " +
-              tensor_name)
+              ni::MemoryTypeString(io_spec.output_type_) +
+              " for result tensor " + tensor_name)
               .c_str());
     }
 
     *buffer = allocated_ptr;
     *buffer_userp = new std::string(tensor_name);
     std::cout << "allocated " << byte_size << " bytes in "
-              << MemoryTypeString(io_spec.output_type_) << " for result tensor "
-              << tensor_name << std::endl;
+              << ni::MemoryTypeString(io_spec.output_type_)
+              << " for result tensor " << tensor_name << std::endl;
   }
 
   *actual_memory_type = io_spec.output_type_;
@@ -158,7 +152,7 @@ ResponseRelease(
   }
 
   std::cout << "Releasing buffer " << buffer << " of size " << byte_size
-            << " in " << MemoryTypeString(memory_type) << " for result '"
+            << " in " << ni::MemoryTypeString(memory_type) << " for result '"
             << *name << "'" << std::endl;
   if (memory_type == TRTSERVER_MEMORY_CPU) {
     free(buffer);
@@ -757,9 +751,9 @@ main(int argc, char** argv)
     FAIL(
         "unexpected output0 memory type (id), expected to be allocated "
         "in " +
-        MemoryTypeString(io_spec.output_type_) + " with id " +
+        ni::MemoryTypeString(io_spec.output_type_) + " with id " +
         std::to_string(io_spec.output_type_id_) + ", got " +
-        MemoryTypeString(output0_memory_type) + " with id " +
+        ni::MemoryTypeString(output0_memory_type) + " with id " +
         std::to_string(output0_memory_type_id));
   }
 
@@ -791,9 +785,9 @@ main(int argc, char** argv)
     FAIL(
         "unexpected output1 memory type (id), expected to be allocated "
         "in " +
-        MemoryTypeString(io_spec.output_type_) + " with id " +
+        ni::MemoryTypeString(io_spec.output_type_) + " with id " +
         std::to_string(io_spec.output_type_id_) + ", got " +
-        MemoryTypeString(output1_memory_type) + " with id " +
+        ni::MemoryTypeString(output1_memory_type) + " with id " +
         std::to_string(output1_memory_type_id));
   }
 

--- a/src/servers/simple.cc
+++ b/src/servers/simple.cc
@@ -73,12 +73,6 @@ Usage(char** argv, const std::string& msg = std::string())
   exit(1);
 }
 
-std::string
-MemoryTypeString(TRTSERVER_Memory_Type memory_type)
-{
-  return (memory_type == TRTSERVER_MEMORY_CPU) ? "CPU memory" : "GPU memory";
-}
-
 TRTSERVER_Error*
 ResponseAlloc(
     TRTSERVER_ResponseAllocator* allocator, const char* tensor_name,
@@ -136,7 +130,7 @@ ResponseAlloc(
       *buffer = allocated_ptr;
       *buffer_userp = new std::string(tensor_name);
       std::cout << "allocated " << byte_size << " bytes in "
-                << MemoryTypeString(*actual_memory_type)
+                << ni::MemoryTypeString(*actual_memory_type)
                 << " for result tensor " << tensor_name << std::endl;
     }
   }
@@ -157,7 +151,7 @@ ResponseRelease(
   }
 
   std::cout << "Releasing buffer " << buffer << " of size " << byte_size
-            << " in " << MemoryTypeString(memory_type) << " for result '"
+            << " in " << ni::MemoryTypeString(memory_type) << " for result '"
             << *name << "'" << std::endl;
   if (memory_type == TRTSERVER_MEMORY_CPU) {
     free(buffer);
@@ -605,8 +599,8 @@ main(int argc, char** argv)
     FAIL(
         "unexpected output0 memory type, expected to be allocated "
         "in " +
-        MemoryTypeString(TRTSERVER_MEMORY_CPU) + ", got " +
-        MemoryTypeString(output0_memory_type) + ", id " +
+        ni::MemoryTypeString(TRTSERVER_MEMORY_CPU) + ", got " +
+        ni::MemoryTypeString(output0_memory_type) + ", id " +
         std::to_string(output0_memory_type_id));
   }
 
@@ -629,8 +623,8 @@ main(int argc, char** argv)
     FAIL(
         "unexpected output1 memory type, expected to be allocated "
         "in " +
-        MemoryTypeString(TRTSERVER_MEMORY_CPU) + ", got " +
-        MemoryTypeString(output1_memory_type) + ", id " +
+        ni::MemoryTypeString(TRTSERVER_MEMORY_CPU) + ", got " +
+        ni::MemoryTypeString(output1_memory_type) + ", id " +
         std::to_string(output1_memory_type_id));
   }
 


### PR DESCRIPTION
Currently we are being conservative on the output from the frameworks (if CPU buffer, then always assume to be non-pinned), and always prefer pinned CPU buffer when TRTIS need to allocate CPU buffer.