### PR TITLE
Handling for GetAsyncRunResults failures in the callback

### DIFF
--- a/src/clients/c++/perf_client/load_manager.h
+++ b/src/clients/c++/perf_client/load_manager.h
@@ -179,10 +179,16 @@ class LoadManager {
 
   // Holds the running status of the thread.
   struct ThreadStat {
-    ThreadStat() : status_(ni::RequestStatusCode::SUCCESS) {}
+    ThreadStat()
+        : status_(ni::RequestStatusCode::SUCCESS),
+          cb_status_(ni::RequestStatusCode::SUCCESS)
+    {
+    }
 
     // The status of the worker thread
     nic::Error status_;
+    // The status of the callback thread for async requests
+    nic::Error cb_status_;
     // The statistics of the InferContext
     std::vector<nic::InferContext::Stat> contexts_stat_;
     // The concurrency level that the worker should produce


### PR DESCRIPTION
PerfClient was not catching the GetAsyncRunResult errors before which made client unaware of failed inferences. 

Before Changes
==========================
 ../clients/perf_client -m onnx_float32_float32_float32 -p 50000 -b 8 --input-data zero --concurrency-range 2  --shared-memory=cuda --output-shared-memory-size=8388608 --shape INPUT0:151658240 --shape INPUT1:151658240 --async
*** Measurement Settings ***
  Batch size: 8
  Measurement window: 50000 msec
  Using asynchronous calls for inference
  Stabilizing using average latency

Request concurrency: 2
Failed to update context stat: [ 0] INTERNAL - Timer not set correctly.
Failed to update context stat: [ 0] INTERNAL - Timer not set correctly.
Failed to update context stat: [ 0] INTERNAL - Timer not set correctly.
Failed to update context stat: [ 0] INTERNAL - Timer not set correctly.
Failed to update context stat: [ 0] INTERNAL - Timer not set correctly.
Failed to update context stat: [ 0] INTERNAL - Timer not set correctly.
Failed to update context stat: [ 0] INTERNAL - Timer not set correctly.
Failed to update context stat: [ 0] INTERNAL - Timer not set correctly.
Failed to update context stat: [ 0] INTERNAL - Timer not set correctly.
Failed to update context stat: [ 0] INTERNAL - Timer not set correctly.
Failed to update context stat: [ 0] INTERNAL - Timer not set correctly.
Failed to update context stat: [ 0] INTERNAL - Timer not set correctly.
Failed to update context stat: [ 0] INTERNAL - Timer not set correctly.
Failed to update context stat: [ 0] INTERNAL - Timer not set correctly.
Failed to update context stat: [ 0] INTERNAL - Timer not set correctly.
Failed to update context stat: [ 0] INTERNAL - Timer not set correctly.
Failed to update context stat: [ 0] INTERNAL - Timer not set correctly.
Failed to update context stat: [ 0] INTERNAL - Timer not set correctly.
Failed to update context stat: [ 0] INTERNAL - Timer not set correctly.
Failed to update context stat: [ 0] INTERNAL - Timer not set correctly.
Failed to update context stat: [ 0] INTERNAL - Timer not set correctly.
Failed to update context stat: [ 0] INTERNAL - Timer not set correctly.
Failed to update context stat: [ 0] INTERNAL - Timer not set correctly.
Failed to update context stat: [ 0] INTERNAL - Timer not set correctly.
Failed to update context stat: [ 0] INTERNAL - Timer not set correctly.
Failed to update context stat: [ 0] INTERNAL - Timer not set correctly.
Failed to update context stat: [ 0] INTERNAL - Timer not set correctly.
  Client: 
    Request count: 7
    Throughput: 1.12 infer/sec
    Avg latency: 12962565 usec (standard deviation 1624332 usec)
    p50 latency: 12974387 usec
    p90 latency: 13020364 usec
    p95 latency: 13044425 usec
    p99 latency: 13044425 usec
    Avg HTTP time: 140731341260 usec (send/recv 140731341260 usec + response wait 0 usec)
  Server: 
    Request count: 0
Inferences/Second vs. Client Average Batch Latency
Concurrency: 2, throughput: 1.12 infer/sec, latency 12962565 usec
Failed to update context stat: [ 0] INTERNAL - Timer not set correctly.
Failed to update context stat: [ 0] INTERNAL - Timer not set correctly.



After Changes
==========================
../clients/perf_client -m onnx_float32_float32_float32 -p 50000 -b 8 --input-data zero --concurrency-range 2  --shared-memory=cuda --output-shared-memory-size=8388608 --shape INPUT0:151658240 --shape INPUT1:151658240 --async
*** Measurement Settings ***
  Batch size: 8
  Measurement window: 50000 msec
  Using asynchronous calls for inference
  Stabilizing using average latency

Request concurrency: 2
Failed to update context stat: [ 0] INTERNAL - Timer not set correctly.
Failed to update context stat: [ 0] INTERNAL - Timer not set correctly.
**[ 0] INTERNAL - Failed to retrieve results from inference request.
Thread [0] had error: [inference:0 34] INTERNAL - onnx runtime error 1: /workspace/onnxruntime/onnxruntime/core/providers/cuda/cuda_call.cc:97 bool onnxruntime::CudaCall(ERRTYPE, const char*, const char*, ERRTYPE, const char*) [with ERRTYPE = cudaError; bool THRW = true] /workspace/onnxruntime/onnxruntime/core/providers/cuda/cuda_call.cc:91 bool onnxruntime::CudaCall(ERRTYPE, const char*, const char*, ERRTYPE, const char*) [with ERRTYPE = cudaError; bool THRW = true] CUDA failure 2: out of memory ; GPU=0 ; hostname=d8eaa15322b1 ; expr=cudaMalloc((void**)&p, size); 
Stacktrace:

Stacktrace:

Thread [1] had error: [inference:0 33] INTERNAL - onnx runtime error 1: /workspace/onnxruntime/onnxruntime/core/providers/cuda/cuda_call.cc:97 bool onnxruntime::CudaCall(ERRTYPE, const char*, const char*, ERRTYPE, const char*) [with ERRTYPE = cudaError; bool THRW = true] /workspace/onnxruntime/onnxruntime/core/providers/cuda/cuda_call.cc:91 bool onnxruntime::CudaCall(ERRTYPE, const char*, const char*, ERRTYPE, const char*) [with ERRTYPE = cudaError; bool THRW = true] CUDA failure 2: out of memory ; GPU=0 ; hostname=d8eaa15322b1 ; expr=cudaMalloc((void**)&p, size); 
Stacktrace:

Stacktrace:**
