### PR TITLE
Removing false warnings from autofiller

### DIFF
--- a/src/core/autofill.cc
+++ b/src/core/autofill.cc
@@ -230,12 +230,16 @@ AutoFill::Create(
                     << model_name
                     << " (verify contents of model directory or use "
                        "--log-verbose=1 for more details)";
-      } else {
+      } else if (!(platform == Platform::PLATFORM_CUSTOM ||
+                   platform == Platform::PLATFORM_ENSEMBLE)) {
         LOG_WARNING << "Autofiller failed to retrieve model. Error Details: "
                     << status.AsString();
       }
     }
-    LOG_WARNING << "Proceeding with simple config for now";
+    if (!(platform == Platform::PLATFORM_CUSTOM ||
+          platform == Platform::PLATFORM_ENSEMBLE)) {
+      LOG_WARNING << "Proceeding with simple config for now";
+    }
 #endif
     std::unique_ptr<AutoFill> afs;
     status = AutoFillSimple::Create(model_name, &afs);


### PR DESCRIPTION
### Before
/opt/tensorrtserver/bin/trtserver --model-repository=/opt/tensorrtserver/qa/L0_perf_client/ensemble_model --strict-model-config=false	
	2020-02-11 23:12:14.334942: I tensorflow/stream_executor/platform/default/dso_loader.cc:44] Successfully opened dynamic library libcudart.so.10.2	
	I0211 23:12:14.366611 332 metrics.cc:164] found 2 GPUs supporting NVML metrics	
	I0211 23:12:14.372117 332 metrics.cc:173]   GPU 0: GeForce GT 710	
	I0211 23:12:14.378348 332 metrics.cc:173]   GPU 1: TITAN RTX	
	I0211 23:12:14.378551 332 server.cc:115] Initializing TensorRT Inference Server	
	**W0211 23:12:14.542686 332 autofill.cc:234] Autofiller failed to retrieve model. Error Details: OK: 	
	W0211 23:12:14.542708 332 autofill.cc:238] Proceeding with simple config for now**	
	2020-02-11 23:12:14.543681: I tensorflow/cc/saved_model/reader.cc:31] Reading SavedModel from: /opt/tensorrtserver/qa/L0_perf_client/ensemble_model/savedmodel_sequence_object/1/model.savedmodel_

### After 
/opt/tensorrtserver/bin/trtserver --model-repository=/opt/tensorrtserver/qa/L0_perf_client/ensemble_model --strict-model-config=false
	2020-02-11 23:38:59.441317: I tensorflow/stream_executor/platform/default/dso_loader.cc:44] Successfully opened dynamic library libcudart.so.10.2
	I0211 23:38:59.475150 421 metrics.cc:164] found 2 GPUs supporting NVML metrics
	I0211 23:38:59.480646 421 metrics.cc:173]   GPU 0: GeForce GT 710
	I0211 23:38:59.486421 421 metrics.cc:173]   GPU 1: TITAN RTX
	I0211 23:38:59.486569 421 server.cc:115] Initializing TensorRT Inference Server
	2020-02-11 23:38:59.710651: I tensorflow/cc/saved_model/reader.cc:31] Reading SavedModel from: /opt/tensorrtserver/qa/L0_perf_client/ensemble_model/savedmodel_sequence_object/1/model.savedmodel