### PR TITLE
System Shared Memory support for GRPC V2

### DIFF
--- a/qa/L0_grpc_v2/test.sh
+++ b/qa/L0_grpc_v2/test.sh
@@ -44,6 +44,7 @@ SIMPLE_INFER_CLIENT=../clients/simple_grpc_v2_infer_client.py
 SIMPLE_ASYNC_INFER_CLIENT=../clients/simple_grpc_v2_async_infer_client.py
 SIMPLE_STRING_INFER_CLIENT=../clients/simple_grpc_v2_string_infer_client.py
 SIMPLE_CLASS_CLIENT=../clients/simple_grpc_v2_class_client.py
+SIMPLE_SHM_CLIENT=../clients/simple_grpc_v2_shm_client.py
 EXPLICIT_BYTE_CONTENT_CLIENT=../clients/grpc_v2_explicit_byte_content_client.py
 EXPLICIT_INT_CONTENT_CLIENT=../clients/grpc_v2_explicit_int_content_client.py
 EXPLICIT_INT8_CONTENT_CLIENT=../clients/grpc_v2_explicit_int8_content_client.py
@@ -97,6 +98,7 @@ for i in \
         $SIMPLE_ASYNC_INFER_CLIENT \
         $SIMPLE_STRING_INFER_CLIENT \
         $SIMPLE_CLASS_CLIENT \
+        $SIMPLE_SHM_CLIENT \
         $EXPLICIT_BYTE_CONTENT_CLIENT \
         $EXPLICIT_INT_CONTENT_CLIENT \
         $EXPLICIT_INT8_CONTENT_CLIENT \

--- a/src/clients/python/experimental_api_v2/examples/CMakeLists.txt
+++ b/src/clients/python/experimental_api_v2/examples/CMakeLists.txt
@@ -38,5 +38,6 @@ install(
     simple_grpc_v2_async_infer_client.py
     simple_grpc_v2_infer_client.py
     simple_grpc_v2_string_infer_client.py
+    simple_grpc_v2_shm_client.py
   DESTINATION python
 )

--- a/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_async_infer_client.py
+++ b/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_async_infer_client.py
@@ -50,7 +50,7 @@ if __name__ == '__main__':
 
     FLAGS = parser.parse_args()
     try:
-        TRTISClient = grpcclient.InferenceServerClient(FLAGS.url)
+        triton_client = grpcclient.InferenceServerClient(FLAGS.url)
     except Exception as e:
         print("context creation failed: " + str(e))
         sys.exit()
@@ -86,7 +86,7 @@ if __name__ == '__main__':
     user_data = []
 
     # Inference call
-    TRTISClient.async_infer(partial(callback, user_data), inputs, outputs,
+    triton_client.async_infer(partial(callback, user_data), inputs, outputs,
                             model_name)
 
     # Wait until the results are available in user_data
@@ -114,4 +114,4 @@ if __name__ == '__main__':
                 sys.exit(1)
         print("PASS: Async infer")
 
-    TRTISClient.close()
+    triton_client.close()

--- a/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_async_infer_client.py
+++ b/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_async_infer_client.py
@@ -113,5 +113,3 @@ if __name__ == '__main__':
                 print("sync infer error: incorrect difference")
                 sys.exit(1)
         print("PASS: Async infer")
-
-    triton_client.close()

--- a/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_class_client.py
+++ b/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_class_client.py
@@ -232,7 +232,7 @@ if __name__ == '__main__':
 
     # Create gRPC client for communicating with the server
     try:
-        TRTISClient = grpcclient.InferenceServerClient(FLAGS.url)
+        triton_client = grpcclient.InferenceServerClient(FLAGS.url)
     except Exception as e:
         print("context creation failed: " + str(e))
         sys.exit()
@@ -240,13 +240,13 @@ if __name__ == '__main__':
     # Make sure the model matches our requirements, and get some
     # properties of the model that we need for preprocessing
     try:
-        model_meta = TRTISClient.get_model_metadata(model_name=FLAGS.model_name)
+        model_meta = triton_client.get_model_metadata(model_name=FLAGS.model_name)
     except InferenceServerException as e:
         print("failed to retrieve the metadata: " + str(e))
         sys.exit()
 
     try:
-        model_config = TRTISClient.get_model_config(model_name=FLAGS.model_name)
+        model_config = triton_client.get_model_config(model_name=FLAGS.model_name)
     except InferenceServerException as e:
         print("failed to retrieve the config: " + str(e))
         sys.exit()
@@ -265,7 +265,7 @@ if __name__ == '__main__':
             input_name, output_name, c, h, w, format, dtype, FLAGS):
         try:
             results.append(
-                TRTISClient.infer(inputs,
+                triton_client.infer(inputs,
                                   outputs,
                                   model_name=FLAGS.model_name,
                                   model_version=FLAGS.model_version))

--- a/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_health_metadata.py
+++ b/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_health_metadata.py
@@ -47,7 +47,7 @@ if __name__ == '__main__':
 
     FLAGS = parser.parse_args()
     try:
-        TRTISClient = grpcclient.InferenceServerClient(FLAGS.url)
+        triton_client = grpcclient.InferenceServerClient(FLAGS.url)
     except Exception as e:
         print("context creation failed: " + str(e))
         sys.exit()
@@ -55,34 +55,34 @@ if __name__ == '__main__':
     model_name = 'simple'
 
     # Health
-    if TRTISClient.is_server_live():
+    if triton_client.is_server_live():
         print("PASS: is_server_live")
 
-    if TRTISClient.is_server_ready():
+    if triton_client.is_server_ready():
         print("PASS: is_server_ready")
 
-    if TRTISClient.is_model_ready(model_name):
+    if triton_client.is_model_ready(model_name):
         print("PASS: is_model_ready")
 
     # Metadata
-    metadata = TRTISClient.get_server_metadata()
+    metadata = triton_client.get_server_metadata()
     if (metadata.name == 'inference:0'):
         print("PASS: get_server_metadata")
 
-    metadata = TRTISClient.get_model_metadata(model_name)
+    metadata = triton_client.get_model_metadata(model_name)
     if (metadata.name == model_name):
         print("PASS: get_model_metadata")
 
     # Passing incorrect model name
     try:
-        metadata = TRTISClient.get_model_metadata("wrong_model_name")
+        metadata = triton_client.get_model_metadata("wrong_model_name")
     except InferenceServerException as ex:
         if "no status available for unknown model" in ex.message():
             print("PASS: detected wrong model")
 
     # Configuration
-    config = TRTISClient.get_model_config(model_name)
+    config = triton_client.get_model_config(model_name)
     if (config.config.name == model_name):
         print("PASS: get_model_config")
 
-    TRTISClient.close()
+    triton_client.close()

--- a/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_health_metadata.py
+++ b/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_health_metadata.py
@@ -84,5 +84,3 @@ if __name__ == '__main__':
     config = triton_client.get_model_config(model_name)
     if (config.config.name == model_name):
         print("PASS: get_model_config")
-
-    triton_client.close()

--- a/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_infer_client.py
+++ b/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_infer_client.py
@@ -90,5 +90,3 @@ if __name__ == '__main__':
             print("sync infer error: incorrect difference")
             sys.exit(1)
     print('PASS: infer')
-
-    triton_client.close()

--- a/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_infer_client.py
+++ b/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_infer_client.py
@@ -47,7 +47,7 @@ if __name__ == '__main__':
 
     FLAGS = parser.parse_args()
     try:
-        TRTISClient = grpcclient.InferenceServerClient(FLAGS.url)
+        triton_client = grpcclient.InferenceServerClient(FLAGS.url)
     except Exception as e:
         print("channel creation failed: " + str(e))
         sys.exit()
@@ -72,7 +72,7 @@ if __name__ == '__main__':
 
     outputs.append(grpcclient.InferOutput('OUTPUT0'))
     outputs.append(grpcclient.InferOutput('OUTPUT1'))
-    results = TRTISClient.infer(inputs, outputs, model_name)
+    results = triton_client.infer(inputs, outputs, model_name)
 
     # Get the output arrays from the
     output0_data = results.as_numpy('OUTPUT0')
@@ -91,4 +91,4 @@ if __name__ == '__main__':
             sys.exit(1)
     print('PASS: infer')
 
-    TRTISClient.close()
+    triton_client.close()

--- a/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_shm_client.py
+++ b/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_shm_client.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python
+# Copyright (c) 2019-2020, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import argparse
+import numpy as np
+import os
+from builtins import range
+import tritongrpcclient.core as grpcclient
+import tritongrpcclient.shared_memory as shm
+from ctypes import *
+
+FLAGS = None
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-v',
+                        '--verbose',
+                        action="store_true",
+                        required=False,
+                        default=False,
+                        help='Enable verbose output')
+    parser.add_argument('-u',
+                        '--url',
+                        type=str,
+                        required=False,
+                        default='localhost:8001',
+                        help='Inference server URL. Default is localhost:8001.')
+
+    FLAGS = parser.parse_args()
+
+    try:
+        triton_client = grpcclient.InferenceServerClient(FLAGS.url)
+    except Exception as e:
+        print("channel creation failed: " + str(e))
+        sys.exit()
+    
+    triton_client.unregister_system_shared_memory()
+    triton_client.unregister_cuda_shared_memory()
+
+    # We use a simple model that takes 2 input tensors of 16 integers
+    # each and returns 2 output tensors of 16 integers each. One
+    # output tensor is the element-wise sum of the inputs and one
+    # output is the element-wise difference.
+    model_name = "simple"
+    model_version = ""
+
+    # Create the data for the two input tensors. Initialize the first
+    # to unique integers and the second to all ones.
+    input0_data = np.arange(start=0, stop=16, dtype=np.int32)
+    input1_data = np.ones(shape=16, dtype=np.int32)
+
+    input_byte_size = input0_data.size * input0_data.itemsize
+    output_byte_size = input_byte_size
+
+    # Create Output0 and Output1 in Shared Memory and store shared memory handles
+    shm_op0_handle = shm.create_shared_memory_region("output0_data", "/output0_simple", output_byte_size)
+    shm_op1_handle = shm.create_shared_memory_region("output1_data", "/output1_simple", output_byte_size)
+
+    # Register Output0 and Output1 shared memory with TRTIS
+    triton_client.register_system_shared_memory("output0_data", "/output0_simple", output_byte_size)
+    triton_client.register_system_shared_memory("output1_data", "/output1_simple", output_byte_size)
+
+    # Create Input0 and Input1 in Shared Memory and store shared memory handles
+    shm_ip0_handle = shm.create_shared_memory_region("input0_data", "/input0_simple", input_byte_size)
+    shm_ip1_handle = shm.create_shared_memory_region("input1_data", "/input1_simple", input_byte_size)
+
+    # Put input data values into shared memory
+    shm.set_shared_memory_region(shm_ip0_handle, [input0_data])
+    shm.set_shared_memory_region(shm_ip1_handle, [input1_data])
+
+    # Register Input0 and Input1 shared memory with Triton Server
+    triton_client.register_system_shared_memory("input0_data", "/input0_simple", input_byte_size)
+    triton_client.register_system_shared_memory("input1_data", "/input1_simple", input_byte_size)
+
+    # Set the parameters to use data from shared memory
+    inputs = []
+    inputs.append(grpcclient.InferInput('INPUT0'))
+    inputs[-1].set_parameter("shared_memory_region", "input0_data")
+    inputs[-1].set_parameter("shared_memory_byte_size", input_byte_size)
+    inputs[-1].datatype = "INT32"
+    inputs[-1].shape = [1, 16]
+
+    inputs.append(grpcclient.InferInput('INPUT1'))
+    inputs[-1].set_parameter("shared_memory_region", "input1_data")
+    inputs[-1].set_parameter("shared_memory_byte_size", input_byte_size)
+    inputs[-1].datatype = "INT32"
+    inputs[-1].shape = [1, 16]
+
+    outputs = []
+    outputs.append(grpcclient.InferOutput('OUTPUT0'))
+    # outputs[-1].set_parameter("shared_memory_region", "output0_data")
+    # outputs[-1].set_parameter("shared_memory_byte_size", output_byte_size)
+
+    outputs.append(grpcclient.InferOutput('OUTPUT1'))
+    # outputs[-1].set_parameter("shared_memory_region", "output1_data")
+    # outputs[-1].set_parameter("shared_memory_byte_size", output_byte_size)
+
+    results = triton_client.infer(inputs, outputs, model_name)
+
+    # Get the output arrays from the
+    output0_data = results.as_numpy('OUTPUT0')
+    output1_data = results.as_numpy('OUTPUT1')
+
+    for i in range(16):
+        print(str(input0_data[i]) + " + " + str(input1_data[i]) + " = " +
+              str(output0_data[0][i]))
+        print(str(input0_data[i]) + " - " + str(input1_data[i]) + " = " +
+              str(output1_data[0][i]))
+        if (input0_data[i] + input1_data[i]) != output0_data[0][i]:
+            print("shm infer error: incorrect sum")
+            sys.exit(1)
+        if (input0_data[i] - input1_data[i]) != output1_data[0][i]:
+            print("shm infer error: incorrect difference")
+            sys.exit(1)
+
+    print(triton_client.get_system_shared_memory_status())
+    triton_client.unregister_system_shared_memory()
+    shm.destroy_shared_memory_region(shm_ip0_handle)
+    shm.destroy_shared_memory_region(shm_ip1_handle)
+    shm.destroy_shared_memory_region(shm_op0_handle)
+    shm.destroy_shared_memory_region(shm_op1_handle)
+
+    print('PASS: shm')

--- a/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_shm_client.py
+++ b/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_shm_client.py
@@ -58,6 +58,8 @@ if __name__ == '__main__':
         print("channel creation failed: " + str(e))
         sys.exit()
     
+    # To make sure no shared memory regions are registered with the
+    # server.
     triton_client.unregister_system_shared_memory()
     triton_client.unregister_cuda_shared_memory()
 
@@ -80,7 +82,7 @@ if __name__ == '__main__':
     shm_op0_handle = shm.create_shared_memory_region("output0_data", "/output0_simple", output_byte_size)
     shm_op1_handle = shm.create_shared_memory_region("output1_data", "/output1_simple", output_byte_size)
 
-    # Register Output0 and Output1 shared memory with TRTIS
+    # Register Output0 and Output1 shared memory with Triton Server
     triton_client.register_system_shared_memory("output0_data", "/output0_simple", output_byte_size)
     triton_client.register_system_shared_memory("output1_data", "/output1_simple", output_byte_size)
 
@@ -121,7 +123,11 @@ if __name__ == '__main__':
 
     results = triton_client.infer(inputs, outputs, model_name)
 
-    # Get the output arrays from the
+    # TODO : Currently, this example doesn't use shared memory for output.
+    # This is done to effectively validate the results.
+    # tritongrpcclient.shared_memory module will be enhanced to read
+    # data from a specified shared memory handle, data_type and shape;
+    # and later return the numpy array.
     output0_data = results.as_numpy('OUTPUT0')
     output1_data = results.as_numpy('OUTPUT1')
 

--- a/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_string_infer_client.py
+++ b/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_string_infer_client.py
@@ -102,5 +102,3 @@ if __name__ == '__main__':
             sys.exit(1)
 
     print('PASS: string')
-
-    triton_client.close()

--- a/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_string_infer_client.py
+++ b/src/clients/python/experimental_api_v2/examples/simple_grpc_v2_string_infer_client.py
@@ -47,7 +47,7 @@ if __name__ == '__main__':
 
     FLAGS = parser.parse_args()
     try:
-        TRTISClient = grpcclient.InferenceServerClient(FLAGS.url)
+        triton_client = grpcclient.InferenceServerClient(FLAGS.url)
     except Exception as e:
         print("context creation failed: " + str(e))
         sys.exit()
@@ -79,7 +79,7 @@ if __name__ == '__main__':
     outputs.append(grpcclient.InferOutput('OUTPUT0'))
     outputs.append(grpcclient.InferOutput('OUTPUT1'))
 
-    results = TRTISClient.infer(inputs, outputs, model_name)
+    results = triton_client.infer(inputs, outputs, model_name)
 
     # Get the output arrays from the
     output0_data = results.as_numpy('OUTPUT0')
@@ -103,4 +103,4 @@ if __name__ == '__main__':
 
     print('PASS: string')
 
-    TRTISClient.close()
+    triton_client.close()

--- a/src/clients/python/experimental_api_v2/library/CMakeLists.txt
+++ b/src/clients/python/experimental_api_v2/library/CMakeLists.txt
@@ -27,8 +27,35 @@
 cmake_minimum_required (VERSION 3.5)
 
 if(${TRTIS_ENABLE_HTTP_V2} OR ${TRTIS_ENABLE_GRPC_V2})
+  if(NOT WIN32)
+    #
+    # libcshmv2.so
+    #
+    add_library(cshmv2 SHARED shared_memory/shared_memory.cc)
+    if(${TRTIS_ENABLE_GPU})
+      target_include_directories(cshmv2 PRIVATE ${CUDA_INCLUDE_DIRS})
+    endif() # TRTIS_ENABLE_GPU
+    target_link_libraries(cshmv2 rt)
+
+    #
+    # libccudashm.so
+    #
+    if(${TRTIS_ENABLE_GPU})
+      add_library(ccudashmv2 SHARED cuda_shared_memory/cuda_shared_memory.cc)
+      target_include_directories(ccudashmv2 PUBLIC ${CUDA_INCLUDE_DIRS})
+      target_link_libraries(ccudashmv2 PRIVATE ${CUDA_LIBRARIES})
+    endif() # TRTIS_ENABLE_GPU
+  endif() # NOT WIN32
+
   configure_file(../../../../../VERSION VERSION COPYONLY)
   configure_file(utils.py utils.py COPYONLY)
+
+  if(NOT WIN32)
+    configure_file(shared_memory/__init__.py shared_memory/__init__.py COPYONLY)
+    if(${TRTIS_ENABLE_GPU})
+      configure_file(cuda_shared_memory/__init__.py cuda_shared_memory/__init__.py COPYONLY)
+    endif() # TRTIS_ENABLE_GPU
+  endif() # NOT WIN32
 endif() # TRTIS_ENABLE_HTTP_V2 || TRTIS_ENABLE_GRPC_V2
 
 

--- a/src/clients/python/experimental_api_v2/library/cuda_shared_memory/__init__.py
+++ b/src/clients/python/experimental_api_v2/library/cuda_shared_memory/__init__.py
@@ -76,12 +76,12 @@ def _raise_error(msg):
     ex = CudaSharedMemoryException(msg)
     raise ex
 
-def create_shared_memory_region(trtis_shm_name, byte_size, device_id):
+def create_shared_memory_region(triton_shm_name, byte_size, device_id):
     """Creates a shared memory region with the specified name and size.
 
     Parameters
     ----------
-    trtis_shm_name : str
+    triton_shm_name : str
         The unique name of the cuda shared memory region to be created.
     byte_size : int
         The size in bytes of the cuda shared memory region to be created.
@@ -100,7 +100,7 @@ def create_shared_memory_region(trtis_shm_name, byte_size, device_id):
 
     cuda_shm_handle = c_void_p()
     _raise_if_error(
-        c_int(_ccudashm_shared_memory_region_create(trtis_shm_name, byte_size, device_id, byref(cuda_shm_handle))))
+        c_int(_ccudashm_shared_memory_region_create(triton_shm_name, byte_size, device_id, byref(cuda_shm_handle))))
 
     return cuda_shm_handle
 

--- a/src/clients/python/experimental_api_v2/library/cuda_shared_memory/__init__.py
+++ b/src/clients/python/experimental_api_v2/library/cuda_shared_memory/__init__.py
@@ -1,0 +1,200 @@
+# Copyright (c) 2019-2020, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from builtins import range
+from enum import IntEnum
+from functools import partial
+from future.utils import iteritems
+from ctypes import *
+import numpy as np
+from numpy.ctypeslib import ndpointer
+import pkg_resources
+import struct
+
+class _utf8(object):
+    @classmethod
+    def from_param(cls, value):
+        if value is None:
+            return None
+        elif isinstance(value, bytes):
+            return value
+        else:
+            return value.encode('utf8')
+
+import os
+_ccudashm_lib = "ccudashmv2" if os.name == 'nt' else 'libccudashmv2.so'
+_ccudashm_path = pkg_resources.resource_filename('tritongrpcclient.cuda_shared_memory', _ccudashm_lib)
+_ccudashm = cdll.LoadLibrary(_ccudashm_path)
+
+_ccudashm_shared_memory_region_create = _ccudashm.CudaSharedMemoryRegionCreate
+_ccudashm_shared_memory_region_create.restype = c_int
+_ccudashm_shared_memory_region_create.argtypes = [_utf8, c_uint64, c_uint64, POINTER(c_void_p)]
+_ccudashm_get_raw_handle = _ccudashm.CudaSharedMemoryGetRawHandle
+_ccudashm_get_raw_handle.restype = c_int
+_ccudashm_get_raw_handle.argtypes = [c_void_p, POINTER(c_char_p)]
+_ccudashm_shared_memory_region_set = _ccudashm.CudaSharedMemoryRegionSet
+_ccudashm_shared_memory_region_set.restype = c_int
+_ccudashm_shared_memory_region_set.argtypes = [c_void_p, c_uint64, c_uint64, c_void_p]
+_ccudashm_shared_memory_region_destroy = _ccudashm.CudaSharedMemoryRegionDestroy
+_ccudashm_shared_memory_region_destroy.restype = c_int
+_ccudashm_shared_memory_region_destroy.argtypes = [c_void_p]
+
+def _raise_if_error(errno):
+    """
+    Raise CudaSharedMemoryException if 'err' is non-success.
+    Otherwise return nothing.
+    """
+    if errno.value != 0:
+        ex = CudaSharedMemoryException(errno)
+        raise ex
+    return
+
+def _raise_error(msg):
+    ex = CudaSharedMemoryException(msg)
+    raise ex
+
+def create_shared_memory_region(trtis_shm_name, byte_size, device_id):
+    """Creates a shared memory region with the specified name and size.
+
+    Parameters
+    ----------
+    trtis_shm_name : str
+        The unique name of the cuda shared memory region to be created.
+    byte_size : int
+        The size in bytes of the cuda shared memory region to be created.
+    device_id : int
+        The GPU device ID of the cuda shared memory region to be created.
+    Returns
+    -------
+    cuda_shm_handle : c_void_p
+        The handle for the cuda shared memory region.
+
+    Raises
+    ------
+    CudaSharedMemoryException
+        If unable to create the cuda shared memory region on the specified device.
+    """
+
+    cuda_shm_handle = c_void_p()
+    _raise_if_error(
+        c_int(_ccudashm_shared_memory_region_create(trtis_shm_name, byte_size, device_id, byref(cuda_shm_handle))))
+
+    return cuda_shm_handle
+
+def get_raw_handle(cuda_shm_handle):
+    """Returns the underlying raw serialized cudaIPC handle.
+
+    Parameters
+    ----------
+    cuda_shm_handle : c_void_p
+        The handle for the cuda shared memory region.
+    
+    Returns
+    -------
+    bytes
+        The underlying raw serialized cudaIPC handle
+
+    """
+    craw_handle = c_char_p()
+    _raise_if_error(c_int(_ccudashm_get_raw_handle(cuda_shm_handle, byref(craw_handle))))
+
+    return craw_handle.value
+
+
+def set_shared_memory_region(cuda_shm_handle, input_values):
+    """Copy the contents of the numpy array into a shared memory region with
+    the specified identifier, offset and size.
+
+    Parameters
+    ----------
+    cuda_shm_handle : c_void_p
+        The handle for the cuda shared memory region.
+    input_values : np.array
+        The list of numpy arrays to be copied into the shared memory region.
+
+    Raises
+    ------
+    CudaSharedMemoryException
+        If unable to set values in the cuda shared memory region.
+    """
+
+    if not isinstance(input_values, (list,tuple)):
+        _raise_error("input_values must be specified as a numpy array")
+    for input_value in input_values:
+        if not isinstance(input_value, (np.ndarray,)):
+            _raise_error("input_values must be specified as a list/tuple of numpy arrays")
+
+    offset_current = 0
+    for input_value in input_values:
+        input_value = np.ascontiguousarray(input_value).flatten()
+        byte_size = input_value.size * input_value.itemsize
+        _raise_if_error(
+            c_int(_ccudashm_shared_memory_region_set(cuda_shm_handle, c_uint64(offset_current), \
+                c_uint64(byte_size), input_value.ctypes.data_as(c_void_p))))
+        offset_current += byte_size
+    return
+
+def destroy_shared_memory_region(cuda_shm_handle):
+    """Close a cuda shared memory region with the specified handle.
+
+    Parameters
+    ----------
+    cuda_shm_handle : c_void_p
+        The handle for the cuda shared memory region.
+
+    Raises
+    ------
+    CudaSharedMemoryException
+        If unable to close the cuda_shm_handle shared memory region and free the device memory.
+    """
+
+    _raise_if_error(
+        c_int(_ccudashm_shared_memory_region_destroy(cuda_shm_handle)))
+    return
+
+class CudaSharedMemoryException(Exception):
+    """Exception indicating non-Success status.
+
+    Parameters
+    ----------
+    err : c_void_p
+        Pointer to an Error that should be used to initialize the exception.
+
+    """
+    def __init__(self, err):
+        self.err_code_map = { -1: "unable to set device successfully",
+                            -2: "unable to create cuda shared memory handle",
+                            -3: "unable to set values in cuda shared memory",
+                            -4: "unable to free GPU device memory"}
+        self._msg = None
+        if type(err) == str:
+            self._msg = err
+        elif err.value != 0 and err.value in self.err_code_map:
+            self._msg = self.err_code_map[err.value]
+
+    def __str__(self):
+        msg = super().__str__() if self._msg is None else self._msg
+        return msg

--- a/src/clients/python/experimental_api_v2/library/cuda_shared_memory/cuda_shared_memory.cc
+++ b/src/clients/python/experimental_api_v2/library/cuda_shared_memory/cuda_shared_memory.cc
@@ -24,11 +24,11 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "src/clients/python/api_v1/library/cuda_shared_memory/cuda_shared_memory.h"
+#include "src/clients/python/experimental_api_v2/library/cuda_shared_memory/cuda_shared_memory.h"
 
 #include <cuda_runtime_api.h>
 #include <iostream>
-#include "src/clients/python/api_v1/library/shared_memory/shared_memory_handle.h"
+#include "src/clients/python/experimental_api_v2/library/shared_memory/shared_memory_handle.h"
 
 //==============================================================================
 // SharedMemoryControlContext
@@ -37,11 +37,11 @@ namespace {
 
 void*
 CudaSharedMemoryHandleCreate(
-    std::string trtis_shm_name, cudaIpcMemHandle_t cuda_shm_handle,
+    std::string triton_shm_name, cudaIpcMemHandle_t cuda_shm_handle,
     void* base_addr, size_t byte_size, int device_id)
 {
   SharedMemoryHandle* handle = new SharedMemoryHandle();
-  handle->trtis_shm_name_ = trtis_shm_name;
+  handle->triton_shm_name_ = triton_shm_name;
   handle->cuda_shm_handle_ = cuda_shm_handle;
   handle->base_addr_ = base_addr;
   handle->byte_size_ = byte_size;
@@ -56,7 +56,7 @@ CudaSharedMemoryHandleCreate(
 
 int
 CudaSharedMemoryRegionCreate(
-    const char* trtis_shm_name, size_t byte_size, int device_id,
+    const char* triton_shm_name, size_t byte_size, int device_id,
     void** cuda_shm_handle)
 {
   // remember previous device and set to new device
@@ -81,7 +81,7 @@ CudaSharedMemoryRegionCreate(
 
   // create a handle for the shared memory region
   *cuda_shm_handle = CudaSharedMemoryHandleCreate(
-      std::string(trtis_shm_name), cuda_handle, base_addr, byte_size,
+      std::string(triton_shm_name), cuda_handle, base_addr, byte_size,
       device_id);
 
   // Set device to previous GPU

--- a/src/clients/python/experimental_api_v2/library/cuda_shared_memory/cuda_shared_memory.cc
+++ b/src/clients/python/experimental_api_v2/library/cuda_shared_memory/cuda_shared_memory.cc
@@ -1,0 +1,164 @@
+// Copyright (c) 2019-2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "src/clients/python/api_v1/library/cuda_shared_memory/cuda_shared_memory.h"
+
+#include <cuda_runtime_api.h>
+#include <iostream>
+#include "src/clients/python/api_v1/library/shared_memory/shared_memory_handle.h"
+
+//==============================================================================
+// SharedMemoryControlContext
+
+namespace {
+
+void*
+CudaSharedMemoryHandleCreate(
+    std::string trtis_shm_name, cudaIpcMemHandle_t cuda_shm_handle,
+    void* base_addr, size_t byte_size, int device_id)
+{
+  SharedMemoryHandle* handle = new SharedMemoryHandle();
+  handle->trtis_shm_name_ = trtis_shm_name;
+  handle->cuda_shm_handle_ = cuda_shm_handle;
+  handle->base_addr_ = base_addr;
+  handle->byte_size_ = byte_size;
+  handle->device_id_ = device_id;
+  handle->offset_ = 0;
+  handle->shm_key_ = "";
+  handle->shm_fd_ = 0;
+  return reinterpret_cast<void*>(handle);
+}
+
+}  // namespace
+
+int
+CudaSharedMemoryRegionCreate(
+    const char* trtis_shm_name, size_t byte_size, int device_id,
+    void** cuda_shm_handle)
+{
+  // remember previous device and set to new device
+  int previous_device;
+  cudaGetDevice(&previous_device);
+  cudaError_t err = cudaSetDevice(device_id);
+  if (err != cudaSuccess) {
+    cudaSetDevice(previous_device);
+    return -1;
+  }
+
+  void* base_addr;
+  cudaIpcMemHandle_t cuda_handle;
+
+  // Allocate data and create cuda IPC handle for data on the gpu
+  err = cudaMalloc(&base_addr, byte_size);
+  err = cudaIpcGetMemHandle(&cuda_handle, base_addr);
+  if (err != cudaSuccess) {
+    cudaSetDevice(previous_device);
+    return -2;
+  }
+
+  // create a handle for the shared memory region
+  *cuda_shm_handle = CudaSharedMemoryHandleCreate(
+      std::string(trtis_shm_name), cuda_handle, base_addr, byte_size,
+      device_id);
+
+  // Set device to previous GPU
+  cudaSetDevice(previous_device);
+
+  return 0;
+}
+
+int
+CudaSharedMemoryGetRawHandle(
+    void* cuda_shm_handle, const char** serialized_raw_handle)
+{
+  if (cuda_shm_handle == nullptr) {
+    return -1;
+  }
+  // TODO: Serialize cuda_shm_handle into serialized_raw_handle
+  return 0;
+}
+
+int
+CudaSharedMemoryRegionSet(
+    void* cuda_shm_handle, size_t offset, size_t byte_size, const void* data)
+{
+  // remember previous device and set to new device
+  int previous_device;
+  cudaGetDevice(&previous_device);
+  cudaError_t err = cudaSetDevice(
+      reinterpret_cast<SharedMemoryHandle*>(cuda_shm_handle)->device_id_);
+  if (err != cudaSuccess) {
+    cudaSetDevice(previous_device);
+    return -1;
+  }
+
+  // Copy data into cuda shared memory
+  void* base_addr =
+      reinterpret_cast<SharedMemoryHandle*>(cuda_shm_handle)->base_addr_;
+  err = cudaMemcpy(
+      reinterpret_cast<uint8_t*>(base_addr) + offset, data, byte_size,
+      cudaMemcpyHostToDevice);
+  if (err != cudaSuccess) {
+    cudaSetDevice(previous_device);
+    return -3;
+  }
+
+  // Set device to previous GPU
+  cudaSetDevice(previous_device);
+
+  return 0;
+}
+
+int
+CudaSharedMemoryRegionDestroy(void* cuda_shm_handle)
+{
+  // remember previous device and set to new device
+  int previous_device;
+  cudaGetDevice(&previous_device);
+  cudaError_t err = cudaSetDevice(
+      reinterpret_cast<SharedMemoryHandle*>(cuda_shm_handle)->device_id_);
+  if (err != cudaSuccess) {
+    cudaSetDevice(previous_device);
+    return -1;
+  }
+
+  SharedMemoryHandle* shm_hand =
+      reinterpret_cast<SharedMemoryHandle*>(cuda_shm_handle);
+
+  // Free GPU device memory
+  err = cudaFree(shm_hand->base_addr_);
+  if (err != cudaSuccess) {
+    cudaSetDevice(previous_device);
+    return -4;
+  }
+
+  // Set device to previous GPU
+  cudaSetDevice(previous_device);
+
+  return 0;
+}
+
+//==============================================================================

--- a/src/clients/python/experimental_api_v2/library/cuda_shared_memory/cuda_shared_memory.h
+++ b/src/clients/python/experimental_api_v2/library/cuda_shared_memory/cuda_shared_memory.h
@@ -1,0 +1,47 @@
+// Copyright (c) 2019-2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//==============================================================================
+// SharedMemoryControlContext
+int CudaSharedMemoryRegionCreate(
+    const char* trtis_shm_name, size_t byte_size, int device_id,
+    void** cuda_shm_handle);
+int CudaSharedMemoryRegionSet(
+    void* cuda_shm_handle, size_t offset, size_t byte_size, const void* data);
+int CudaSharedMemoryRegionDestroy(void* cuda_shm_handle);
+
+//==============================================================================
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/clients/python/experimental_api_v2/library/cuda_shared_memory/cuda_shared_memory.h
+++ b/src/clients/python/experimental_api_v2/library/cuda_shared_memory/cuda_shared_memory.h
@@ -34,7 +34,7 @@ extern "C" {
 //==============================================================================
 // SharedMemoryControlContext
 int CudaSharedMemoryRegionCreate(
-    const char* trtis_shm_name, size_t byte_size, int device_id,
+    const char* triton_shm_name, size_t byte_size, int device_id,
     void** cuda_shm_handle);
 int CudaSharedMemoryRegionSet(
     void* cuda_shm_handle, size_t offset, size_t byte_size, const void* data);

--- a/src/clients/python/experimental_api_v2/library/grpc_build_wheel.sh
+++ b/src/clients/python/experimental_api_v2/library/grpc_build_wheel.sh
@@ -58,6 +58,22 @@ function main() {
   cp utils.py \
     "${WHLDIR}/tritongrpcclient/."
 
+  if [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+    mkdir -p ${WHLDIR}/tritongrpcclient/shared_memory
+    cp libcshmv2.so \
+      "${WHLDIR}/tritongrpcclient/shared_memory/."
+    cp shared_memory/__init__.py \
+      "${WHLDIR}/tritongrpcclient/shared_memory/."
+
+    if [ -f libccudashmv2.so ] && [ -f cuda_shared_memory/__init__.py ]; then
+      mkdir -p ${WHLDIR}/tritongrpcclient/cuda_shared_memory
+      cp libccudashmv2.so \
+        "${WHLDIR}/tritongrpcclient/cuda_shared_memory/."
+      cp cuda_shared_memory/__init__.py \
+        "${WHLDIR}/tritongrpcclient/cuda_shared_memory/."
+    fi
+  fi
+
   cp grpc_setup.py "${WHLDIR}"
   touch ${WHLDIR}/tritongrpcclient/__init__.py
 

--- a/src/clients/python/experimental_api_v2/library/grpc_setup.py
+++ b/src/clients/python/experimental_api_v2/library/grpc_setup.py
@@ -53,6 +53,11 @@ try:
 except ImportError:
     bdist_wheel = None
 
+if not os.name == 'nt':
+    platform_package_data = [ 'libcshmv2.so' ]
+    if bool(os.environ.get('CUDA_VERSION', 0)):
+        platform_package_data += ['libccudashmv2.so']
+
 setup(
     name='tritongrpcclient',
     version=VERSION,
@@ -64,6 +69,9 @@ setup(
     keywords='triton tensorrt inference server service client',
     packages=find_packages(),
     install_requires=REQUIRED,
+    package_data={
+        '': platform_package_data,
+    },
     zip_safe=False,
     cmdclass={'bdist_wheel': bdist_wheel},
 )

--- a/src/clients/python/experimental_api_v2/library/grpcclient.py
+++ b/src/clients/python/experimental_api_v2/library/grpcclient.py
@@ -301,6 +301,183 @@ class InferenceServerClient:
         """
         raise_error("Not implemented yet")
 
+    def get_system_shared_memory_status(self, region_name="", as_json=False):
+        """Request system shared memory status from the server.
+
+        Parameters
+        ----------
+        region_name : str
+            The name of the region to query status. The default
+            value is an empty string, which means that the status
+            of all active system shared memory will be returned.
+
+        Returns
+        -------
+        dict or protobuf message 
+            The JSON dict or SystemSharedMemoryStatusResponse message holding
+            the metadata.
+
+        Raises
+        ------
+        InferenceServerException
+            If unable to get the status of specified shared memory.
+
+        """
+
+        try:
+            request = grpc_service_v2_pb2.SystemSharedMemoryStatusRequest(name=region_name)
+            response = self._client_stub.SystemSharedMemoryStatus(request)
+            if as_json:
+                return json.loads(MessageToJson(response))
+            else:
+                return response
+        except grpc.RpcError as rpc_error:
+            raise_error_grpc(rpc_error)
+
+    def register_system_shared_memory(self, name, key, byte_size, offset=0):
+        """Request the server to register a system shared memory with the
+        following specification.
+
+        Parameters
+        ----------
+        name : str
+            The name of the region to register.
+        key : str 
+            The key of the underlying memory object that contains the
+            system shared memory region.
+        byte_size : int
+            The size of the system shared memory region, in bytes.
+        offset : int
+            Offset, in bytes, within the underlying memory object to
+            the start of the system shared memory region. The default
+            value is zero.
+
+        Raises
+        ------
+        InferenceServerException
+            If unable to register the specified system shared memory.     
+
+        """
+        try:
+            request = grpc_service_v2_pb2.SystemSharedMemoryRegisterRequest(
+                    name=name,
+                    key=key,
+                    offset=offset,
+                    byte_size=byte_size)
+            self._client_stub.SystemSharedMemoryRegister(request)
+        except grpc.RpcError as rpc_error:
+            raise_error_grpc(rpc_error)
+
+    def unregister_system_shared_memory(self, name=""):
+        """Request the server to unregister a system shared memory with the
+        specified name.
+
+        Parameters
+        ----------
+        name : str
+            The name of the region to unregister. The default value is empty
+            string which means all the system shared memory regions will be
+            unregistered.
+        
+        Raises
+        ------
+        InferenceServerException
+            If unable to unregister the specified system shared memory region.
+
+        """
+        try:
+            request = grpc_service_v2_pb2.SystemSharedMemoryUnregisterRequest(name=name)
+            self._client_stub.SystemSharedMemoryUnregister(request)
+        except grpc.RpcError as rpc_error:
+            raise_error_grpc(rpc_error)
+
+    def get_cuda_shared_memory_status(self, region_name="", as_json=False):
+        """Request cuda shared memory status from the server.
+
+        Parameters
+        ----------
+        region_name : str
+            The name of the region to query status. The default
+            value is an empty string, which means that the status
+            of all active cuda shared memory will be returned.
+
+        Returns
+        -------
+        dict or protobuf message 
+            The JSON dict or CudaSharedMemoryStatusResponse message holding
+            the metadata.
+
+        Raises
+        ------
+        InferenceServerException
+            If unable to get the status of specified shared memory.
+
+        """
+
+        try:
+            request = grpc_service_v2_pb2.CudaSharedMemoryStatusRequest(name=region_name)
+            response = self._client_stub.CudaSharedMemoryStatus(request)
+            if as_json:
+                return json.loads(MessageToJson(response))
+            else:
+                return response
+        except grpc.RpcError as rpc_error:
+            raise_error_grpc(rpc_error)
+
+    def register_cuda_shared_memory(self, name, raw_handle, device_id, byte_size):
+        """Request the server to register a system shared memory with the
+        following specification.
+
+        Parameters
+        ----------
+        name : str
+            The name of the region to register.
+        raw_handle : bytes 
+            The raw serialized cudaIPC handle.
+        device_id : int
+            The GPU device ID on which the cudaIPC handle was created.
+        byte_size : int
+            The size of the cuda shared memory region, in bytes.
+
+        Raises
+        ------
+        InferenceServerException
+            If unable to register the specified cuda shared memory.     
+
+        """
+        try:
+            request = grpc_service_v2_pb2.CudaSharedMemoryRegisterRequest(
+                    name=name,
+                    raw_handle=raw_handle,
+                    device_id=device_id,
+                    byte_size=byte_size)
+            self._client_stub.CudaSharedMemoryRegister(request)
+        except grpc.RpcError as rpc_error:
+            raise_error_grpc(rpc_error)
+
+    def unregister_cuda_shared_memory(self, name=""):
+        """Request the server to unregister a cuda shared memory with the
+        specified name.
+
+        Parameters
+        ----------
+        name : str
+            The name of the region to unregister. The default value is empty
+            string which means all the cuda shared memory regions will be
+            unregistered.
+        
+        Raises
+        ------
+        InferenceServerException
+            If unable to unregister the specified cuda shared memory region.
+
+        """
+        try:
+            request = grpc_service_v2_pb2.CudaSharedMemoryUnregisterRequest(name=name)
+            self._client_stub.CudaSharedMemoryUnregister(request)
+        except grpc.RpcError as rpc_error:
+            raise_error_grpc(rpc_error)
+    
     # FIXMEPV2: Add parameter support
     def parameters(self):
         raise_error("Not implemented yet")
@@ -484,6 +661,7 @@ class InferInput:
         """
         return self._input.name
 
+    @property
     def datatype(self):
         """Get the datatype of input associated with this object.
 
@@ -494,6 +672,19 @@ class InferInput:
         """
         return self._input.datatype
 
+    @datatype.setter
+    def datatype(self, value):
+        """Sets the datatype for the input associated with this
+        object
+
+        Parameters
+        ----------
+        value : str
+            The datatype of input
+        """
+        self._input.datatype = value
+
+    @property
     def shape(self):
         """Get the shape of input associated with this object.
 
@@ -503,6 +694,18 @@ class InferInput:
             The shape of input
         """
         return self._input.shape
+
+    @shape.setter
+    def shape(self, value):
+        """Sets the shape of input associated with this object.
+
+        Parameters
+        ----------
+        value : list
+            The shape of input
+        """
+        self._input.ClearField('shape')
+        self._input.shape.extend(value)
 
     def set_data_from_numpy(self, input_tensor):
         """Set the tensor data (datatype, shape, contents) from the
@@ -524,9 +727,32 @@ class InferInput:
         else:
             self._input.contents.raw_contents = input_tensor.tobytes()
 
-    # FIXMEPV2: Add parameter support
-    def parameters(self):
-        raise_error("Not implemented yet")
+    def set_parameter(self, key, value):
+        """Adds the specified key-value pair in the requested input parameters
+
+        Parameters
+        ----------
+        key : str
+            The name of the parameter to be included in the request. 
+        value : str/int/bool
+            The value of the parameter
+        
+        """
+        if not type(key) is str:
+            raise_error(
+                "only string data type for key is supported in parameters")
+
+        param = self._input.parameters[key]
+        if type(value) is int:
+            param.int64_param = value
+        elif type(value) is bool:
+            param.bool_param = value
+        elif type(value) is str:
+            param.string_param = value.encode()
+        elif type(value) is bytes:
+            param.string_param = value
+        else:
+            raise_error("unsupported value type for the parameter")
 
     def _get_tensor(self):
         """Retrieve the underlying InferInputTensor message.
@@ -584,6 +810,8 @@ class InferOutput:
         elif type(value) is bool:
             param.bool_param = value
         elif type(value) is str:
+            param.string_param = value.encode()
+        elif type(value) is bytes:
             param.string_param = value
         else:
             raise_error("unsupported value type for the parameter")

--- a/src/clients/python/experimental_api_v2/library/grpcclient.py
+++ b/src/clients/python/experimental_api_v2/library/grpcclient.py
@@ -310,6 +310,10 @@ class InferenceServerClient:
             The name of the region to query status. The default
             value is an empty string, which means that the status
             of all active system shared memory will be returned.
+        as_json : bool
+            If True then returns system shared memory status as a 
+            json dict, otherwise as a protobuf message. Default
+            value is False.
 
         Returns
         -------
@@ -400,6 +404,10 @@ class InferenceServerClient:
             The name of the region to query status. The default
             value is an empty string, which means that the status
             of all active cuda shared memory will be returned.
+        as_json : bool
+            If True then returns cuda shared memory status as a 
+            json dict, otherwise as a protobuf message. Default
+            value is False.
 
         Returns
         -------
@@ -748,8 +756,6 @@ class InferInput:
         elif type(value) is bool:
             param.bool_param = value
         elif type(value) is str:
-            param.string_param = value.encode()
-        elif type(value) is bytes:
             param.string_param = value
         else:
             raise_error("unsupported value type for the parameter")
@@ -810,8 +816,6 @@ class InferOutput:
         elif type(value) is bool:
             param.bool_param = value
         elif type(value) is str:
-            param.string_param = value.encode()
-        elif type(value) is bytes:
             param.string_param = value
         else:
             raise_error("unsupported value type for the parameter")

--- a/src/clients/python/experimental_api_v2/library/shared_memory/__init__.py
+++ b/src/clients/python/experimental_api_v2/library/shared_memory/__init__.py
@@ -73,12 +73,12 @@ def _raise_error(msg):
     ex = SharedMemoryException(msg)
     raise ex
 
-def create_shared_memory_region(trtis_shm_name, shm_key, byte_size):
+def create_shared_memory_region(triton_shm_name, shm_key, byte_size):
     """Creates a shared memory region with the specified name and size.
 
     Parameters
     ----------
-    trtis_shm_name : str
+    triton_shm_name : str
         The unique name of the shared memory region to be created.
     shm_key : str
         The unique key of the shared memory object.
@@ -98,7 +98,7 @@ def create_shared_memory_region(trtis_shm_name, shm_key, byte_size):
 
     shm_handle = c_void_p()
     _raise_if_error(
-        c_int(_cshm_shared_memory_region_create(trtis_shm_name, shm_key, byte_size, byref(shm_handle))))
+        c_int(_cshm_shared_memory_region_create(triton_shm_name, shm_key, byte_size, byref(shm_handle))))
 
     return shm_handle
 

--- a/src/clients/python/experimental_api_v2/library/shared_memory/__init__.py
+++ b/src/clients/python/experimental_api_v2/library/shared_memory/__init__.py
@@ -1,0 +1,177 @@
+# Copyright (c) 2019-2020, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from builtins import range
+from enum import IntEnum
+from functools import partial
+from future.utils import iteritems
+from ctypes import *
+import numpy as np
+from numpy.ctypeslib import ndpointer
+import pkg_resources
+import struct
+
+class _utf8(object):
+    @classmethod
+    def from_param(cls, value):
+        if value is None:
+            return None
+        elif isinstance(value, bytes):
+            return value
+        else:
+            return value.encode('utf8')
+
+import os
+_cshm_lib = "cshmv2" if os.name == 'nt' else 'libcshmv2.so'
+_cshm_path = pkg_resources.resource_filename('tritongrpcclient.shared_memory', _cshm_lib)
+_cshm = cdll.LoadLibrary(_cshm_path)
+
+_cshm_shared_memory_region_create = _cshm.SharedMemoryRegionCreate
+_cshm_shared_memory_region_create.restype = c_int
+_cshm_shared_memory_region_create.argtypes = [_utf8, _utf8, c_uint64, POINTER(c_void_p)]
+_cshm_shared_memory_region_set = _cshm.SharedMemoryRegionSet
+_cshm_shared_memory_region_set.restype = c_int
+_cshm_shared_memory_region_set.argtypes = [c_void_p, c_uint64, c_uint64, c_void_p]
+_cshm_shared_memory_region_destroy = _cshm.SharedMemoryRegionDestroy
+_cshm_shared_memory_region_destroy.restype = c_int
+_cshm_shared_memory_region_destroy.argtypes = [c_void_p]
+
+def _raise_if_error(errno):
+    """
+    Raise SharedMemoryException if 'err' is non-success.
+    Otherwise return nothing.
+    """
+    if errno.value != 0:
+        ex = SharedMemoryException(errno)
+        raise ex
+    return
+
+def _raise_error(msg):
+    ex = SharedMemoryException(msg)
+    raise ex
+
+def create_shared_memory_region(trtis_shm_name, shm_key, byte_size):
+    """Creates a shared memory region with the specified name and size.
+
+    Parameters
+    ----------
+    trtis_shm_name : str
+        The unique name of the shared memory region to be created.
+    shm_key : str
+        The unique key of the shared memory object.
+    byte_size : int
+        The size in bytes of the shared memory region to be created.
+
+    Returns
+    -------
+    shm_handle : c_void_p
+        The handle for the shared memory region.
+
+    Raises
+    ------
+    SharedMemoryException
+        If unable to create the shared memory region.
+    """
+
+    shm_handle = c_void_p()
+    _raise_if_error(
+        c_int(_cshm_shared_memory_region_create(trtis_shm_name, shm_key, byte_size, byref(shm_handle))))
+
+    return shm_handle
+
+def set_shared_memory_region(shm_handle, input_values):
+    """Copy the contents of the numpy array into a shared memory region.
+
+    Parameters
+    ----------
+    shm_handle : c_void_p
+        The handle for the shared memory region.
+    input_values : np.array
+        The list of numpy arrays to be copied into the shared memory region.
+
+    Raises
+    ------
+    SharedMemoryException
+        If unable to mmap or set values in the shared memory region.
+    """
+
+    if not isinstance(input_values, (list,tuple)):
+        _raise_error("input_values must be specified as a list/tuple of numpy arrays")
+    for input_value in input_values:
+        if not isinstance(input_value, np.ndarray):
+            _raise_error("each element of input_values must be a numpy array")
+
+    offset_current = 0
+    for input_value in input_values:
+        input_value = np.ascontiguousarray(input_value).flatten()
+        byte_size = input_value.size * input_value.itemsize
+        _raise_if_error(
+            c_int(_cshm_shared_memory_region_set(shm_handle, c_uint64(offset_current), \
+                c_uint64(byte_size), input_value.ctypes.data_as(c_void_p))))
+        offset_current += byte_size
+    return
+
+def destroy_shared_memory_region(shm_handle):
+    """Unlink a shared memory region with the specified handle.
+
+    Parameters
+    ----------
+    shm_handle : c_void_p
+        The handle for the shared memory region.
+
+    Raises
+    ------
+    SharedMemoryException
+        If unable to unlink the shared memory region.
+    """
+
+    _raise_if_error(
+        c_int(_cshm_shared_memory_region_destroy(shm_handle)))
+    return
+
+class SharedMemoryException(Exception):
+    """Exception indicating non-Success status.
+
+    Parameters
+    ----------
+    err : c_void_p
+        Pointer to an Error that should be used to initialize the exception.
+
+    """
+    def __init__(self, err):
+        self.err_code_map = { -2: "unable to get shared memory descriptor",
+                            -3: "unable to initialize the size",
+                            -4: "unable to read/mmap the shared memory region",
+                            -5: "unable to unlink the shared memory region"}
+        self._msg = None
+        if type(err) == str:
+            self._msg = err
+        elif err.value != 0 and err.value in self.err_code_map:
+            self._msg = self.err_code_map[err.value]
+
+    def __str__(self):
+        msg = super().__str__() if self._msg is None else self._msg
+        return msg

--- a/src/clients/python/experimental_api_v2/library/shared_memory/shared_memory.cc
+++ b/src/clients/python/experimental_api_v2/library/shared_memory/shared_memory.cc
@@ -1,0 +1,127 @@
+// Copyright (c) 2019-2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "src/clients/python/api_v1/library/shared_memory/shared_memory.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <cstring>
+#include <iostream>
+#include "src/clients/python/api_v1/library/shared_memory/shared_memory_handle.h"
+
+//==============================================================================
+// SharedMemoryControlContext
+
+namespace {
+
+void*
+SharedMemoryHandleCreate(
+    std::string trtis_shm_name, void* shm_addr, std::string shm_key, int shm_fd,
+    size_t offset, size_t byte_size)
+{
+  SharedMemoryHandle* handle = new SharedMemoryHandle();
+  handle->trtis_shm_name_ = trtis_shm_name;
+  handle->base_addr_ = shm_addr;
+  handle->shm_key_ = shm_key;
+  handle->shm_fd_ = shm_fd;
+  handle->offset_ = offset;
+  handle->byte_size_ = byte_size;
+  return reinterpret_cast<void*>(handle);
+}
+
+int
+SharedMemoryRegionMap(
+    int shm_fd, size_t offset, size_t byte_size, void** shm_addr)
+{
+  // map shared memory to process address space
+  *shm_addr = mmap(NULL, byte_size, PROT_WRITE, MAP_SHARED, shm_fd, offset);
+  if (*shm_addr == MAP_FAILED) {
+    return -1;
+  }
+
+  // close shared memory descriptor, return 0 if success else return -1
+  return close(shm_fd);
+}
+
+}  // namespace
+
+int
+SharedMemoryRegionCreate(
+    const char* trtis_shm_name, const char* shm_key, size_t byte_size,
+    void** shm_handle)
+{
+  // get shared memory region descriptor
+  int shm_fd = shm_open(shm_key, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
+  if (shm_fd == -1) {
+    return -2;
+  }
+
+  // extend shared memory object as by default it's initialized with size 0
+  int res = ftruncate(shm_fd, byte_size);
+  if (res == -1) {
+    return -3;
+  }
+
+  // get base address of shared memory region
+  void* shm_addr = nullptr;
+  int err = SharedMemoryRegionMap(shm_fd, 0, byte_size, &shm_addr);
+  if (err == -1) {
+    return -4;
+  }
+
+  // create a handle for the shared memory region
+  *shm_handle = SharedMemoryHandleCreate(
+      std::string(trtis_shm_name), shm_addr, std::string(shm_key), shm_fd, 0,
+      byte_size);
+  return 0;
+}
+
+int
+SharedMemoryRegionSet(
+    void* shm_handle, size_t offset, size_t byte_size, const void* data)
+{
+  void* shm_addr =
+      reinterpret_cast<SharedMemoryHandle*>(shm_handle)->base_addr_;
+  char* shm_addr_offset = reinterpret_cast<char*>(shm_addr);
+  std::memcpy(shm_addr_offset + offset, data, byte_size);
+  return 0;
+}
+
+int
+SharedMemoryRegionDestroy(void* shm_handle)
+{
+  std::string shm_key =
+      reinterpret_cast<SharedMemoryHandle*>(shm_handle)->shm_key_;
+  int shm_fd = shm_unlink(shm_key.c_str());
+  if (shm_fd == -1) {
+    return -5;
+  }
+  return 0;
+}
+
+//==============================================================================

--- a/src/clients/python/experimental_api_v2/library/shared_memory/shared_memory.cc
+++ b/src/clients/python/experimental_api_v2/library/shared_memory/shared_memory.cc
@@ -24,7 +24,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "src/clients/python/api_v1/library/shared_memory/shared_memory.h"
+#include "src/clients/python/experimental_api_v2/library/shared_memory/shared_memory.h"
 
 #include <errno.h>
 #include <fcntl.h>
@@ -32,7 +32,7 @@
 #include <unistd.h>
 #include <cstring>
 #include <iostream>
-#include "src/clients/python/api_v1/library/shared_memory/shared_memory_handle.h"
+#include "src/clients/python/experimental_api_v2/library/shared_memory/shared_memory_handle.h"
 
 //==============================================================================
 // SharedMemoryControlContext
@@ -41,11 +41,11 @@ namespace {
 
 void*
 SharedMemoryHandleCreate(
-    std::string trtis_shm_name, void* shm_addr, std::string shm_key, int shm_fd,
-    size_t offset, size_t byte_size)
+    std::string triton_shm_name, void* shm_addr, std::string shm_key,
+    int shm_fd, size_t offset, size_t byte_size)
 {
   SharedMemoryHandle* handle = new SharedMemoryHandle();
-  handle->trtis_shm_name_ = trtis_shm_name;
+  handle->triton_shm_name_ = triton_shm_name;
   handle->base_addr_ = shm_addr;
   handle->shm_key_ = shm_key;
   handle->shm_fd_ = shm_fd;
@@ -72,7 +72,7 @@ SharedMemoryRegionMap(
 
 int
 SharedMemoryRegionCreate(
-    const char* trtis_shm_name, const char* shm_key, size_t byte_size,
+    const char* triton_shm_name, const char* shm_key, size_t byte_size,
     void** shm_handle)
 {
   // get shared memory region descriptor
@@ -96,7 +96,7 @@ SharedMemoryRegionCreate(
 
   // create a handle for the shared memory region
   *shm_handle = SharedMemoryHandleCreate(
-      std::string(trtis_shm_name), shm_addr, std::string(shm_key), shm_fd, 0,
+      std::string(triton_shm_name), shm_addr, std::string(shm_key), shm_fd, 0,
       byte_size);
   return 0;
 }

--- a/src/clients/python/experimental_api_v2/library/shared_memory/shared_memory.h
+++ b/src/clients/python/experimental_api_v2/library/shared_memory/shared_memory.h
@@ -1,0 +1,50 @@
+// Copyright (c) 2019-2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include <fcntl.h>
+#include <stddef.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//==============================================================================
+// SharedMemoryControlContext
+int SharedMemoryRegionCreate(
+    const char* trtis_shm_name, const char* shm_key, size_t byte_size,
+    void** shm_handle);
+int SharedMemoryRegionSet(
+    void* shm_handle, size_t offset, size_t byte_size, const void* data);
+int SharedMemoryRegionDestroy(void* shm_handle);
+
+//==============================================================================
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/clients/python/experimental_api_v2/library/shared_memory/shared_memory.h
+++ b/src/clients/python/experimental_api_v2/library/shared_memory/shared_memory.h
@@ -37,7 +37,7 @@ extern "C" {
 //==============================================================================
 // SharedMemoryControlContext
 int SharedMemoryRegionCreate(
-    const char* trtis_shm_name, const char* shm_key, size_t byte_size,
+    const char* triton_shm_name, const char* shm_key, size_t byte_size,
     void** shm_handle);
 int SharedMemoryRegionSet(
     void* shm_handle, size_t offset, size_t byte_size, const void* data);

--- a/src/clients/python/experimental_api_v2/library/shared_memory/shared_memory_handle.h
+++ b/src/clients/python/experimental_api_v2/library/shared_memory/shared_memory_handle.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2019-2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#ifdef TRTIS_ENABLE_GPU
+#include <cuda_runtime_api.h>
+#endif  // TRTIS_ENABLE_GPU
+
+struct SharedMemoryHandle {
+  std::string trtis_shm_name_;
+  std::string shm_key_;
+#ifdef TRTIS_ENABLE_GPU
+  cudaIpcMemHandle_t cuda_shm_handle_;
+  int device_id_;
+#endif  // TRTIS_ENABLE_GPU
+  void* base_addr_;
+  int shm_fd_;
+  size_t offset_;
+  size_t byte_size_;
+};

--- a/src/clients/python/experimental_api_v2/library/shared_memory/shared_memory_handle.h
+++ b/src/clients/python/experimental_api_v2/library/shared_memory/shared_memory_handle.h
@@ -31,7 +31,7 @@
 #endif  // TRTIS_ENABLE_GPU
 
 struct SharedMemoryHandle {
-  std::string trtis_shm_name_;
+  std::string triton_shm_name_;
   std::string shm_key_;
 #ifdef TRTIS_ENABLE_GPU
   cudaIpcMemHandle_t cuda_shm_handle_;

--- a/src/core/grpc_service_v2.proto
+++ b/src/core/grpc_service_v2.proto
@@ -812,7 +812,8 @@ message SystemSharedMemoryStatusResponse
   //@@
   //@@     Status for a shared memory region.
   //@@
-  message RegionStatus {
+  message RegionStatus
+  {
     //@@
     //@@    .. cpp:var:: string name
     //@@
@@ -890,9 +891,7 @@ message SystemSharedMemoryRegisterRequest
 //@@
 //@@   Response message for SystemSharedMemoryRegister.
 //@@
-message SystemSharedMemoryRegisterResponse
-{
-}
+message SystemSharedMemoryRegisterResponse {}
 
 //@@
 //@@.. cpp:var:: message SystemSharedMemoryUnregisterRequest
@@ -904,8 +903,8 @@ message SystemSharedMemoryUnregisterRequest
   //@@
   //@@  .. cpp:var:: string name
   //@@
-  //@@     The name of the region to unregister. If empty all
-  //@@     shared-memory regions are unregistered.
+  //@@     The name of the system region to unregister. If empty
+  //@@     all system shared-memory regions are unregistered.
   //@@
   string name = 1;
 }
@@ -915,9 +914,7 @@ message SystemSharedMemoryUnregisterRequest
 //@@
 //@@   Response message for SystemSharedMemoryUnregister.
 //@@
-message SystemSharedMemoryUnregisterResponse
-{
-}
+message SystemSharedMemoryUnregisterResponse {}
 
 //@@
 //@@.. cpp:var:: message CudaSharedMemoryStatusRequest
@@ -947,7 +944,8 @@ message CudaSharedMemoryStatusResponse
   //@@
   //@@     Status for a shared memory region.
   //@@
-  message RegionStatus {
+  message RegionStatus
+  {
     //@@
     //@@    .. cpp:var:: string name
     //@@
@@ -1015,9 +1013,7 @@ message CudaSharedMemoryRegisterRequest
 //@@
 //@@   Response message for CudaSharedMemoryRegister.
 //@@
-message CudaSharedMemoryRegisterResponse
-{
-}
+message CudaSharedMemoryRegisterResponse {}
 
 //@@
 //@@.. cpp:var:: message CudaSharedMemoryUnregisterRequest
@@ -1029,8 +1025,8 @@ message CudaSharedMemoryUnregisterRequest
   //@@
   //@@  .. cpp:var:: string name
   //@@
-  //@@     The name of the region to unregister. If empty all
-  //@@     shared-memory regions are unregistered.
+  //@@     The name of the cuda region to unregister. If empty
+  //@@     all cuda shared-memory regions are unregistered.
   //@@
   string name = 1;
 }
@@ -1040,6 +1036,4 @@ message CudaSharedMemoryUnregisterRequest
 //@@
 //@@   Response message for CudaSharedMemoryUnregister.
 //@@
-message CudaSharedMemoryUnregisterResponse
-{
-}
+message CudaSharedMemoryUnregisterResponse {}

--- a/src/core/grpc_service_v2.proto
+++ b/src/core/grpc_service_v2.proto
@@ -87,6 +87,72 @@ service GRPCInferenceService
   //@@     Get model configuration.
   //@@
   rpc ModelConfig(ModelConfigRequest) returns (ModelConfigResponse) {}
+
+  //@@  .. cpp:var:: rpc SystemSharedMemoryStatus(
+  //@@                     SystemSharedMemoryStatusRequest)
+  //@@                   returns (SystemSharedMemoryStatusRespose)
+  //@@
+  //@@     Get the status of all registered system-shared-memory regions.
+  //@@
+  rpc SystemSharedMemoryStatus(SystemSharedMemoryStatusRequest)
+      returns (SystemSharedMemoryStatusResponse)
+  {
+  }
+
+  //@@  .. cpp:var:: rpc SystemSharedMemoryRegister(
+  //@@                     SystemSharedMemoryRegisterRequest)
+  //@@                   returns (SystemSharedMemoryRegisterResponse)
+  //@@
+  //@@     Register a system-shared-memory region.
+  //@@
+  rpc SystemSharedMemoryRegister(SystemSharedMemoryRegisterRequest)
+      returns (SystemSharedMemoryRegisterResponse)
+  {
+  }
+
+  //@@  .. cpp:var:: rpc SystemSharedMemoryUnregister(
+  //@@                     SystemSharedMemoryUnregisterRequest)
+  //@@                   returns (SystemSharedMemoryUnregisterResponse)
+  //@@
+  //@@     Unregister a system-shared-memory region.
+  //@@
+  rpc SystemSharedMemoryUnregister(SystemSharedMemoryUnregisterRequest)
+      returns (SystemSharedMemoryUnregisterResponse)
+  {
+  }
+
+  //@@  .. cpp:var:: rpc CudaSharedMemoryStatus(
+  //@@                     CudaSharedMemoryStatusRequest)
+  //@@                   returns (CudaSharedMemoryStatusRespose)
+  //@@
+  //@@     Get the status of all registered CUDA-shared-memory regions.
+  //@@
+  rpc CudaSharedMemoryStatus(CudaSharedMemoryStatusRequest)
+      returns (CudaSharedMemoryStatusResponse)
+  {
+  }
+
+  //@@  .. cpp:var:: rpc CudaSharedMemoryRegister(
+  //@@                     CudaSharedMemoryRegisterRequest)
+  //@@                   returns (CudaSharedMemoryRegisterResponse)
+  //@@
+  //@@     Register a CUDA-shared-memory region.
+  //@@
+  rpc CudaSharedMemoryRegister(CudaSharedMemoryRegisterRequest)
+      returns (CudaSharedMemoryRegisterResponse)
+  {
+  }
+
+  //@@  .. cpp:var:: rpc CudaSharedMemoryUnregister(
+  //@@                     CudaSharedMemoryUnregisterRequest)
+  //@@                   returns (CudaSharedMemoryUnregisterResponse)
+  //@@
+  //@@     Unregister a CUDA-shared-memory region.
+  //@@
+  rpc CudaSharedMemoryUnregister(CudaSharedMemoryUnregisterRequest)
+      returns (CudaSharedMemoryUnregisterResponse)
+  {
+  }
 }
 
 //@@
@@ -716,4 +782,264 @@ message ModelConfigResponse
   //@@     The model configuration.
   //@@
   ModelConfig config = 1;
+}
+
+//@@
+//@@.. cpp:var:: message SystemSharedMemoryStatusRequest
+//@@
+//@@   Request message for SystemSharedMemoryStatus.
+//@@
+message SystemSharedMemoryStatusRequest
+{
+  //@@
+  //@@  .. cpp:var:: string name
+  //@@
+  //@@     The name of the region to get status for. If empty the
+  //@@     status is returned for all registered regions.
+  //@@
+  string name = 1;
+}
+
+//@@
+//@@.. cpp:var:: message SystemSharedMemoryStatusResponse
+//@@
+//@@   Response message for SystemSharedMemoryStatus.
+//@@
+message SystemSharedMemoryStatusResponse
+{
+  //@@
+  //@@  .. cpp:var:: message RegionStatus
+  //@@
+  //@@     Status for a shared memory region.
+  //@@
+  message RegionStatus {
+    //@@
+    //@@    .. cpp:var:: string name
+    //@@
+    //@@       The name for the shared memory region.
+    //@@
+    string name = 1;
+
+    //@@    .. cpp:var:: string shared_memory_key
+    //@@
+    //@@       The key of the underlying memory object that contains the
+    //@@       shared memory region.
+    //@@
+    string key = 2;
+
+    //@@    .. cpp:var:: uint64 offset
+    //@@
+    //@@       Offset, in bytes, within the underlying memory object to
+    //@@       the start of the shared memory region.
+    //@@
+    uint64 offset = 3;
+
+    //@@    .. cpp:var:: uint64 byte_size
+    //@@
+    //@@       Size of the shared memory region, in bytes.
+    //@@
+    uint64 byte_size = 4;
+  }
+
+  //@@
+  //@@  .. cpp:var:: map<string,RegionStatus> regions
+  //@@
+  //@@     Status for each of the registered regions, indexed by
+  //@@     region name.
+  //@@
+  map<string, RegionStatus> regions = 1;
+}
+
+//@@
+//@@.. cpp:var:: message SystemSharedMemoryRegisterRequest
+//@@
+//@@   Request message for SystemSharedMemoryRegister.
+//@@
+message SystemSharedMemoryRegisterRequest
+{
+  //@@
+  //@@  .. cpp:var:: string name
+  //@@
+  //@@     The name of the region to register.
+  //@@
+  string name = 1;
+
+  //@@  .. cpp:var:: string shared_memory_key
+  //@@
+  //@@     The key of the underlying memory object that contains the
+  //@@     shared memory region.
+  //@@
+  string key = 2;
+
+  //@@  .. cpp:var:: uint64 offset
+  //@@
+  //@@     Offset, in bytes, within the underlying memory object to
+  //@@     the start of the shared memory region.
+  //@@
+  uint64 offset = 3;
+
+  //@@  .. cpp:var:: uint64 byte_size
+  //@@
+  //@@     Size of the shared memory region, in bytes.
+  //@@
+  uint64 byte_size = 4;
+}
+
+//@@
+//@@.. cpp:var:: message SystemSharedMemoryRegisterResponse
+//@@
+//@@   Response message for SystemSharedMemoryRegister.
+//@@
+message SystemSharedMemoryRegisterResponse
+{
+}
+
+//@@
+//@@.. cpp:var:: message SystemSharedMemoryUnregisterRequest
+//@@
+//@@   Request message for SystemSharedMemoryUnregister.
+//@@
+message SystemSharedMemoryUnregisterRequest
+{
+  //@@
+  //@@  .. cpp:var:: string name
+  //@@
+  //@@     The name of the region to unregister. If empty all
+  //@@     shared-memory regions are unregistered.
+  //@@
+  string name = 1;
+}
+
+//@@
+//@@.. cpp:var:: message SystemSharedMemoryUnregisterResponse
+//@@
+//@@   Response message for SystemSharedMemoryUnregister.
+//@@
+message SystemSharedMemoryUnregisterResponse
+{
+}
+
+//@@
+//@@.. cpp:var:: message CudaSharedMemoryStatusRequest
+//@@
+//@@   Request message for CudaSharedMemoryStatus.
+//@@
+message CudaSharedMemoryStatusRequest
+{
+  //@@
+  //@@  .. cpp:var:: string name
+  //@@
+  //@@     The name of the region to get status for. If empty the
+  //@@     status is returned for all registered regions.
+  //@@
+  string name = 1;
+}
+
+//@@
+//@@.. cpp:var:: message CudaSharedMemoryStatusResponse
+//@@
+//@@   Response message for CudaSharedMemoryStatus.
+//@@
+message CudaSharedMemoryStatusResponse
+{
+  //@@
+  //@@  .. cpp:var:: message RegionStatus
+  //@@
+  //@@     Status for a shared memory region.
+  //@@
+  message RegionStatus {
+    //@@
+    //@@    .. cpp:var:: string name
+    //@@
+    //@@       The name for the shared memory region.
+    //@@
+    string name = 1;
+
+    //@@    .. cpp:var:: uin64 device_id
+    //@@
+    //@@       The GPU device ID where the cudaIPC handle was created.
+    //@@
+    uint64 device_id = 2;
+
+    //@@    .. cpp:var:: uint64 byte_size
+    //@@
+    //@@       Size of the shared memory region, in bytes.
+    //@@
+    uint64 byte_size = 3;
+  }
+
+  //@@
+  //@@  .. cpp:var:: map<string,RegionStatus> regions
+  //@@
+  //@@     Status for each of the registered regions, indexed by
+  //@@     region name.
+  //@@
+  map<string, RegionStatus> regions = 1;
+}
+
+//@@
+//@@.. cpp:var:: message CudaSharedMemoryRegisterRequest
+//@@
+//@@   Request message for CudaSharedMemoryRegister.
+//@@
+message CudaSharedMemoryRegisterRequest
+{
+  //@@
+  //@@  .. cpp:var:: string name
+  //@@
+  //@@     The name of the region to register.
+  //@@
+  string name = 1;
+
+  //@@  .. cpp:var:: bytes raw_handle
+  //@@
+  //@@     The raw serialized cudaIPC handle.
+  //@@
+  bytes raw_handle = 2;
+
+  //@@  .. cpp:var:: int64 device_id
+  //@@
+  //@@     The GPU device ID on which the cudaIPC handle was created.
+  //@@
+  int64 device_id = 3;
+
+  //@@  .. cpp:var:: uint64 byte_size
+  //@@
+  //@@     Size of the shared memory block, in bytes.
+  //@@
+  uint64 byte_size = 4;
+}
+
+//@@
+//@@.. cpp:var:: message CudaSharedMemoryRegisterResponse
+//@@
+//@@   Response message for CudaSharedMemoryRegister.
+//@@
+message CudaSharedMemoryRegisterResponse
+{
+}
+
+//@@
+//@@.. cpp:var:: message CudaSharedMemoryUnregisterRequest
+//@@
+//@@   Request message for CudaSharedMemoryUnregister.
+//@@
+message CudaSharedMemoryUnregisterRequest
+{
+  //@@
+  //@@  .. cpp:var:: string name
+  //@@
+  //@@     The name of the region to unregister. If empty all
+  //@@     shared-memory regions are unregistered.
+  //@@
+  string name = 1;
+}
+
+//@@
+//@@.. cpp:var:: message CudaSharedMemoryUnregisterResponse
+//@@
+//@@   Response message for CudaSharedMemoryUnregister.
+//@@
+message CudaSharedMemoryUnregisterResponse
+{
 }

--- a/src/core/server.cc
+++ b/src/core/server.cc
@@ -83,6 +83,7 @@ InferenceServer::InferenceServer()
 
   id_ = "inference:0";
   protocol_version_ = 1;
+  extensions_.push_back("classification");
   extensions_.push_back("model_configuration");
   extensions_.push_back("system_shared_memory");
   extensions_.push_back("cuda_shared_memory");

--- a/src/core/server.cc
+++ b/src/core/server.cc
@@ -83,13 +83,9 @@ InferenceServer::InferenceServer()
 
   id_ = "inference:0";
   protocol_version_ = 1;
-  extensions_.push_back("classification");
-  extensions_.push_back("flat_tensor_format");
   extensions_.push_back("model_configuration");
-  extensions_.push_back("model_control");
-  extensions_.push_back("sequence");
-  extensions_.push_back("shared_memory_tensor_format");
-  extensions_.push_back("statistics");
+  extensions_.push_back("system_shared_memory");
+  extensions_.push_back("cuda_shared_memory");
 
   strict_model_config_ = true;
   strict_readiness_ = true;

--- a/src/servers/grpc_server.cc
+++ b/src/servers/grpc_server.cc
@@ -863,7 +863,7 @@ InferAllocatorPayload(
     if (io.has_shared_memory()) {
       void* base;
       TRTSERVER_Memory_Type memory_type;
-      int memory_type_id;
+      int64_t memory_type_id;
       RETURN_IF_ERR(shm_manager->GetMemoryInfo(
           io.shared_memory().name(), io.shared_memory().offset(), &base,
           &memory_type, &memory_type_id));
@@ -896,7 +896,7 @@ InferGRPCToInput(
     const void* base;
     size_t byte_size;
     TRTSERVER_Memory_Type memory_type = TRTSERVER_MEMORY_CPU;
-    int memory_type_id = 0;
+    int64_t memory_type_id = 0;
     if (io.has_shared_memory()) {
       void* tmp;
       RETURN_IF_ERR(shm_manager->GetMemoryInfo(

--- a/src/servers/grpc_server_v2.cc
+++ b/src/servers/grpc_server_v2.cc
@@ -49,8 +49,7 @@
 #include "src/servers/tracer.h"
 #endif  // TRTIS_ENABLE_TRACING
 
-namespace nvidia {
-namespace inferenceserver {
+namespace nvidia { namespace inferenceserver {
 
 namespace {
 
@@ -1643,10 +1642,10 @@ ParseSharedMemoryParams(
 {
   *has_shared_memory = false;
   *offset = 0 /* default value */;
-  if (tensor.parameters().find("shared_memory_region") !=
-      tensor.parameters().end()) {
+  const auto& region_it = tensor.parameters().find("shared_memory_region");
+  if (region_it != tensor.parameters().end()) {
     *has_shared_memory = true;
-    const auto& infer_param = tensor.parameters().at("shared_memory_region");
+    const auto& infer_param = region_it->second;
     if (infer_param.parameter_choice_case() !=
         InferParameter::ParameterChoiceCase::kStringParam) {
       return TRTSERVER_ErrorNew(
@@ -1660,8 +1659,8 @@ ParseSharedMemoryParams(
     *region_name = infer_param.string_param();
   }
 
-  if (tensor.parameters().find("shared_memory_offset") !=
-      tensor.parameters().end()) {
+  const auto& offset_it = tensor.parameters().find("shared_memory_offset");
+  if (offset_it != tensor.parameters().end()) {
     if (!*has_shared_memory) {
       return TRTSERVER_ErrorNew(
           TRTSERVER_ERROR_INVALID_ARG,
@@ -1671,7 +1670,7 @@ ParseSharedMemoryParams(
               tensor.name() + "'")
               .c_str());
     }
-    const auto& infer_param = tensor.parameters().at("shared_memory_offset");
+    const auto& infer_param = offset_it->second;
     if (infer_param.parameter_choice_case() !=
         InferParameter::ParameterChoiceCase::kInt64Param) {
       return TRTSERVER_ErrorNew(
@@ -1685,8 +1684,8 @@ ParseSharedMemoryParams(
     *offset = infer_param.int64_param();
   }
 
-  if (tensor.parameters().find("shared_memory_byte_size") !=
-      tensor.parameters().end()) {
+  const auto& bs_it = tensor.parameters().find("shared_memory_byte_size");
+  if (bs_it != tensor.parameters().end()) {
     if (!*has_shared_memory) {
       return TRTSERVER_ErrorNew(
           TRTSERVER_ERROR_INVALID_ARG,
@@ -1696,7 +1695,7 @@ ParseSharedMemoryParams(
               tensor.name() + "'")
               .c_str());
     }
-    const auto& infer_param = tensor.parameters().at("shared_memory_byte_size");
+    const auto& infer_param = bs_it->second;
     if (infer_param.parameter_choice_case() !=
         InferParameter::ParameterChoiceCase::kInt64Param) {
       return TRTSERVER_ErrorNew(
@@ -1759,7 +1758,7 @@ InferAllocatorPayload(
     if (has_shared_memory) {
       void* base;
       TRTSERVER_Memory_Type memory_type;
-      int memory_type_id;
+      int64_t memory_type_id;
       RETURN_IF_ERR(shm_manager->GetMemoryInfo(
           region_name, offset, &base, &memory_type, &memory_type_id));
 
@@ -1818,7 +1817,7 @@ InferGRPCToInput(
     const void* base;
     size_t byte_size;
     TRTSERVER_Memory_Type memory_type = TRTSERVER_MEMORY_CPU;
-    int memory_type_id = 0;
+    int64_t memory_type_id = 0;
     bool has_byte_contents = false;
 
     std::string region_name;

--- a/src/servers/grpc_server_v2.h
+++ b/src/servers/grpc_server_v2.h
@@ -54,6 +54,14 @@ class GRPCServerV2 {
     virtual ~HandlerBase() = default;
   };
 
+  class ICallData {
+   public:
+    virtual ~ICallData() = default;
+    virtual bool Process(bool ok) = 0;
+    virtual std::string Name() = 0;
+    virtual uint64_t Id() = 0;
+  };
+
  private:
   GRPCServerV2(
       const std::shared_ptr<TRTSERVER_Server>& server,

--- a/src/servers/http_server.cc
+++ b/src/servers/http_server.cc
@@ -1030,7 +1030,7 @@ HTTPAPIServer::EVBufferToInput(
 
         void* base;
         TRTSERVER_Memory_Type memory_type = TRTSERVER_MEMORY_CPU;
-        int memory_type_id;
+        int64_t memory_type_id;
         RETURN_IF_ERR(shm_manager_->GetMemoryInfo(
             io.shared_memory().name(), io.shared_memory().offset(), &base,
             &memory_type, &memory_type_id));
@@ -1083,7 +1083,7 @@ HTTPAPIServer::EVBufferToInput(
     if (io.has_shared_memory()) {
       void* base;
       TRTSERVER_Memory_Type memory_type;
-      int memory_type_id;
+      int64_t memory_type_id;
       RETURN_IF_ERR(shm_manager_->GetMemoryInfo(
           io.shared_memory().name(), io.shared_memory().offset(), &base,
           &memory_type, &memory_type_id));

--- a/src/servers/http_v2_server.cc
+++ b/src/servers/http_v2_server.cc
@@ -586,7 +586,7 @@ HTTPAPIServer::EVBufferToInput(
 
         void* base;
         TRTSERVER_Memory_Type memory_type = TRTSERVER_MEMORY_CPU;
-        int memory_type_id;
+        int64_t memory_type_id;
         RETURN_IF_ERR(shm_manager_->GetMemoryInfo(
             io.shared_memory().name(), io.shared_memory().offset(), &base,
             &memory_type, &memory_type_id));
@@ -620,7 +620,7 @@ HTTPAPIServer::EVBufferToInput(
     if (io.has_shared_memory()) {
       void* base;
       TRTSERVER_Memory_Type memory_type;
-      int memory_type_id;
+      int64_t memory_type_id;
       RETURN_IF_ERR(shm_manager_->GetMemoryInfo(
           io.shared_memory().name(), io.shared_memory().offset(), &base,
           &memory_type, &memory_type_id));

--- a/src/servers/shared_memory_manager.cc
+++ b/src/servers/shared_memory_manager.cc
@@ -130,7 +130,12 @@ OpenCudaIPCRegion(
 
 SharedMemoryManager::~SharedMemoryManager()
 {
+  // FIXME: Replace UnregisterAll() call with below commented lines
   UnregisterAll();
+#ifdef TRTIS_ENABLE_GRPC_V2
+  // UnregisterAllV2(TRTSERVER_MEMORY_CPU);
+  // UnregisterAllV2(TRTSERVER_MEMORY_GPU);
+#endif
 }
 
 TRTSERVER_Error*
@@ -358,5 +363,199 @@ SharedMemoryManager::UnregisterHelper(const std::string& name)
 
   return nullptr;
 }
+
+#ifdef TRTIS_ENABLE_GRPC_V2
+TRTSERVER_Error*
+SharedMemoryManager::GetStatusV2(
+    const std::string& name, SystemSharedMemoryStatusResponse*& shm_status)
+{
+  std::lock_guard<std::mutex> lock(mu_);
+
+  if (name.empty()) {
+    for (const auto& shm_info : shared_memory_map_) {
+      if (shm_info.second->kind_ == TRTSERVER_MEMORY_CPU) {
+        SystemSharedMemoryStatusResponse::RegionStatus region_status;
+
+        region_status.set_name(shm_info.second->name_);
+        region_status.set_key(shm_info.second->shm_key_);
+        region_status.set_offset(shm_info.second->offset_);
+        region_status.set_byte_size(shm_info.second->byte_size_);
+
+        (*shm_status->mutable_regions())[shm_info.second->name_] =
+            region_status;
+      }
+    }
+  } else {
+    auto it = shared_memory_map_.find(name);
+    if (it == shared_memory_map_.end()) {
+      return TRTSERVER_ErrorNew(
+          TRTSERVER_ERROR_NOT_FOUND,
+          std::string(
+              "Unable to find system shared memory region: '" + name + "'")
+              .c_str());
+    }
+
+    if (it->second->kind_ == TRTSERVER_MEMORY_GPU) {
+      return TRTSERVER_ErrorNew(
+          TRTSERVER_ERROR_NOT_FOUND,
+          std::string(
+              "The region named '" + name +
+              "' is registered as CUDA shared memory, not system shared memory")
+              .c_str());
+    }
+
+    SystemSharedMemoryStatusResponse::RegionStatus region_status;
+
+    region_status.set_name(it->second->name_);
+    region_status.set_key(it->second->shm_key_);
+    region_status.set_offset(it->second->offset_);
+    region_status.set_byte_size(it->second->byte_size_);
+
+    (*shm_status->mutable_regions())[name] = region_status;
+  }
+
+  return nullptr;
+}
+
+TRTSERVER_Error*
+SharedMemoryManager::GetStatusV2(
+    const std::string& name, CudaSharedMemoryStatusResponse*& shm_status)
+{
+  std::lock_guard<std::mutex> lock(mu_);
+
+  if (name.empty()) {
+    for (const auto& shm_info : shared_memory_map_) {
+      if (shm_info.second->kind_ == TRTSERVER_MEMORY_GPU) {
+        CudaSharedMemoryStatusResponse::RegionStatus region_status;
+
+        region_status.set_name(shm_info.second->name_);
+        region_status.set_device_id(shm_info.second->device_id_);
+        region_status.set_byte_size(shm_info.second->byte_size_);
+
+        (*shm_status->mutable_regions())[shm_info.second->name_] =
+            region_status;
+      }
+    }
+  } else {
+    auto it = shared_memory_map_.find(name);
+    if (it == shared_memory_map_.end()) {
+      return TRTSERVER_ErrorNew(
+          TRTSERVER_ERROR_NOT_FOUND,
+          std::string(
+              "Unable to find cuda shared memory region: '" + name + "'")
+              .c_str());
+    }
+
+    if (it->second->kind_ == TRTSERVER_MEMORY_CPU) {
+      return TRTSERVER_ErrorNew(
+          TRTSERVER_ERROR_NOT_FOUND,
+          std::string(
+              "The region named '" + name +
+              "' is registered as system shared memory, not CUDA shared memory")
+              .c_str());
+    }
+
+    CudaSharedMemoryStatusResponse::RegionStatus region_status;
+
+    region_status.set_name(it->second->name_);
+    region_status.set_device_id(it->second->device_id_);
+    region_status.set_byte_size(it->second->byte_size_);
+
+    (*shm_status->mutable_regions())[name] = region_status;
+  }
+
+
+  return nullptr;
+}
+
+TRTSERVER_Error*
+SharedMemoryManager::UnregisterV2(
+    const std::string& name, TRTSERVER_Memory_Type memory_type)
+{
+  // Serialize all operations that write/read current shared memory regions
+  std::lock_guard<std::mutex> lock(mu_);
+
+  return UnregisterHelperV2(name, memory_type);
+}
+
+TRTSERVER_Error*
+SharedMemoryManager::UnregisterAllV2(TRTSERVER_Memory_Type memory_type)
+{
+  std::lock_guard<std::mutex> lock(mu_);
+  std::string error_message = "Failed to unregister the following ";
+  std::vector<std::string> unregister_fails;
+  if (memory_type == TRTSERVER_MEMORY_CPU) {
+    // Serialize all operations that write/read current shared memory regions
+    error_message += "system shared memory regions: ";
+    for (const auto& shm_info : shared_memory_map_) {
+      if (shm_info.second->kind_ == TRTSERVER_MEMORY_CPU) {
+        TRTSERVER_Error* err = UnregisterHelperV2(shm_info.first, memory_type);
+        if (err != nullptr) {
+          unregister_fails.push_back(shm_info.first);
+        }
+      }
+    }
+  } else if (memory_type == TRTSERVER_MEMORY_GPU) {
+    error_message += "cuda shared memory regions: ";
+    for (const auto& shm_info : shared_memory_map_) {
+      if (shm_info.second->kind_ == TRTSERVER_MEMORY_GPU) {
+        TRTSERVER_Error* err = UnregisterHelperV2(shm_info.first, memory_type);
+        if (err != nullptr) {
+          unregister_fails.push_back(shm_info.first);
+        }
+      }
+    }
+  }
+
+  if (!unregister_fails.empty()) {
+    for (auto unreg_fail : unregister_fails) {
+      error_message += unreg_fail + " ,";
+    }
+    LOG_ERROR << error_message;
+    return TRTSERVER_ErrorNew(TRTSERVER_ERROR_INTERNAL, error_message.c_str());
+  }
+
+  return nullptr;
+}
+
+
+TRTSERVER_Error*
+SharedMemoryManager::UnregisterHelperV2(
+    const std::string& name, TRTSERVER_Memory_Type memory_type)
+{
+  // Must hold the lock on register_mu_ while calling this function.
+  auto it = shared_memory_map_.find(name);
+  if (it != shared_memory_map_.end() && it->second->kind_ == memory_type) {
+    if (it->second->kind_ == TRTSERVER_MEMORY_CPU) {
+      RETURN_IF_ERR(
+          UnmapSharedMemory(it->second->mapped_addr_, it->second->byte_size_));
+    } else {
+#ifdef TRTIS_ENABLE_GPU
+      cudaError_t err = cudaIpcCloseMemHandle(it->second->mapped_addr_);
+      if (err != cudaSuccess) {
+        return TRTSERVER_ErrorNew(
+            TRTSERVER_ERROR_INTERNAL, std::string(
+                                          "failed to close CUDA IPC handle: " +
+                                          std::string(cudaGetErrorString(err)))
+                                          .c_str());
+      }
+#else
+      return TRTSERVER_ErrorNew(
+          TRTSERVER_ERROR_INVALID_ARG,
+          std::string(
+              "failed to unregister CUDA shared memory region: '" + name +
+              "', GPUs not supported")
+              .c_str());
+#endif  // TRTIS_ENABLE_GPU
+    }
+
+    // Remove region information from shared_memory_map_
+    shared_memory_map_.erase(it);
+  }
+
+  return nullptr;
+}
+
+#endif  // TRTIS_ENABLE_GRPC_V2
 
 }}  // namespace nvidia::inferenceserver

--- a/src/servers/shared_memory_manager.cc
+++ b/src/servers/shared_memory_manager.cc
@@ -244,7 +244,7 @@ SharedMemoryManager::RegisterCUDASharedMemory(
 TRTSERVER_Error*
 SharedMemoryManager::GetMemoryInfo(
     const std::string& name, size_t offset, void** shm_mapped_addr,
-    TRTSERVER_Memory_Type* memory_type, int* device_id)
+    TRTSERVER_Memory_Type* memory_type, int64_t* device_id)
 {
   auto it = shared_memory_map_.find(name);
   if (it == shared_memory_map_.end()) {

--- a/src/servers/shared_memory_manager.h
+++ b/src/servers/shared_memory_manager.h
@@ -88,7 +88,7 @@ class SharedMemoryManager {
   /// \return a TRTSERVER_Error indicating success or failure.
   TRTSERVER_Error* GetMemoryInfo(
       const std::string& name, size_t offset, void** shm_mapped_addr,
-      TRTSERVER_Memory_Type* memory_type, int* device_id);
+      TRTSERVER_Memory_Type* memory_type, int64_t* device_id);
 
   /// Removes the named shared memory block from the manager. Any future
   /// attempt to get the details of this block will result in an array
@@ -157,7 +157,7 @@ class SharedMemoryManager {
         const std::string& name, const std::string& shm_key,
         const size_t offset, const size_t byte_size, int shm_fd,
         void* mapped_addr, const TRTSERVER_Memory_Type kind,
-        const int device_id)
+        const int64_t device_id)
         : name_(name), shm_key_(shm_key), offset_(offset),
           byte_size_(byte_size), shm_fd_(shm_fd), mapped_addr_(mapped_addr),
           kind_(kind), device_id_(device_id)
@@ -171,7 +171,7 @@ class SharedMemoryManager {
     int shm_fd_;
     void* mapped_addr_;
     TRTSERVER_Memory_Type kind_;
-    int device_id_;
+    int64_t device_id_;
   };
 
   using SharedMemoryStateMap =

--- a/src/servers/shared_memory_manager.h
+++ b/src/servers/shared_memory_manager.h
@@ -31,6 +31,10 @@
 #include "src/core/server_status.pb.h"
 #include "src/core/trtserver.h"
 
+#ifdef TRTIS_ENABLE_GRPC_V2
+#include "src/core/grpc_service_v2.grpc.pb.h"
+#endif
+
 #ifdef TRTIS_ENABLE_GPU
 #include <cuda_runtime_api.h>
 #endif  // TRTIS_ENABLE_GPU
@@ -103,9 +107,48 @@ class SharedMemoryManager {
   /// \return a TRTSERVER_Error indicating success or failure.
   TRTSERVER_Error* GetStatus(SharedMemoryStatus* status);
 
+#ifdef TRTIS_ENABLE_GRPC_V2
+  /// Removes the named shared memory block of the specified type from
+  /// the manager. Any future attempt to get the details of this block
+  /// will result in an array till another block with the same name is
+  /// added to the manager.
+  /// \param name The name of the shared memory block to remove.
+  /// \param memory_type The type of memory to unregister
+  /// \return a TRTSERVER_Error indicating success or failure.
+  TRTSERVER_Error* UnregisterV2(
+      const std::string& name, TRTSERVER_Memory_Type memory_type);
+
+  /// Unregister all shared memory blocks of specified type from the manager.
+  /// \param memory_type The type of memory to unregister
+  /// \return a TRTSERVER_Error indicating success or failure.
+  TRTSERVER_Error* UnregisterAllV2(TRTSERVER_Memory_Type memory_type);
+
+  /// Populates the status of active system shared memory regions
+  /// in the response protobuf
+  /// \param shm_status Returns status of active shared meeory blocks
+  /// \return a TRTSERVER_Error indicating success or failure.
+  TRTSERVER_Error* GetStatusV2(
+      const std::string& name, SystemSharedMemoryStatusResponse*& shm_status);
+
+  /// Populates the status of active cuda shared memory regions
+  /// in the response protobuf
+  /// \param shm_status Returns status of active shared meeory blocks
+  /// \return a TRTSERVER_Error indicating success or failure.
+  TRTSERVER_Error* GetStatusV2(
+      const std::string& name, CudaSharedMemoryStatusResponse*& shm_status);
+
+#endif
+
  private:
   /// A helper function to remove the named shared memory blocks.
   TRTSERVER_Error* UnregisterHelper(const std::string& name);
+
+#ifdef TRTIS_ENABLE_GRPC_V2
+  /// A helper function to remove the named shared memory blocks of
+  /// specified type
+  TRTSERVER_Error* UnregisterHelperV2(
+      const std::string& name, TRTSERVER_Memory_Type memory_type);
+#endif  // TRTIS_ENABLE_GRPC_V2
 
   /// A struct that records the shared memory regions registered by the shared
   /// memory manager.


### PR DESCRIPTION
 The following enhancements are included in this PR:
1. New handler for handling multiple RPCs in grpc_server_v2
2. System and CUDA shared memory support in server
3. Client side support for system shared memory
4. Simple example using system shared memory

I plan to make the following changes as future set of PRs:
1. Client side support for cuda shared memory
2. Simple example using cuda shared memory
3. L0_shared_memory_v2 and L0_cuda_shared_memory_v2 using the new clients.
4. Package the shared_memory and cuda_shared_memory modules in separate packages outside tritongrpcclient and tritonhttpclient.