### PR TITLE
Avoid copy-list-initialization as it is ill-formed if explicit constructor is chosen

### DIFF
--- a/src/core/backend_context.cc
+++ b/src/core/backend_context.cc
@@ -176,7 +176,7 @@ BackendContext::SetInputBuffer(
                 name, pinned_buffer_info, payloads, stream, input);
           }
           // always reset 'pinned_buffer_info' to maintain proper input offset
-          pinned_buffer_info = {
+          pinned_buffer_info = BufferInfo{
               buffer_copy_offset + copied_byte_size + content_byte_size, 0, {}};
         }
       }
@@ -202,7 +202,8 @@ BackendContext::SetInputBuffer(
             name, pinned_buffer_info, payloads, stream, input);
       }
       // reset 'pinned_buffer_info'
-      pinned_buffer_info = {buffer_copy_offset + expected_byte_size, 0, {}};
+      pinned_buffer_info =
+          BufferInfo{buffer_copy_offset + expected_byte_size, 0, {}};
     }
 
     buffer_copy_offset += expected_byte_size;
@@ -408,7 +409,8 @@ BackendContext::SetFixedSizeOutputBuffer(
                   name, pinned_buffer_info, payloads, stream_, output);
             }
             // reset 'pinned_buffer_info'
-            pinned_buffer_info = {output_offset + expected_byte_size, 0, {}};
+            pinned_buffer_info =
+                OutputBufferInfo{output_offset + expected_byte_size, 0, {}};
           }
         }
       }
@@ -429,7 +431,8 @@ BackendContext::SetFixedSizeOutputBuffer(
             name, pinned_buffer_info, payloads, stream_, output);
       }
       // reset 'pinned_buffer_info'
-      pinned_buffer_info = {output_offset + expected_byte_size, 0, {}};
+      pinned_buffer_info =
+          OutputBufferInfo{output_offset + expected_byte_size, 0, {}};
     }
 
     output_offset += expected_byte_size;


### PR DESCRIPTION
#1148 can be reproduced using an older compiler gcc 5.4.0, which will raise error in such case. Changing to "creating object with direct-list-initialization and then copy assign" allows the build to continue