### PR TITLE
Remove unnecessary NvInfer.h

### DIFF
--- a/src/backends/onnx/autofill.cc
+++ b/src/backends/onnx/autofill.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2020, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/backends/onnx/autofill.cc
+++ b/src/backends/onnx/autofill.cc
@@ -26,7 +26,6 @@
 
 #include "src/backends/onnx/autofill.h"
 
-#include <NvInfer.h>
 #include "src/backends/onnx/loader.h"
 #include "src/backends/onnx/onnx_utils.h"
 #include "src/core/autofill.h"

--- a/src/backends/onnx/onnx_backend.cc
+++ b/src/backends/onnx/onnx_backend.cc
@@ -41,8 +41,11 @@
 #ifdef TRTIS_ENABLE_GPU
 #include <cuda_provider_factory.h>
 #include <cuda_runtime_api.h>
-#include <tensorrt_provider_factory.h>
 #endif  // TRTIS_ENABLE_GPU
+
+#ifdef TRTIS_ENABLE_TENSORRT
+#include <tensorrt_provider_factory.h>
+#endif  // TRTIS_ENABLE_TENSORRT
 
 #ifdef TRTIS_ENABLE_ONNXRUNTIME_OPENVINO
 #include <openvino_provider_factory.h>
@@ -211,12 +214,15 @@ OnnxBackend::CreateExecutionContext(
                .optimization()
                .execution_accelerators()
                .gpu_execution_accelerator()) {
+#ifdef TRTIS_ENABLE_TENSORRT
         if (execution_accelerator.name() == kTensorRTExecutionAccelerator) {
           RETURN_IF_ORT_ERROR(OrtSessionOptionsAppendExecutionProvider_Tensorrt(
               session_options, gpu_device));
           LOG_VERBOSE(1) << "TensorRT Execution Accelerator is set for "
                          << instance_name << " on device " << gpu_device;
-        } else {
+        } else
+#endif  // TRTIS_ENABLE_TENSORRT
+        {
           return Status(
               RequestStatusCode::INVALID_ARG,
               "unknown Execution Accelerator '" + execution_accelerator.name() +


### PR DESCRIPTION
Not needed and caused build error when building on a system without
TensorRT installed.