### PR TITLE
Fixing backwards compatibility in ResponseHeader

### DIFF
--- a/src/core/provider.cc
+++ b/src/core/provider.cc
@@ -436,7 +436,10 @@ InferResponseProvider::FinalizeResponse(const InferenceBackend& is)
 
     auto poutput = response_header->add_output();
     poutput->set_name(output.name_);
-    poutput->set_data_type(output_config->data_type());
+
+    if (irequest_->ProtocolVersion() == 2) {
+      poutput->set_data_type(output_config->data_type());
+    }
 
     if (output.cls_count_ == 0) {
       // Raw result...


### PR DESCRIPTION
The data_type field should be populated only when the --api-version is set 2. The following tests were conducted on the 20.02 clients.

### Before

> Traceback (most recent call last):
>   File "infer_variable_test.py", line 151, in test_raw_ooo
>     self._full_exact(np_dtype_string, np_dtype_string, np_dtype_string, (16,), (16,), (16,))
>   File "infer_variable_test.py", line 91, in _full_exact
>     output0_raw=output0_raw, output1_raw=output1_raw, swap=swap)
>   File "infer_variable_test.py", line 65, in _infer_exact_helper
>     use_cuda_shared_memory=TEST_CUDA_SHARED_MEMORY)
>   File "../common/infer_util.py", line 215, in infer_exact
>     output_req, batch_size)
>   File "/usr/local/lib/python3.6/dist-packages/tensorrtserver/api/__init__.py", line 1582, in run
>     self._last_request_id = _raise_if_error(c_void_p(_crequest_infer_ctx_run(self._ctx)))
>   File "/usr/local/lib/python3.6/dist-packages/tensorrtserver/api/__init__.py", line 259, in _raise_if_error
>     raise ex
> tensorrtserver.api.InferenceServerException: [ 0] infer request did not return response header

### After

> 
> L0_infer# ./test.sh 
> === Running /opt/tensorrtserver/bin/trtserver --model-repository=/opt/tensorrtserver/qa/L0_infer/models --exit-timeout-secs=120
> 3352
> === Running /opt/tensorrtserver/bin/trtserver --model-repository=/opt/tensorrtserver/qa/L0_infer/models --exit-timeout-secs=120
> 3352
> 
> ./test.sh 
> === Running /opt/tensorrtserver/bin/trtserver --model-repository=/opt/tensorrtserver/qa/L0_infer_variable/models --exit-timeout-secs=120
> 1698
> === Running /opt/tensorrtserver/bin/trtserver --model-repository=/opt/tensorrtserver/qa/L0_infer_variable/models --exit-timeout-secs=120
> 1698

