### PR TITLE
Fixing the model generation script to pick correct gpu id

### DIFF
--- a/qa/common/gen_qa_custom_ops
+++ b/qa/common/gen_qa_custom_ops
@@ -67,8 +67,6 @@ cat >$HOST_SRCDIR/$TFSCRIPT <<EOF
 #!/bin/bash -x
 set -e
 
-export CUDA_VISIBLE_DEVICES=$CUDA_DEVICE
-
 TF_CFLAGS=\$(python -c 'import tensorflow as tf; print(" ".join(tf.sysconfig.get_compile_flags()))')
 TF_LFLAGS=\$(python -c 'import tensorflow as tf; print(" ".join(tf.sysconfig.get_link_flags()))')
 
@@ -102,7 +100,7 @@ if [ $? -ne 0 ]; then
 fi
 
 docker pull $TENSORFLOW_IMAGE
-docker run --gpus=1 --rm --entrypoint $SRCDIR/$TFSCRIPT \
+docker run --gpus device=$CUDA_DEVICE --rm --entrypoint $SRCDIR/$TFSCRIPT \
        --mount type=bind,source=$HOST_SRCDIR,target=$SRCDIR \
        --mount type=bind,source=$HOST_DESTDIR/tf_custom_ops,target=$DESTDIR \
        $TENSORFLOW_IMAGE
@@ -115,8 +113,6 @@ fi
 cat >$HOST_SRCDIR/$PYTSCRIPT <<EOF
 #!/bin/bash -x
 set -e
-
-export CUDA_VISIBLE_DEVICES=$CUDA_DEVICE
 
 python3 $SRCDIR/gen_qa_custom_ops_models.py --libtorch --models_dir=$DESTDIR
 chown -R $(id -u):$(id -g) $DESTDIR
@@ -131,7 +127,7 @@ if [ $? -ne 0 ]; then
 fi
 
 docker pull $PYTORCH_IMAGE
-docker run --gpus=1 --rm --entrypoint $SRCDIR/$PYTSCRIPT \
+docker run --gpus device=$CUDA_DEVICE --rm --entrypoint $SRCDIR/$PYTSCRIPT \
        --mount type=bind,source=$HOST_SRCDIR,target=$SRCDIR \
        --mount type=bind,source=$HOST_DESTDIR/libtorch_custom_ops,target=$DESTDIR \
        -u $(id -u):$(id -g) $PYTORCH_IMAGE

--- a/qa/common/gen_qa_model_repository
+++ b/qa/common/gen_qa_model_repository
@@ -130,7 +130,6 @@ PLGDESTDIR=/tmp/pluginmodels
 cat >$HOST_SRCDIR/$C2SCRIPT <<EOF
 #!/bin/bash
 set -e
-export CUDA_VISIBLE_DEVICES=$CUDA_DEVICE
 cd $SRCDIR
 python3 $SRCDIR/gen_qa_models.py --onnx --netdef --libtorch --models_dir=$DESTDIR
 chown -R $(id -u):$(id -g) $DESTDIR
@@ -155,7 +154,7 @@ if [ $? -ne 0 ]; then
 fi
 
 docker pull $PYTORCH_IMAGE
-docker run --gpus=1 --rm --entrypoint $SRCDIR/$C2SCRIPT \
+docker run --gpus device=$CUDA_DEVICE --rm --entrypoint $SRCDIR/$C2SCRIPT \
        --mount type=bind,source=$HOST_SRCDIR,target=$SRCDIR \
        --mount type=bind,source=$HOST_DESTDIR,target=$DESTDIR \
        --mount type=bind,source=$HOST_VARDESTDIR,target=$VARDESTDIR \
@@ -174,7 +173,6 @@ fi
 cat >$HOST_SRCDIR/$TFSCRIPT <<EOF
 #!/bin/bash
 set -e
-export CUDA_VISIBLE_DEVICES=$CUDA_DEVICE
 cd $SRCDIR
 python3 $SRCDIR/gen_qa_models.py --graphdef --savedmodel --models_dir=$DESTDIR
 chown -R $(id -u):$(id -g) $DESTDIR
@@ -208,7 +206,7 @@ if [ $? -ne 0 ]; then
 fi
 
 docker pull $TENSORFLOW_IMAGE
-docker run --gpus=1 --rm --entrypoint $SRCDIR/$TFSCRIPT \
+docker run --gpus device=$CUDA_DEVICE --rm --entrypoint $SRCDIR/$TFSCRIPT \
        --mount type=bind,source=$HOST_SRCDIR,target=$SRCDIR \
        --mount type=bind,source=$HOST_DESTDIR,target=$DESTDIR \
        --mount type=bind,source=$HOST_VARDESTDIR,target=$VARDESTDIR \
@@ -229,7 +227,6 @@ fi
 cat >$HOST_SRCDIR/$TRTSCRIPT <<EOF
 #!/bin/bash
 set -e
-export CUDA_VISIBLE_DEVICES=$CUDA_DEVICE
 export TRT_SUPPRESS_DEPRECATION_WARNINGS=1
 cd $SRCDIR
 python3 $SRCDIR/gen_qa_models.py --tensorrt --models_dir=$DESTDIR
@@ -262,7 +259,7 @@ if [ $? -ne 0 ]; then
 fi
 
 docker pull $TENSORRT_IMAGE
-docker run --gpus=1 --rm --entrypoint $SRCDIR/$TRTSCRIPT \
+docker run --gpus device=$CUDA_DEVICE --rm --entrypoint $SRCDIR/$TRTSCRIPT \
        --mount type=bind,source=$HOST_SRCDIR,target=$SRCDIR \
        --mount type=bind,source=$HOST_DESTDIR,target=$DESTDIR \
        --mount type=bind,source=$HOST_VARDESTDIR,target=$VARDESTDIR \


### PR DESCRIPTION
Setting gpus=1 was selecting the first gpu irrespective of CUDA_DEVICE id. Verified the model generation on a system with multiple gpus. 