### PR TITLE
Improve inline comment

### DIFF
--- a/src/servers/http_server.cc
+++ b/src/servers/http_server.cc
@@ -1305,10 +1305,12 @@ HTTPAPIServer::InferRequest::InferComplete(
     evthr_defer(infer_request->thread_, BADReplyCallback, infer_request);
   }
 
-  // Don't need to explicitly delete 'trace_manager'. It will be deleted by
-  // the TraceMetaData object in 'infer_request'.
+  // Don't need to explicitly delete 'trace_manager'. It is owned by
+  // 'infer_request' which will be deleted after the response is sent
+  // in ReplayCallback.
   LOG_TRTSERVER_ERROR(
-      TRTSERVER_InferenceResponseDelete(response), "deleting HTTP response");
+      TRTSERVER_InferenceResponseDelete(response),
+      "deleting inference response");
 }
 
 evhtp_res

--- a/src/servers/http_server_v2.cc
+++ b/src/servers/http_server_v2.cc
@@ -184,8 +184,8 @@ class HTTPAPIServerV2 : public HTTPServerV2Impl {
     explicit AllocPayload() : shm_map_(nullptr) {}
     ~AllocPayload()
     {
-      // Don't delete 'response_buffer_' or 'response_json_' here. Destoryed as a part of the
-      // InferRequestClass
+      // Don't delete 'response_buffer_' or 'response_json_' here. Destoryed as
+      // a part of the InferRequestClass
       delete shm_map_;
     }
 
@@ -1393,10 +1393,12 @@ HTTPAPIServerV2::InferRequestClass::InferComplete(
     evthr_defer(infer_request->thread_, BADReplyCallback, infer_request);
   }
 
-  // Don't need to explicitly delete 'trace_manager'. It will be deleted by
-  // the TraceMetaData object in 'infer_request'.
+  // Don't need to explicitly delete 'trace_manager'. It is owned by
+  // 'infer_request' which will be deleted after the response is sent
+  // in ReplayCallback.
   LOG_TRTSERVER_ERROR(
-      TRTSERVER_InferenceResponseDelete(response), "deleting HTTP response");
+      TRTSERVER_InferenceResponseDelete(response),
+      "deleting inference response");
 }
 
 evhtp_res


### PR DESCRIPTION
Pointing out where the lifecycle of the HTTP infer request object is manged, which is not obvious.