### PR TITLE
[HTTP V2] Add metrics support

### DIFF
--- a/src/servers/CMakeLists.txt
+++ b/src/servers/CMakeLists.txt
@@ -120,8 +120,8 @@ if(${TRTIS_ENABLE_HTTP} OR ${TRTIS_ENABLE_METRICS} OR ${TRTIS_ENABLE_HTTP_V2})
       HTTP_ENDPOINT_HDRS
       http_server.h
       )
-  endif() # TRTIS_ENABLE_HTTP
-  if(${TRTIS_ENABLE_HTTP_V2})
+  endif() # TRTIS_ENABLE_HTTP || TRTIS_ENABLE_METRICS
+  if(${TRTIS_ENABLE_HTTP_V2} OR ${TRTIS_ENABLE_METRICS})
     list(APPEND
       HTTP_ENDPOINT_SRCS
       http_server_v2.cc
@@ -130,7 +130,7 @@ if(${TRTIS_ENABLE_HTTP} OR ${TRTIS_ENABLE_METRICS} OR ${TRTIS_ENABLE_HTTP_V2})
       HTTP_ENDPOINT_HDRS
       http_server_v2.h
       )
-  endif() # TRTIS_ENABLE_HTTP_V2
+  endif() # TRTIS_ENABLE_HTTP_V2 || TRTIS_ENABLE_METRICS
 
   add_library(
     http-endpoint-library EXCLUDE_FROM_ALL OBJECT

--- a/src/servers/http_server_v2.cc
+++ b/src/servers/http_server_v2.cc
@@ -131,6 +131,64 @@ HTTPServerV2Impl::Dispatch(evhtp_request_t* req, void* arg)
   (static_cast<HTTPServerV2Impl*>(arg))->Handle(req);
 }
 
+#ifdef TRTIS_ENABLE_METRICS
+
+// Handle HTTP requests to obtain prometheus metrics
+class HTTPMetricsServer : public HTTPServerImpl {
+ public:
+  explicit HTTPMetricsServer(
+      const std::shared_ptr<TRTSERVER_Server>& server, const int32_t port,
+      const int thread_cnt)
+      : HTTPServerImpl(port, thread_cnt), server_(server),
+        api_regex_(R"(/metrics/?)")
+  {
+  }
+
+  ~HTTPMetricsServer() = default;
+
+ private:
+  void Handle(evhtp_request_t* req) override;
+
+  std::shared_ptr<TRTSERVER_Server> server_;
+  re2::RE2 api_regex_;
+};
+
+void
+HTTPMetricsServer::Handle(evhtp_request_t* req)
+{
+  LOG_VERBOSE(1) << "HTTP request: " << req->method << " "
+                 << req->uri->path->full;
+
+  if (req->method != htp_method_GET) {
+    evhtp_send_reply(req, EVHTP_RES_METHNALLOWED);
+    return;
+  }
+
+  evhtp_res res = EVHTP_RES_BADREQ;
+
+  // Call to metric endpoint should not have any trailing string
+  if (RE2::FullMatch(std::string(req->uri->path->full), api_regex_)) {
+    TRTSERVER_Metrics* metrics = nullptr;
+    TRTSERVER_Error* err = TRTSERVER_ServerMetrics(server_.get(), &metrics);
+    if (err == nullptr) {
+      const char* base;
+      size_t byte_size;
+      err = TRTSERVER_MetricsFormatted(
+          metrics, TRTSERVER_METRIC_PROMETHEUS, &base, &byte_size);
+      if (err == nullptr) {
+        res = EVHTP_RES_OK;
+        evbuffer_add(req->buffer_out, base, byte_size);
+      }
+    }
+
+    TRTSERVER_MetricsDelete(metrics);
+    TRTSERVER_ErrorDelete(err);
+  }
+
+  evhtp_send_reply(req, res);
+}
+
+#endif  // TRTIS_ENABLE_METRICS
 
 // Handle HTTP requests to inference server APIs
 class HTTPAPIServerV2 : public HTTPServerV2Impl {

--- a/src/servers/http_server_v2.h
+++ b/src/servers/http_server_v2.h
@@ -51,6 +51,10 @@ class HTTPServerV2 {
       const int thread_cnt,
       std::vector<std::unique_ptr<HTTPServerV2>>* http_servers);
 
+  static TRTSERVER_Error* CreateMetricsServer(
+      const std::shared_ptr<TRTSERVER_Server>& server, int32_t port,
+      int thread_cnt, std::unique_ptr<HTTPServerV2>* metrics_server);
+
   virtual ~HTTPServerV2() = default;
 
   virtual TRTSERVER_Error* Start() = 0;

--- a/src/servers/main.cc
+++ b/src/servers/main.cc
@@ -53,9 +53,9 @@ static_assert(
 #if defined(TRTIS_ENABLE_HTTP) || defined(TRTIS_ENABLE_METRICS)
 #include "src/servers/http_server.h"
 #endif  // TRTIS_ENABLE_HTTP || TRTIS_ENABLE_METRICS
-#if defined(TRTIS_ENABLE_HTTP_V2)
+#if defined(TRTIS_ENABLE_HTTP_V2) || defined(TRTIS_ENABLE_METRICS)
 #include "src/servers/http_server_v2.h"
-#endif  // TRTIS_ENABLE_HTTP_V2
+#endif  // TRTIS_ENABLE_HTTP_V2|| TRTIS_ENABLE_METRICS
 
 #ifdef TRTIS_ENABLE_GRPC
 #include "src/servers/grpc_server.h"

--- a/src/servers/main.cc
+++ b/src/servers/main.cc
@@ -117,6 +117,7 @@ int32_t grpc_port_ = 8001;
 
 #ifdef TRTIS_ENABLE_METRICS
 std::unique_ptr<nvidia::inferenceserver::HTTPServer> metrics_service_;
+std::unique_ptr<nvidia::inferenceserver::HTTPServerV2> metrics_service_v2_;
 bool allow_metrics_ = true;
 int32_t metrics_port_ = 8002;
 #endif  // TRTIS_ENABLE_METRICS
@@ -567,6 +568,24 @@ StartMetricsService(
 
   return err;
 }
+
+TRTSERVER_Error*
+StartMetricsV2Service(
+    std::unique_ptr<nvidia::inferenceserver::HTTPServerV2>* service,
+    const std::shared_ptr<TRTSERVER_Server>& server)
+{
+  TRTSERVER_Error* err =
+      nvidia::inferenceserver::HTTPServerV2::CreateMetricsServer(
+          server, metrics_port_, 1 /* HTTP thread count */, service);
+  if (err == nullptr) {
+    err = (*service)->Start();
+  }
+  if (err != nullptr) {
+    service->reset();
+  }
+
+  return err;
+}
 #endif  // TRTIS_ENABLE_METRICS
 
 bool
@@ -640,7 +659,7 @@ StartEndpoints(
     TRTSERVER_Error* err = StartHttpV2Service(
         &http_services_v2_, server, trace_manager, shm_manager, port_map);
     if (err != nullptr) {
-      LOG_TRTSERVER_ERROR(err, "failed to start HTTP service");
+      LOG_TRTSERVER_ERROR(err, "failed to start HTTP V2 service");
       return false;
     }
   }
@@ -649,10 +668,19 @@ StartEndpoints(
 #ifdef TRTIS_ENABLE_METRICS
   // Enable metrics endpoint if requested...
   if (metrics_port_ != -1) {
-    TRTSERVER_Error* err = StartMetricsService(&metrics_service_, server);
-    if (err != nullptr) {
-      LOG_TRTSERVER_ERROR(err, "failed to start Metrics service");
-      return false;
+    if (api_version_ == 1) {
+      TRTSERVER_Error* err = StartMetricsService(&metrics_service_, server);
+      if (err != nullptr) {
+        LOG_TRTSERVER_ERROR(err, "failed to start Metrics service");
+        return false;
+      }
+    } else if (api_version_ == 2) {
+      TRTSERVER_Error* err =
+          StartMetricsV2Service(&metrics_service_v2_, server);
+      if (err != nullptr) {
+        LOG_TRTSERVER_ERROR(err, "failed to start Metrics V2 service");
+        return false;
+      }
     }
   }
 #endif  // TRTIS_ENABLE_METRICS
@@ -684,7 +712,7 @@ StopEndpoints()
     if (http_eps != nullptr) {
       TRTSERVER_Error* err = http_eps->Stop();
       if (err != nullptr) {
-        LOG_TRTSERVER_ERROR(err, "failed to stop HTTP service");
+        LOG_TRTSERVER_ERROR(err, "failed to stop HTTP V2 service");
         ret = false;
       }
     }
@@ -726,6 +754,16 @@ StopEndpoints()
     }
 
     metrics_service_.reset();
+  }
+
+  if (metrics_service_v2_) {
+    TRTSERVER_Error* err = metrics_service_v2_->Stop();
+    if (err != nullptr) {
+      LOG_TRTSERVER_ERROR(err, "failed to stop Metrics V2 service");
+      ret = false;
+    }
+
+    metrics_service_v2_.reset();
   }
 #endif  // TRTIS_ENABLE_METRICS
 


### PR DESCRIPTION
api_version decides which metrics server version to launch. 
PS: The duplication of the HTTP metrics server is intentional and will be remove once the old HTTP server is removed.  