### PR TITLE
[HTTP V2] Update V2 Infer API, Fix response error json

### DIFF
--- a/src/servers/http_server_v2.cc
+++ b/src/servers/http_server_v2.cc
@@ -918,7 +918,6 @@ HTTPAPIServerV2::HandleModelReady(
   }
 
   TRTSERVER_ProtobufDelete(model_status_protobuf);
-
   evhtp_send_reply(
       req, (ready && (err == nullptr)) ? EVHTP_RES_OK : EVHTP_RES_BADREQ);
 


### PR DESCRIPTION
Fix Infer - Update to use new V2 Infer API
Ensure error message responses are in json form