### PR TITLE
Fix to build METRICS support when both HTTP is disabled

### DIFF
--- a/src/servers/CMakeLists.txt
+++ b/src/servers/CMakeLists.txt
@@ -111,7 +111,7 @@ if(${TRTIS_ENABLE_HTTP} OR ${TRTIS_ENABLE_METRICS} OR ${TRTIS_ENABLE_HTTP_V2})
   find_package(libevhtp CONFIG REQUIRED)
   message(STATUS "Using libevhtp ${libevhtp_VERSION}")
 
-  if(${TRTIS_ENABLE_HTTP})
+  if(${TRTIS_ENABLE_HTTP} OR ${TRTIS_ENABLE_METRICS})
     list(APPEND
       HTTP_ENDPOINT_SRCS
       http_server.cc


### PR DESCRIPTION
Should build METRICS support even when HTTP if off just as before