### PR TITLE
Add CUDA memory manger to avoid raw cudaMalloc / cudaFree

### DIFF
--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -486,7 +486,7 @@ ExternalProject_Add(trtis
     -Daws-c-event-stream_DIR:PATH=${CMAKE_CURRENT_BINARY_DIR}/aws-sdk-cpp/install/lib/aws-c-event-stream/cmake
     -Daws-c-common_DIR:PATH=${CMAKE_CURRENT_BINARY_DIR}/aws-sdk-cpp/install/lib/aws-c-common/cmake
     -Daws-checksums_DIR:PATH=${CMAKE_CURRENT_BINARY_DIR}/aws-sdk-cpp/install/lib/aws-checksums/cmake
-    -Dcnmem_DIR:PATH=${CMAKE_CURRENT_BINARY_DIR}/cnmem
+    -DCNMEM_PATH:PATH=${CMAKE_CURRENT_BINARY_DIR}/cnmem
     -DTRTIS_ONNXRUNTIME_INCLUDE_PATHS:PATH=${TRTIS_ONNXRUNTIME_INCLUDE_PATHS}
     -DTRTIS_PYTORCH_INCLUDE_PATHS:PATH=${TRTIS_PYTORCH_INCLUDE_PATHS}
     -DTRTIS_EXTRA_LIB_PATHS:PATH=${TRTIS_EXTRA_LIB_PATHS}

--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -319,6 +319,20 @@ ExternalProject_Add(google-cloud-cpp
 )
 
 #
+# Build CNMeM (CUDA memeory management library)
+#
+ExternalProject_Add(cnmem
+  PREFIX cnmem
+  GIT_REPOSITORY "https://github.com/NVIDIA/cnmem.git"
+  GIT_TAG "37896cc9bfc6536a8c878a1e675835c22d827821"
+  PATCH_COMMAND sed -i "s/SHARED/STATIC/g" ${CMAKE_CURRENT_BINARY_DIR}/cnmem/src/cnmem/CMakeLists.txt
+  SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/cnmem/src/cnmem"
+  CMAKE_CACHE_ARGS
+    -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON
+    -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_CURRENT_BINARY_DIR}/cnmem
+)
+
+#
 # Build AWS sdk for S3 support
 #
 ExternalProject_Add(aws-sdk-cpp
@@ -446,6 +460,9 @@ endif() # TRTIS_ENABLE_GRPC || TRTIS_ENABLE_GRPC_V2
 if(${TRTIS_ENABLE_METRICS})
   set(TRTIS_DEPENDS ${TRTIS_DEPENDS} prometheus-cpp)
 endif() # TRTIS_ENABLE_METRICS
+if(${TRTIS_ENABLE_GPU})
+  set(TRTIS_DEPENDS ${TRTIS_DEPENDS} cnmem)
+endif() # TRTIS_ENABLE_GPU
 
 ExternalProject_Add(trtis
   PREFIX trtis
@@ -469,6 +486,7 @@ ExternalProject_Add(trtis
     -Daws-c-event-stream_DIR:PATH=${CMAKE_CURRENT_BINARY_DIR}/aws-sdk-cpp/install/lib/aws-c-event-stream/cmake
     -Daws-c-common_DIR:PATH=${CMAKE_CURRENT_BINARY_DIR}/aws-sdk-cpp/install/lib/aws-c-common/cmake
     -Daws-checksums_DIR:PATH=${CMAKE_CURRENT_BINARY_DIR}/aws-sdk-cpp/install/lib/aws-checksums/cmake
+    -Dcnmem_DIR:PATH=${CMAKE_CURRENT_BINARY_DIR}/cnmem
     -DTRTIS_ONNXRUNTIME_INCLUDE_PATHS:PATH=${TRTIS_ONNXRUNTIME_INCLUDE_PATHS}
     -DTRTIS_PYTORCH_INCLUDE_PATHS:PATH=${TRTIS_PYTORCH_INCLUDE_PATHS}
     -DTRTIS_EXTRA_LIB_PATHS:PATH=${TRTIS_EXTRA_LIB_PATHS}

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -247,7 +247,7 @@ if(${TRTIS_ENABLE_GPU})
   target_include_directories(
     server-library
     PRIVATE ${CUDA_INCLUDE_DIRS}
-    PRIVATE ${cnmem_DIR}/include
+    PRIVATE ${CNMEM_PATH}/include
   )
 endif() # TRTIS_ENABLE_GPU
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -224,6 +224,19 @@ set(
   trtserver.h
 )
 
+if(${TRTIS_ENABLE_GPU})
+  set(
+    SERVER_SRCS
+    ${SERVER_SRCS}
+    cuda_memory_manager.cc
+  )
+  set(
+    SERVER_HDRS
+    ${SERVER_HDRS}
+    cuda_memory_manager.h
+  )
+endif() # TRTIS_ENABLE_GPU
+
 add_library(
   server-library EXCLUDE_FROM_ALL OBJECT
   ${SERVER_SRCS} ${SERVER_HDRS}
@@ -234,6 +247,7 @@ if(${TRTIS_ENABLE_GPU})
   target_include_directories(
     server-library
     PRIVATE ${CUDA_INCLUDE_DIRS}
+    PRIVATE ${cnmem_DIR}/include
   )
 endif() # TRTIS_ENABLE_GPU
 

--- a/src/core/cuda_memory_manager.cc
+++ b/src/core/cuda_memory_manager.cc
@@ -1,0 +1,98 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+#include "src/core/cuda_memory_manager.h"
+
+#include <cnmem.h>
+#include <set>
+#include "src/core/logging.h"
+#include "src/core/model_config_utils.h"
+
+namespace {
+
+#define RETURN_IF_CNMEM_ERROR(S)                                             \
+  do {                                                                       \
+    auto status__ = (S);                                                     \
+    if (status__ != CNMEM_STATUS_SUCCESS) {                                  \
+      std::string msg = std::string(cnmemGetErrorString(status__));          \
+      return Status(                                                         \
+          RequestStatusCode::INTERNAL, "CUDA memory manager error " +        \
+                                           std::to_string(status__) + ": " + \
+                                           std::string(msg));                \
+    }                                                                        \
+  } while (false)
+
+}  // namespace
+
+namespace nvidia { namespace inferenceserver {
+
+std::unique_ptr<CUDAMemoryManager> CUDAMemoryManager::instance_;
+
+CUDAMemoryManager::~CUDAMemoryManager()
+{
+  auto status = cnmemFinalize();
+  if (status != CNMEM_STATUS_SUCCESS) {
+    LOG_ERROR << "Failed to finalize CUDA memory manager: [" << status << "] "
+              << cnmemGetErrorString(status);
+  }
+}
+
+Status
+CUDAMemoryManager::Create(const Options& options)
+{
+  std::set<int> supported_gpus;
+  RETURN_IF_ERROR(GetSupportedGPUs(
+      &supported_gpus, options.min_supported_compute_capability_));
+  std::vector<cnmemDevice_t> devices;
+  for (auto gpu : supported_gpus) {
+    devices.emplace_back();
+    auto& device = devices.back();
+    memset(&device, 0, sizeof(device));
+    device.device = gpu;
+    device.size = options.memory_pool_byte_size_;
+  }
+  RETURN_IF_CNMEM_ERROR(
+      cnmemInit(devices.size(), devices.data(), CNMEM_FLAGS_CANNOT_GROW));
+  return Status::Success;
+}
+
+Status
+CUDAMemoryManager::Alloc(void** ptr, uint64_t size)
+{
+  return Status(
+      RequestStatusCode::UNSUPPORTED,
+      "CUDAMemoryManager::Alloc() not implemented");
+}
+
+Status
+CUDAMemoryManager::Free(void* ptr)
+{
+  return Status(
+      RequestStatusCode::UNSUPPORTED,
+      "CUDAMemoryManager::Free() not implemented");
+}
+
+}}  // namespace nvidia::inferenceserver

--- a/src/core/cuda_memory_manager.cc
+++ b/src/core/cuda_memory_manager.cc
@@ -84,11 +84,14 @@ CudaMemoryManager::Create(const CudaMemoryManager::Options& options)
   if (status.IsOk()) {
     std::vector<cnmemDevice_t> devices;
     for (auto gpu : supported_gpus) {
-      devices.emplace_back();
-      auto& device = devices.back();
-      memset(&device, 0, sizeof(device));
-      device.device = gpu;
-      device.size = options.memory_pool_byte_size_;
+      const auto it = options.memory_pool_byte_size_.find(gpu);
+      if ((it != options.memory_pool_byte_size_.end()) && (it->second != 0)) {
+        devices.emplace_back();
+        auto& device = devices.back();
+        memset(&device, 0, sizeof(device));
+        device.device = gpu;
+        device.size = it->second;
+      }
     }
 
     auto status =

--- a/src/core/cuda_memory_manager.h
+++ b/src/core/cuda_memory_manager.h
@@ -1,0 +1,75 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+#pragma once
+
+#include <memory>
+#include "src/core/status.h"
+
+namespace nvidia { namespace inferenceserver {
+
+// This is a singleton class responsible for maintaining CUDA memory pool
+// used by the inference server. CUDA memory allocations and deallocations
+// must be requested via functions provided by this class.
+class CUDAMemoryManager {
+ public:
+  // Options to configure CUDA memeory manager.
+  struct Options {
+    Options(double cc = 6.0, uint64_t b = 0)
+        : min_supported_compute_capability_(cc), memory_pool_byte_size_(b)
+    {
+    }
+
+    // The minimum compute capability of the supported devices.
+    double min_supported_compute_capability_;
+
+    // The size of CUDA memory reserved for every supported device.
+    uint64_t memory_pool_byte_size_;
+  };
+
+  ~CUDAMemoryManager();
+
+  // Create the memory manager based on 'options' specified.
+  // Return Status object indicating success or failure.
+  static Status Create(const Options& options);
+
+  // Allocate CUDA memory with the requested 'size' and return the pointer
+  // in 'ptr'.
+  // Return Status object indicating success or failure.
+  static Status Alloc(void** ptr, uint64_t size);
+
+  // Free the memory allocated by the memory manager.
+  // Return Status object indicating success or failure.
+  static Status Free(void* ptr);
+
+ protected:
+  CUDAMemoryManager() = default;
+
+ private:
+  static std::unique_ptr<CUDAMemoryManager> instance_;
+};
+
+}}  // namespace nvidia::inferenceserver

--- a/src/core/cuda_memory_manager.h
+++ b/src/core/cuda_memory_manager.h
@@ -34,7 +34,7 @@ namespace nvidia { namespace inferenceserver {
 // This is a singleton class responsible for maintaining CUDA memory pool
 // used by the inference server. CUDA memory allocations and deallocations
 // must be requested via functions provided by this class.
-class CUDAMemoryManager {
+class CudaMemoryManager {
  public:
   // Options to configure CUDA memeory manager.
   struct Options {
@@ -50,26 +50,26 @@ class CUDAMemoryManager {
     uint64_t memory_pool_byte_size_;
   };
 
-  ~CUDAMemoryManager();
+  ~CudaMemoryManager();
 
   // Create the memory manager based on 'options' specified.
   // Return Status object indicating success or failure.
   static Status Create(const Options& options);
 
-  // Allocate CUDA memory with the requested 'size' and return the pointer
-  // in 'ptr'.
+  // Allocate CUDA memory on GPU 'device_id' with
+  // the requested 'size' and return the pointer in 'ptr'.
   // Return Status object indicating success or failure.
-  static Status Alloc(void** ptr, uint64_t size);
+  static Status Alloc(void** ptr, uint64_t size, int64_t device_id);
 
-  // Free the memory allocated by the memory manager.
+  // Free the memory allocated by the memory manager on 'device_id'.
   // Return Status object indicating success or failure.
-  static Status Free(void* ptr);
+  static Status Free(void* ptr, int64_t device_id);
 
  protected:
-  CUDAMemoryManager() = default;
+  CudaMemoryManager() = default;
 
  private:
-  static std::unique_ptr<CUDAMemoryManager> instance_;
+  static std::unique_ptr<CudaMemoryManager> instance_;
 };
 
 }}  // namespace nvidia::inferenceserver

--- a/src/core/cuda_memory_manager.h
+++ b/src/core/cuda_memory_manager.h
@@ -38,16 +38,17 @@ class CudaMemoryManager {
  public:
   // Options to configure CUDA memeory manager.
   struct Options {
-    Options(double cc = 6.0, uint64_t b = 0)
-        : min_supported_compute_capability_(cc), memory_pool_byte_size_(b)
+    Options(double cc = 6.0, const std::map<int, uint64_t>& s = {})
+        : min_supported_compute_capability_(cc), memory_pool_byte_size_(s)
     {
     }
 
     // The minimum compute capability of the supported devices.
     double min_supported_compute_capability_;
 
-    // The size of CUDA memory reserved for every supported device.
-    uint64_t memory_pool_byte_size_;
+    // The size of CUDA memory reserved for the specified devices.
+    // No memory will be reserved for devices that is not listed.
+    std::map<int, uint64_t> memory_pool_byte_size_;
   };
 
   ~CudaMemoryManager();

--- a/src/core/cuda_utils.cc
+++ b/src/core/cuda_utils.cc
@@ -99,24 +99,20 @@ CopyBuffer(
       copy_kind = cudaMemcpyDeviceToHost;
     }
 
-    cudaError_t err;
     if ((src_memory_type_id != dst_memory_type_id) &&
         (copy_kind == cudaMemcpyDeviceToDevice)) {
-      err = cudaMemcpyPeerAsync(
-          dst, dst_memory_type_id, src, src_memory_type_id, byte_size,
-          cuda_stream);
+      RETURN_IF_CUDA_ERR(
+          cudaMemcpyPeerAsync(
+              dst, dst_memory_type_id, src, src_memory_type_id, byte_size,
+              cuda_stream),
+          msg + ": failed to perform CUDA copy");
     } else {
-      err = cudaMemcpyAsync(dst, src, byte_size, copy_kind, cuda_stream);
+      RETURN_IF_CUDA_ERR(
+          cudaMemcpyAsync(dst, src, byte_size, copy_kind, cuda_stream),
+          msg + ": failed to perform CUDA copy");
     }
 
-    if (err != cudaSuccess) {
-      return Status(
-          RequestStatusCode::INTERNAL,
-          msg + ": failed to use CUDA copy : " +
-              std::string(cudaGetErrorString(err)));
-    } else {
-      *cuda_used = true;
-    }
+    *cuda_used = true;
 #else
     return Status(
         RequestStatusCode::INTERNAL,

--- a/src/core/cuda_utils.h
+++ b/src/core/cuda_utils.h
@@ -33,6 +33,18 @@
 
 namespace nvidia { namespace inferenceserver {
 
+#ifdef TRTIS_ENABLE_GPU
+#define RETURN_IF_CUDA_ERR(X, MSG)                   \
+  do {                                               \
+    cudaError_t err__ = (X);                         \
+    if (err__ != cudaSuccess) {                      \
+      return Status(                                 \
+          RequestStatusCode::INTERNAL,               \
+          (MSG) + ": " + cudaGetErrorString(err__)); \
+    }                                                \
+  } while (false)
+#endif  // TRTIS_ENABLE_GPU
+
 #ifndef TRTIS_ENABLE_GPU
 using cudaStream_t = void*;
 #endif  // TRTIS_ENABLE_GPU

--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -121,17 +121,17 @@ AllocatedMemory::AllocatedMemory(
 #ifdef TRTIS_ENABLE_GPU
         auto status = CudaMemoryManager::Alloc(
             (void**)&buffer_, total_byte_size_, memory_type_id_);
-        // [TODO] fallback to pinned memory if can't allocate on GPU
+        // Fall back to allocate pinned memory if can't allocate CUDA memory
         if (!status.IsOk()) {
           LOG_ERROR << status.Message();
-          buffer_ = nullptr;
+          goto pinned_memory_allocation;
         }
 #else
         buffer_ = nullptr;
 #endif  // TRTIS_ENABLE_GPU
         break;
       }
-
+      pinned_memory_allocation:
       default: {
         auto status = PinnedMemoryManager::Alloc(
             (void**)&buffer_, total_byte_size_, &memory_type_, true);

--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -31,6 +31,7 @@
 
 #ifdef TRTIS_ENABLE_GPU
 #include <cuda_runtime_api.h>
+#include "src/core/cuda_memory_manager.h"
 #endif  // TRTIS_ENABLE_GPU
 
 namespace nvidia { namespace inferenceserver {
@@ -118,26 +119,12 @@ AllocatedMemory::AllocatedMemory(
     switch (memory_type_) {
       case TRTSERVER_MEMORY_GPU: {
 #ifdef TRTIS_ENABLE_GPU
-        int current_device;
-        auto err = cudaGetDevice(&current_device);
-        bool overridden = false;
-        if (err == cudaSuccess) {
-          overridden = (current_device != memory_type_id_);
-          if (overridden) {
-            err = cudaSetDevice(memory_type_id_);
-          }
-        }
-        if (err == cudaSuccess) {
-          err = cudaMalloc((void**)&buffer_, total_byte_size_);
-        }
-        if (err != cudaSuccess) {
-          LOG_ERROR << "failed to allocate GPU memory with byte size"
-                    << total_byte_size_ << ": "
-                    << std::string(cudaGetErrorString(err));
+        auto status = CudaMemoryManager::Alloc(
+            (void**)&buffer_, total_byte_size_, memory_type_id_);
+        // [TODO] fallback to pinned memory if can't allocate on GPU
+        if (!status.IsOk()) {
+          LOG_ERROR << status.Message();
           buffer_ = nullptr;
-        }
-        if (overridden) {
-          cudaSetDevice(current_device);
         }
 #else
         buffer_ = nullptr;
@@ -165,24 +152,9 @@ AllocatedMemory::~AllocatedMemory()
     switch (memory_type_) {
       case TRTSERVER_MEMORY_GPU: {
 #ifdef TRTIS_ENABLE_GPU
-        int current_device;
-        auto err = cudaGetDevice(&current_device);
-        bool overridden = false;
-        if (err == cudaSuccess) {
-          overridden = (current_device != memory_type_id_);
-          if (overridden) {
-            err = cudaSetDevice(memory_type_id_);
-          }
-        }
-        if (err == cudaSuccess) {
-          err = cudaFree(buffer_);
-        }
-        if (err != cudaSuccess) {
-          LOG_ERROR << "failed to free GPU memory at address " << buffer_
-                    << ": " << std::string(cudaGetErrorString(err));
-        }
-        if (overridden) {
-          cudaSetDevice(current_device);
+        auto status = CudaMemoryManager::Free(buffer_, memory_type_id_);
+        if (!status.IsOk()) {
+          LOG_ERROR << status.Message();
         }
 #endif  // TRTIS_ENABLE_GPU
         break;

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -131,7 +131,10 @@ class MutableMemory : public Memory {
 class AllocatedMemory : public MutableMemory {
  public:
   // Create a continuous data buffer with 'byte_size', 'memory_type' and
-  // 'memory_id.
+  // 'memory_tye_id'. Note that the buffer may be created on different memeory
+  // type and memory type id if the original request type and id can not be
+  // satisfied, thus the function caller should always check the actual memory
+  // type and memory type id before use.
   AllocatedMemory(
       size_t byte_size, TRTSERVER_Memory_Type memory_type,
       int64_t memory_type_id);

--- a/src/core/pinned_memory_manager.h
+++ b/src/core/pinned_memory_manager.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2020, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -47,19 +47,20 @@ class PinnedMemoryManager {
   ~PinnedMemoryManager();
 
   // Create the pinned memory manager based on 'options' specified.
-  // Return true on success, false otherwise.
+  // Return Status object indicating success or failure.
   static Status Create(const Options& options);
 
   // Allocate pinned memory with the requested 'size' and return the pointer
   // in 'ptr'. If 'allow_nonpinned_fallback' is true, regular system memory
   // will be allocated as fallback in the case where pinned memory fails to
   // be allocated.
-  // Return true on success, false otherwise.
+  // Return Status object indicating success or failure.
   static Status Alloc(
       void** ptr, uint64_t size, TRTSERVER_Memory_Type* allocated_type,
       bool allow_nonpinned_fallback = false);
 
   // Free the memory allocated by the pinned memory manager.
+  // Return Status object indicating success or failure.
   static Status Free(void* ptr);
 
  protected:

--- a/src/core/server.h
+++ b/src/core/server.h
@@ -138,6 +138,17 @@ class InferenceServer {
     pinned_memory_pool_size_ = std::max((int64_t)0, s);
   }
 
+  // Get / set CUDA memory pool size
+  const std::map<int, uint64_t>& CudaMemoryPoolByteSize() const
+  {
+    return cuda_memory_pool_size_;
+  }
+
+  void SetCudaMemoryPoolByteSize(const std::map<int, uint64_t>& s)
+  {
+    cuda_memory_pool_size_ = s;
+  }
+
   // Get / set the minimum support CUDA compute capability.
   double MinSupportedComputeCapability() const
   {
@@ -216,7 +227,7 @@ class InferenceServer {
   bool strict_readiness_;
   uint32_t exit_timeout_secs_;
   uint64_t pinned_memory_pool_size_;
-  uint64_t cuda_memory_pool_size_;
+  std::map<int, uint64_t> cuda_memory_pool_size_;
   double min_supported_compute_capability_;
 
   // Tensorflow options

--- a/src/core/server.h
+++ b/src/core/server.h
@@ -216,6 +216,7 @@ class InferenceServer {
   bool strict_readiness_;
   uint32_t exit_timeout_secs_;
   uint64_t pinned_memory_pool_size_;
+  uint64_t cuda_memory_pool_size_;
   double min_supported_compute_capability_;
 
   // Tensorflow options

--- a/src/core/trtserver.cc
+++ b/src/core/trtserver.cc
@@ -237,6 +237,16 @@ class TrtServerOptions {
   uint64_t PinnedMemoryPoolByteSize() const { return pinned_memory_pool_size_; }
   void SetPinnedMemoryPoolByteSize(uint64_t s) { pinned_memory_pool_size_ = s; }
 
+
+  const std::map<int, uint64_t>& CudaMemoryPoolByteSize() const
+  {
+    return cuda_memory_pool_size_;
+  }
+  void SetCudaMemoryPoolByteSize(int id, uint64_t s)
+  {
+    cuda_memory_pool_size_[id] = s;
+  }
+
   double MinSupportedComputeCapability() const
   {
     return min_compute_capability_;
@@ -289,6 +299,7 @@ class TrtServerOptions {
   bool gpu_metrics_;
   unsigned int exit_timeout_;
   uint64_t pinned_memory_pool_size_;
+  std::map<int, uint64_t> cuda_memory_pool_size_;
   double min_compute_capability_;
 
   bool tf_soft_placement_;
@@ -1232,6 +1243,15 @@ TRTSERVER_ServerOptionsSetPinnedMemoryPoolByteSize(
 }
 
 TRTSERVER_Error*
+TRTSERVER_ServerOptionsSetCudaMemoryPoolByteSize(
+    TRTSERVER_ServerOptions* options, int gpu_device, uint64_t size)
+{
+  TrtServerOptions* loptions = reinterpret_cast<TrtServerOptions*>(options);
+  loptions->SetCudaMemoryPoolByteSize(gpu_device, size);
+  return nullptr;  // Success
+}
+
+TRTSERVER_Error*
 TRTSERVER_ServerOptionsSetMinSupportedComputeCapability(
     TRTSERVER_ServerOptions* options, double cc)
 {
@@ -1395,6 +1415,7 @@ TRTSERVER_ServerNew(TRTSERVER_Server** server, TRTSERVER_ServerOptions* options)
   lserver->SetStartupModels(loptions->StartupModels());
   lserver->SetStrictModelConfigEnabled(loptions->StrictModelConfig());
   lserver->SetPinnedMemoryPoolByteSize(loptions->PinnedMemoryPoolByteSize());
+  lserver->SetCudaMemoryPoolByteSize(loptions->CudaMemoryPoolByteSize());
   lserver->SetMinSupportedComputeCapability(
       loptions->MinSupportedComputeCapability());
   lserver->SetStrictReadinessEnabled(loptions->StrictReadiness());

--- a/src/core/trtserver.h
+++ b/src/core/trtserver.h
@@ -778,6 +778,17 @@ TRTSERVER_EXPORT TRTSERVER_Error*
 TRTSERVER_ServerOptionsSetPinnedMemoryPoolByteSize(
     TRTSERVER_ServerOptions* options, uint64_t size);
 
+/// Set the total CUDA memory byte size that the server can allocate on given
+/// GPU device in a server options. This option will not affect the allocation
+/// conducted by the backend frameworks.
+/// \param options The server options object.
+/// \param gpu_device The GPU device to allocate the memory pool.
+/// \param size The CUDA memory pool byte size.
+/// \return a TRTSERVER_Error indicating success or failure.
+TRTSERVER_EXPORT TRTSERVER_Error*
+TRTSERVER_ServerOptionsSetCudaMemoryPoolByteSize(
+    TRTSERVER_ServerOptions* options, int gpu_device, uint64_t size);
+
 /// Set the minimum support CUDA compute capability in a server
 /// options.
 /// \param options The server options object.

--- a/src/servers/CMakeLists.txt
+++ b/src/servers/CMakeLists.txt
@@ -492,6 +492,8 @@ if(${TRTIS_ENABLE_GPU})
     PUBLIC -L/usr/local/cuda/lib64/stubs
     PUBLIC -lnvidia-ml
     PRIVATE ${CUDA_LIBRARIES}
+    PRIVATE -L${cnmem_DIR}/lib
+    PRIVATE -lcnmem
   )
 endif() # TRTIS_ENABLE_GPU
 

--- a/src/servers/CMakeLists.txt
+++ b/src/servers/CMakeLists.txt
@@ -492,7 +492,7 @@ if(${TRTIS_ENABLE_GPU})
     PUBLIC -L/usr/local/cuda/lib64/stubs
     PUBLIC -lnvidia-ml
     PRIVATE ${CUDA_LIBRARIES}
-    PRIVATE -L${cnmem_DIR}/lib
+    PRIVATE -L${CNMEM_PATH}/lib
     PRIVATE -lcnmem
   )
 endif() # TRTIS_ENABLE_GPU


### PR DESCRIPTION
@deadeyegoodwin Unfortunately the management library that I am using doesn't support growing the buffer until threshold, we can only preallocate enough CUDA memory on initialization. The other option is the [caching allocator](https://github.com/NVlabs/cub/blob/1.8.0/cub/util_allocator.cuh#L59) where it will allocate new memory if there is no appropriate cached bin, but we can't control the behavior when max_cached_size is reach (i.e. it `cudaFree()` the allocation if max_cached_size is reach). I will keep looking into other alternatives and replace the library if I find one that fits.

One concern about the growing approach is that we can not completely avoid `cudaMalloc` as it is needed for growing the pool, so some requests will be affected if they happen to trigger the growth.