### PR TITLE
Add TRTServer options for setting priority and request timeout

### DIFF
--- a/src/core/backend.cc
+++ b/src/core/backend.cc
@@ -360,7 +360,7 @@ InferenceBackend::GenerateWarmupData(std::vector<WarmupData>* samples)
     warmup_data.irequest_->SetRequestedModelVersion(Version());
     warmup_data.irequest_->SetBatchSize(1);
     warmup_data.irequest_->SetPriority(0);
-    warmup_data.irequest_->SetTimeoutMs(0);
+    warmup_data.irequest_->SetTimeoutMicroseconds(0);
 
     // Request all outputs
     for (const auto& io : Config().output()) {

--- a/src/core/backend.cc
+++ b/src/core/backend.cc
@@ -359,6 +359,8 @@ InferenceBackend::GenerateWarmupData(std::vector<WarmupData>* samples)
     warmup_data.irequest_->SetModelName(Name());
     warmup_data.irequest_->SetRequestedModelVersion(Version());
     warmup_data.irequest_->SetBatchSize(1);
+    warmup_data.irequest_->SetPriority(0);
+    warmup_data.irequest_->SetTimeoutMs(0);
 
     // Request all outputs
     for (const auto& io : Config().output()) {

--- a/src/core/ensemble_scheduler.cc
+++ b/src/core/ensemble_scheduler.cc
@@ -167,6 +167,7 @@ class EnsembleContext {
   uint32_t flags_;
   uint64_t correlation_id_;
   uint32_t batch_size_;
+  uint32_t priority_;
 
   // Objects related to the ensemble infer request
   Status ensemble_status_;
@@ -272,6 +273,7 @@ EnsembleContext::EnsembleContext(
     batch_size_ = irequest->BatchSize();
     correlation_id_ = irequest->CorrelationId();
     flags_ = irequest->Flags();
+    priority_ = irequest->Priority();
 
     for (const auto& pr : irequest->Inputs()) {
       const auto& input = pr.second;
@@ -555,6 +557,9 @@ EnsembleContext::InitStep(size_t step_idx, std::shared_ptr<Step>* step)
   irequest->SetCorrelationId(correlation_id_);
   irequest->SetFlags(flags_);
   irequest->SetBatchSize((batch_size == 0 ? 1 : batch_size));
+  irequest->SetPriority(priority_);
+  // FIXME: need to think about how to interpret timeout in ensemble.
+  irequest->SetTimeoutMs(0);
   RETURN_IF_ERROR(irequest->Normalize(*backend));
 
   step->reset(new Step(step_idx));

--- a/src/core/ensemble_scheduler.cc
+++ b/src/core/ensemble_scheduler.cc
@@ -558,8 +558,10 @@ EnsembleContext::InitStep(size_t step_idx, std::shared_ptr<Step>* step)
   irequest->SetFlags(flags_);
   irequest->SetBatchSize((batch_size == 0 ? 1 : batch_size));
   irequest->SetPriority(priority_);
-  // FIXME: need to think about how to interpret timeout in ensemble.
-  irequest->SetTimeoutMs(0);
+  // Request for ensemble model cannot override the timeout values for the
+  // composing models. Thus currently the timeout field in request has no
+  // effect until we support an overall ensemble timeout.
+  irequest->SetTimeoutMicroseconds(0);
   RETURN_IF_ERROR(irequest->Normalize(*backend));
 
   step->reset(new Step(step_idx));

--- a/src/core/trtserver.cc
+++ b/src/core/trtserver.cc
@@ -1113,7 +1113,8 @@ TRTSERVER_InferenceRequestProviderNewV2(
   request->SetCorrelationId(loptions->InferRequestHeader()->correlation_id());
   request->SetBatchSize(loptions->InferRequestHeader()->batch_size());
   request->SetPriority(loptions->InferRequestHeader()->priority());
-  request->SetTimeoutMicroseconds(loptions->InferRequestHeader()->timeout_microseconds());
+  request->SetTimeoutMicroseconds(
+      loptions->InferRequestHeader()->timeout_microseconds());
   for (const auto& io : loptions->InferRequestHeader()->input()) {
     if (io.has_shared_memory()) {
       RETURN_IF_STATUS_ERROR(request->AddInput(

--- a/src/core/trtserver.cc
+++ b/src/core/trtserver.cc
@@ -401,7 +401,7 @@ class TrtServerRequestOptions {
   TRTSERVER_Error* SetCorrelationId(uint64_t correlation_id);
   TRTSERVER_Error* SetBatchSize(uint64_t batch_size);
   TRTSERVER_Error* SetPriority(uint32_t priority);
-  TRTSERVER_Error* SetTimeoutMs(uint64_t timeout_ms);
+  TRTSERVER_Error* SetTimeoutMicroseconds(uint64_t timeout_us);
 
   TRTSERVER_Error* AddInput(
       const char* input_name, const int64_t* dims, uint64_t dim_count,
@@ -495,10 +495,10 @@ TrtServerRequestOptions::SetPriority(uint32_t priority)
 }
 
 TRTSERVER_Error*
-TrtServerRequestOptions::SetTimeoutMs(uint64_t timeout_ms)
+TrtServerRequestOptions::SetTimeoutMicroseconds(uint64_t timeout_us)
 {
   std::lock_guard<std::mutex> lk(mtx_);
-  request_header_->set_timeout_microseconds(timeout_ms);
+  request_header_->set_timeout_microseconds(timeout_us);
   return nullptr;  // Success
 }
 
@@ -1009,12 +1009,12 @@ TRTSERVER_InferenceRequestOptionsSetPriority(
 }
 
 TRTSERVER_Error*
-TRTSERVER_InferenceRequestOptionsSetTimeout(
-    TRTSERVER_InferenceRequestOptions* request_options, uint64_t timeout_ms)
+TRTSERVER_InferenceRequestOptionsSetTimeoutMicroseconds(
+    TRTSERVER_InferenceRequestOptions* request_options, uint64_t timeout_us)
 {
   TrtServerRequestOptions* loptions =
       reinterpret_cast<TrtServerRequestOptions*>(request_options);
-  loptions->SetTimeoutMs(timeout_ms);
+  loptions->SetTimeoutMicroseconds(timeout_us);
   return nullptr;  // Success
 }
 
@@ -1113,7 +1113,7 @@ TRTSERVER_InferenceRequestProviderNewV2(
   request->SetCorrelationId(loptions->InferRequestHeader()->correlation_id());
   request->SetBatchSize(loptions->InferRequestHeader()->batch_size());
   request->SetPriority(loptions->InferRequestHeader()->priority());
-  request->SetTimeoutMs(loptions->InferRequestHeader()->timeout_microseconds());
+  request->SetTimeoutMicroseconds(loptions->InferRequestHeader()->timeout_microseconds());
   for (const auto& io : loptions->InferRequestHeader()->input()) {
     if (io.has_shared_memory()) {
       RETURN_IF_STATUS_ERROR(request->AddInput(

--- a/src/core/trtserver.h
+++ b/src/core/trtserver.h
@@ -549,7 +549,8 @@ TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_InferenceRequestOptionsSetPriority(
 /// \param request_options The request options object.
 /// \param timeout_us The timeout, in microseconds.
 /// \return a TRTSERVER_Error indicating success or failure.
-TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_InferenceRequestOptionsSetTimeoutMicroseconds(
+TRTSERVER_EXPORT TRTSERVER_Error*
+TRTSERVER_InferenceRequestOptionsSetTimeoutMicroseconds(
     TRTSERVER_InferenceRequestOptions* request_options, uint64_t timeout_us);
 
 /// Add a input meta-data associated with the request in a request options.

--- a/src/core/trtserver.h
+++ b/src/core/trtserver.h
@@ -547,10 +547,10 @@ TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_InferenceRequestOptionsSetPriority(
 
 /// Set the timeout for the request in a request options, in microseconds.
 /// \param request_options The request options object.
-/// \param timeout_ms The timeout, in microseconds.
+/// \param timeout_us The timeout, in microseconds.
 /// \return a TRTSERVER_Error indicating success or failure.
-TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_InferenceRequestOptionsSetTimeout(
-    TRTSERVER_InferenceRequestOptions* request_options, uint64_t timeout_ms);
+TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_InferenceRequestOptionsSetTimeoutMicroseconds(
+    TRTSERVER_InferenceRequestOptions* request_options, uint64_t timeout_us);
 
 /// Add a input meta-data associated with the request in a request options.
 /// \param request_options The request options object.

--- a/src/core/trtserver.h
+++ b/src/core/trtserver.h
@@ -538,6 +538,20 @@ TRTSERVER_InferenceRequestOptionsSetCorrelationId(
 TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_InferenceRequestOptionsSetBatchSize(
     TRTSERVER_InferenceRequestOptions* request_options, uint32_t batch_size);
 
+/// Set the priority for the request in a request options.
+/// \param request_options The request options object.
+/// \param priority The priority level.
+/// \return a TRTSERVER_Error indicating success or failure.
+TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_InferenceRequestOptionsSetPriority(
+    TRTSERVER_InferenceRequestOptions* request_options, uint32_t priority);
+
+/// Set the timeout for the request in a request options, in microseconds.
+/// \param request_options The request options object.
+/// \param timeout_ms The timeout, in microseconds.
+/// \return a TRTSERVER_Error indicating success or failure.
+TRTSERVER_EXPORT TRTSERVER_Error* TRTSERVER_InferenceRequestOptionsSetTimeout(
+    TRTSERVER_InferenceRequestOptions* request_options, uint64_t timeout_ms);
+
 /// Add a input meta-data associated with the request in a request options.
 /// \param request_options The request options object.
 /// \param input_name The name of the input.

--- a/src/servers/common.cc
+++ b/src/servers/common.cc
@@ -117,7 +117,7 @@ SetTRTSERVER_InferenceRequestOptions(
       request_options, request_header.batch_size()));
   RETURN_IF_ERR(TRTSERVER_InferenceRequestOptionsSetPriority(
       request_options, request_header.priority()));
-  RETURN_IF_ERR(TRTSERVER_InferenceRequestOptionsSetTimeout(
+  RETURN_IF_ERR(TRTSERVER_InferenceRequestOptionsSetTimeoutMicroseconds(
       request_options, request_header.timeout_microseconds()));
 
   for (const auto& input : request_header.input()) {
@@ -152,7 +152,7 @@ SetInferenceRequestOptions(
   //    request_options, request_header.flags()));
   // RETURN_IF_ERR(TRTSERVER_InferenceRequestOptionsSetPriority(
   //   request_options, request_header.priority()));
-  // RETURN_IF_ERR(TRTSERVER_InferenceRequestOptionsSetTimeout(
+  // RETURN_IF_ERR(TRTSERVER_InferenceRequestOptionsSetTimeoutMicroseconds(
   //   request_options, request_header.timeout_microseconds()));
   RETURN_IF_ERR(TRTSERVER_InferenceRequestOptionsSetCorrelationId(
       request_options, request.sequence_id()));

--- a/src/servers/common.cc
+++ b/src/servers/common.cc
@@ -150,6 +150,10 @@ SetInferenceRequestOptions(
   // FIXMEV2 parameters
   // RETURN_IF_ERR(TRTSERVER_InferenceRequestOptionsSetFlags(
   //    request_options, request_header.flags()));
+  // RETURN_IF_ERR(TRTSERVER_InferenceRequestOptionsSetPriority(
+  //   request_options, request_header.priority()));
+  // RETURN_IF_ERR(TRTSERVER_InferenceRequestOptionsSetTimeout(
+  //   request_options, request_header.timeout_microseconds()));
   RETURN_IF_ERR(TRTSERVER_InferenceRequestOptionsSetCorrelationId(
       request_options, request.sequence_id()));
 

--- a/src/servers/common.cc
+++ b/src/servers/common.cc
@@ -115,6 +115,10 @@ SetTRTSERVER_InferenceRequestOptions(
       request_options, request_header.correlation_id()));
   RETURN_IF_ERR(TRTSERVER_InferenceRequestOptionsSetBatchSize(
       request_options, request_header.batch_size()));
+  RETURN_IF_ERR(TRTSERVER_InferenceRequestOptionsSetPriority(
+      request_options, request_header.priority()));
+  RETURN_IF_ERR(TRTSERVER_InferenceRequestOptionsSetTimeout(
+      request_options, request_header.timeout_microseconds()));
 
   for (const auto& input : request_header.input()) {
     RETURN_IF_ERR(TRTSERVER_InferenceRequestOptionsAddInput(

--- a/src/servers/memory_alloc.cc
+++ b/src/servers/memory_alloc.cc
@@ -584,7 +584,7 @@ main(int argc, char** argv)
       TRTSERVER_InferenceRequestOptionsSetPriority(request_options, 0),
       "setting priority for the request");
   FAIL_IF_ERR(
-      TRTSERVER_InferenceRequestOptionsSetTimeout(request_options, 0),
+      TRTSERVER_InferenceRequestOptionsSetTimeoutMicroseconds(request_options, 0),
       "setting timeout for the request");
 
   auto input0 = is_torch_model ? "INPUT__0" : "INPUT0";

--- a/src/servers/memory_alloc.cc
+++ b/src/servers/memory_alloc.cc
@@ -584,7 +584,8 @@ main(int argc, char** argv)
       TRTSERVER_InferenceRequestOptionsSetPriority(request_options, 0),
       "setting priority for the request");
   FAIL_IF_ERR(
-      TRTSERVER_InferenceRequestOptionsSetTimeoutMicroseconds(request_options, 0),
+      TRTSERVER_InferenceRequestOptionsSetTimeoutMicroseconds(
+          request_options, 0),
       "setting timeout for the request");
 
   auto input0 = is_torch_model ? "INPUT__0" : "INPUT0";

--- a/src/servers/memory_alloc.cc
+++ b/src/servers/memory_alloc.cc
@@ -580,6 +580,12 @@ main(int argc, char** argv)
   FAIL_IF_ERR(
       TRTSERVER_InferenceRequestOptionsSetBatchSize(request_options, 1),
       "setting batch size for the request");
+  FAIL_IF_ERR(
+      TRTSERVER_InferenceRequestOptionsSetPriority(request_options, 0),
+      "setting priority for the request");
+  FAIL_IF_ERR(
+      TRTSERVER_InferenceRequestOptionsSetTimeout(request_options, 0),
+      "setting timeout for the request");
 
   auto input0 = is_torch_model ? "INPUT__0" : "INPUT0";
   auto input1 = is_torch_model ? "INPUT__1" : "INPUT1";

--- a/src/servers/simple.cc
+++ b/src/servers/simple.cc
@@ -446,7 +446,8 @@ main(int argc, char** argv)
       TRTSERVER_InferenceRequestOptionsSetPriority(request_options, 0),
       "setting priority for the request");
   FAIL_IF_ERR(
-      TRTSERVER_InferenceRequestOptionsSetTimeoutMicroseconds(request_options, 0),
+      TRTSERVER_InferenceRequestOptionsSetTimeoutMicroseconds(
+          request_options, 0),
       "setting timeout for the request");
 
   auto input0 = is_torch_model ? "INPUT__0" : "INPUT0";

--- a/src/servers/simple.cc
+++ b/src/servers/simple.cc
@@ -446,7 +446,7 @@ main(int argc, char** argv)
       TRTSERVER_InferenceRequestOptionsSetPriority(request_options, 0),
       "setting priority for the request");
   FAIL_IF_ERR(
-      TRTSERVER_InferenceRequestOptionsSetTimeout(request_options, 0),
+      TRTSERVER_InferenceRequestOptionsSetTimeoutMicroseconds(request_options, 0),
       "setting timeout for the request");
 
   auto input0 = is_torch_model ? "INPUT__0" : "INPUT0";

--- a/src/servers/simple.cc
+++ b/src/servers/simple.cc
@@ -442,6 +442,12 @@ main(int argc, char** argv)
   FAIL_IF_ERR(
       TRTSERVER_InferenceRequestOptionsSetBatchSize(request_options, 1),
       "setting batch size for the request");
+  FAIL_IF_ERR(
+      TRTSERVER_InferenceRequestOptionsSetPriority(request_options, 0),
+      "setting priority for the request");
+  FAIL_IF_ERR(
+      TRTSERVER_InferenceRequestOptionsSetTimeout(request_options, 0),
+      "setting timeout for the request");
 
   auto input0 = is_torch_model ? "INPUT__0" : "INPUT0";
   auto input1 = is_torch_model ? "INPUT__1" : "INPUT1";


### PR DESCRIPTION
This PR is branch-off from `gluo-timeout` and targeted to `gluo-timeout` to show the change for adding TRTServer options on top of the changes in `gluo-timeout`